### PR TITLE
Fix commit regex used by FindTfsCommits to detect a commit from git log

### DIFF
--- a/GitTfs/Core/GitRepository.cs
+++ b/GitTfs/Core/GitRepository.cs
@@ -255,10 +255,9 @@ namespace Sep.Git.Tfs.Core
         {
             string currentCommit = null;
             string line;
-            var commitRegex = new Regex("commit (" + GitTfsConstants.Sha1 + ")");
             while (null != (line = stdout.ReadLine()))
             {
-                var match = commitRegex.Match(line);
+                var match = GitTfsConstants.CommitRegex.Match(line);
                 if (match.Success)
                 {
                     currentCommit = match.Groups[1].Value;

--- a/GitTfs/GitTfsConstants.cs
+++ b/GitTfs/GitTfsConstants.cs
@@ -6,6 +6,7 @@ namespace Sep.Git.Tfs
     {
         public static readonly Regex Sha1 = new Regex("[a-f\\d]{40}", RegexOptions.IgnoreCase);
         public static readonly Regex Sha1Short = new Regex("[a-f\\d]{4,40}", RegexOptions.IgnoreCase);
+        public static readonly Regex CommitRegex = new Regex("^commit (" + Sha1 + ")\\s*$");
 
         public const string DefaultRepositoryId = "default";
 

--- a/GitTfsTest/GitTfsRegexTests.cs
+++ b/GitTfsTest/GitTfsRegexTests.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Sep.Git.Tfs.Test
+{
+    [TestClass]
+    public class GitTfsRegexTests
+    {
+        [TestMethod]
+        public void CommitRegexShouldApproveGitCommitTitle()
+        {
+            const string line = "commit 9b655abe865ef0e4048aba904b79c7a2f10bdfce";
+            var match = GitTfsConstants.CommitRegex.Match(line);
+            Assert.IsTrue(match.Success);
+        }
+
+        [TestMethod]
+        public void CommitRegexShouldDeclineCommitRevertMessage()
+        {
+            const string line = "    This reverts commit e096daaf57d937fef3c0c639c3a59232310c6a20.";
+            var match = GitTfsConstants.CommitRegex.Match(line);
+            Assert.IsFalse(match.Success);
+        }
+    }
+}

--- a/GitTfsTest/GitTfsTest.csproj
+++ b/GitTfsTest/GitTfsTest.csproj
@@ -99,6 +99,7 @@
     <Compile Include="Core\GitChangeInfoTests.cs" />
     <Compile Include="Core\GitTfsRemoteTests.cs" />
     <Compile Include="Core\ModeTests.cs" />
+    <Compile Include="GitTfsRegexTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestHelpers\ExtensionMethods.cs" />
     <Compile Include="Util\GitTfsCommandRunnerTests.cs" />


### PR DESCRIPTION
FindTfsCommits failed in detecting Tfs commits when parsing a
revert commit.

For instance when parsing following git log report the Tfs commit finder
failed when parsing commit 027a14b24280ca3ba24e4c1e52411de35b944442.

Failure occurred when parsing the line
    This reverts commit e096daaf57d937fef3c0c639c3a59232310c6a20.
Old Regex("commit (" + GitTfsConstants.Sha1 + ")") failed by parsing this
as a start of a new commit.
Commit regex is tightened to Regex("^commit (" + Sha1 + ")\s*$")

Added tests prove that the new Regex handles both commit topic lines
and revert commit subjects.

==================== Example git log report ====================
$ git log --no-color --pretty=medium HEAD
commit 8c7350acc9a1feffa9882badecc625129c9b8943
Merge: 027a14b fe03e90
Author: Tuomas J<C3><A4>rvensivu tuomas.jarvensivu@reaktor.fi
Date:   Sun Sep 11 22:16:46 2011 +0300

```
Merge commit 'fe03e9009e46c4eb1b961578b201553eb59b11ed'
```

commit fe03e9009e46c4eb1b961578b201553eb59b11ed
Author: Tuomas J<C3><A4>rvensivu tuomas.jarvensivu@reaktor.fi
Date:   Sun Sep 11 22:02:48 2011 +0300

```
Change on top of reverted commit
```

commit 027a14b24280ca3ba24e4c1e52411de35b944442
Merge: 2b9fe0c f3b25d8
Author: Administrator <WIN-R5AMS97DB6H\Administrator>
Date:   Sun Sep 11 18:50:31 2011 +0000

```
Subject: Revert "This commit will be reverted."
Author: Tuomas J<C7><CF>rvensivu tuomas.jarvensivu@reaktor.fi
Date: Sun, 11 Sep 2011 21:45:01 +0300
Git commit hash: d5e949694e8d1442921250e0df4fb38d314dce53

This reverts commit e096daaf57d937fef3c0c639c3a59232310c6a20.

git-tfs-id: [http://localhost:8888/tfs/GitTfsTestCollection]$/GitTfsTest;C9
```

==================== Example git log report ====================

Signed-off-by: Tuomas Järvensivu tuomas.jarvensivu@reaktor.fi
