### PR TITLE
tfs-remote.<id>.autotag option implemented. Defaults to false.

### DIFF
--- a/GitTfs/Core/DerivedGitTfsRemote.cs
+++ b/GitTfs/Core/DerivedGitTfsRemote.cs
@@ -32,6 +32,12 @@ namespace Sep.Git.Tfs.Core
             set { throw new NotImplementedException(); }
         }
 
+        public bool Autotag
+        {
+            get { throw new NotImplementedException(); }
+            set { throw new NotImplementedException(); }
+        }
+
         public string TfsUsername
         {
             get

--- a/GitTfs/Core/GitRepository.cs
+++ b/GitTfs/Core/GitRepository.cs
@@ -90,7 +90,7 @@ namespace Sep.Git.Tfs.Core
         private IDictionary<string, IGitTfsRemote> ReadTfsRemotes()
         {
             var remotes = new Dictionary<string, IGitTfsRemote>();
-            CommandOutputPipe(stdout => ParseRemoteConfig(stdout, remotes), "config", "-l");
+            CommandOutputPipe(stdout => ParseRemoteConfig(stdout, remotes), "config", "--list");
             return remotes;
         }
 
@@ -198,14 +198,14 @@ namespace Sep.Git.Tfs.Core
                 case "ignore-paths":
                     remote.IgnoreRegexExpression = value;
                     break;
-                    //case "fetch":
-                    //    remote.??? = value;
-                    //    break;
                 case "username":
                     remote.TfsUsername = value;
                     break;
                 case "password":
                     remote.TfsPassword = value;
+                    break;
+                case "autotag":
+                    remote.Autotag = bool.Parse(value);
                     break;
             }
         }

--- a/GitTfs/Core/GitTfsRemote.cs
+++ b/GitTfs/Core/GitTfsRemote.cs
@@ -46,6 +46,8 @@ namespace Sep.Git.Tfs.Core
             set { Tfs.Url = value; }
         }
 
+        public bool Autotag { get; set; }
+
         public string TfsUsername
         {
             get { return Tfs.Username; }
@@ -209,7 +211,8 @@ namespace Sep.Git.Tfs.Core
             MaxCommitHash = commitHash;
             MaxChangesetId = changesetId;
             Repository.CommandNoisy("update-ref", "-m", "C" + MaxChangesetId, RemoteRef, MaxCommitHash);
-            Repository.CommandNoisy("update-ref", TagPrefix + "C" + MaxChangesetId, MaxCommitHash);
+            if (Autotag)
+                Repository.CommandNoisy("update-ref", TagPrefix + "C" + MaxChangesetId, MaxCommitHash);
             LogCurrentMapping();
         }
 

--- a/GitTfs/Core/IGitTfsRemote.cs
+++ b/GitTfs/Core/IGitTfsRemote.cs
@@ -11,6 +11,7 @@ namespace Sep.Git.Tfs.Core
         string TfsUrl { get; set; }
         string TfsRepositoryPath { get; set; }
         string IgnoreRegexExpression { get; set; }
+        bool Autotag { get; set; }
         string TfsUsername { get; set; }
         string TfsPassword { get; set; }
         IGitRepository Repository { get; set; }


### PR DESCRIPTION
See details [here](https://groups.google.com/d/topic/git-tfs-dev/MWnkTwuK4TE/discussion).

Makes tagging of each changeset with `tfa/<id>/C<changeset number>` tag optional. Default is false.
