### PR TITLE
Minor bugfix

### DIFF
--- a/GitTfs/Core/TfsChangeset.cs
+++ b/GitTfs/Core/TfsChangeset.cs
@@ -196,8 +196,8 @@ namespace Sep.Git.Tfs.Core
         {
             var log = new LogEntry();
             var identity = tfs.GetIdentity(changesetToLog.Committer);
-            log.CommitterName = log.AuthorName = identity.DisplayName ?? "Unknown TFS user";
-            log.CommitterEmail = log.AuthorEmail = identity.MailAddress ?? changesetToLog.Committer;
+            log.CommitterName = log.AuthorName = null != identity ? identity.DisplayName ?? "Unknown TFS user" : changesetToLog.Committer ?? "Unknown TFS user";
+            log.CommitterEmail = log.AuthorEmail = null != identity ? identity.MailAddress ?? changesetToLog.Committer : changesetToLog.Committer;
             log.Date = changesetToLog.CreationDate;
             log.Log = changesetToLog.Comment + Environment.NewLine;
             log.ChangesetId = changesetToLog.ChangesetId;


### PR DESCRIPTION
I was getting a NullReferenceException in this code.  I looked at the TFS changeset and saw that the code didn't null check the TFS identity.  As it turns out, the TFS history will keep the user name in the changeset history even when the user no longer exists in the system.

After making the change, my import is cruising along.
