### PR TITLE
Issue #80 and files with non-ASCII names

### DIFF
--- a/GitTfs/Core/Ext.cs
+++ b/GitTfs/Core/Ext.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 using CommandLine.OptParse;
 using StructureMap;
@@ -114,6 +115,15 @@ namespace Sep.Git.Tfs.Core
             var chars = new char[length];
             var charsRead = reader.Read(chars, 0, length);
             return new string(chars, 0, charsRead);
+        }
+
+        /// <summary>
+        /// Force the <paramref name="stream"/> to use current Windows ANSI code page.
+        /// For the StdIn-interactions with git it is important to use the standard ANSI codepage 
+        /// (i.e. the codepage returned by  GetACP()), and not the current terminal codepage.
+        /// </summary>
+        public static StreamWriter WithDefaultEncoding(this StreamWriter stream) {
+            return new StreamWriter(stream.BaseStream, Encoding.Default);
         }
     }
 }

--- a/GitTfs/Core/GitHelpers.cs
+++ b/GitTfs/Core/GitHelpers.cs
@@ -158,7 +158,7 @@ namespace Sep.Git.Tfs.Core
                               {
                                   AssertValidCommand(command);
                                   var process = Start(command, RedirectStdin);
-                                  action(process.StandardInput);
+                                  action(process.StandardInput.WithDefaultEncoding());
                                   Close(process);
                               });
         }
@@ -169,9 +169,8 @@ namespace Sep.Git.Tfs.Core
                               {
                                   AssertValidCommand(command);
                                   var process = Start(command,
-                                                      Ext.And<ProcessStartInfo>(RedirectStdin, RedirectStdout));
-                                  var encodedStdin = new StreamWriter(process.StandardInput.BaseStream, Encoding.Default);
-                                  interact(encodedStdin, process.StandardOutput);
+                                                      Ext.And<ProcessStartInfo>(RedirectStdin, RedirectStdout));                                  
+                                  interact(process.StandardInput.WithDefaultEncoding(), process.StandardOutput);
                                   Close(process);
                               });
         }


### PR DESCRIPTION
The current Windows ANSI codepage should be used for all stdin
interactions with git, and not the current console codepage. 
So both calls to StdIn are wrapped to use Encoding.Standard
