### PR TITLE
I was unable to create a shelfset (error TF14045)

### DIFF
--- a/GitTfs.Vs2010/TfsHelper.Vs2010.cs
+++ b/GitTfs.Vs2010/TfsHelper.Vs2010.cs
@@ -73,7 +73,7 @@ namespace Sep.Git.Tfs.Vs2010
 
         protected override string GetAuthenticatedUser()
         {
-            return VersionControl.TeamProjectCollection.AuthorizedIdentity.DisplayName;
+            return VersionControl.AuthorizedUser;
         }
 
         public override bool CanShowCheckinDialog { get { return true; } }


### PR DESCRIPTION
It was trying to use <Domain><FirstName> <LastName> to get existing selfsets.  This change fixed things for me.  Not sure if it is something other folks are running into or not.

Detauls:
Replaced implementation of GetAuthenticatedUser with a call to VersionControl.AuthorizedUser.  The old version was returning '<Firstname> <Lastname>' which was throwing back an identity error when trying to fetch existing shelfsets
