### PR TITLE
Fix error message when incorrect option typed (#91)

### DIFF
--- a/GitTfs/Core/GitRepository.cs
+++ b/GitTfs/Core/GitRepository.cs
@@ -246,7 +246,7 @@ namespace Sep.Git.Tfs.Core
             }
             catch (GitCommandException e)
             {
-                Trace.WriteLine("An error occurred while loading head " + head + " (maybe it doesn't exist?): " + e);
+                throw new GitTfsException("An error occurred while loading head " + head + " (maybe it doesn't exist?).");
             }
             return tfsCommits;
         }


### PR DESCRIPTION
I changed a Trace output to a new GitTfsException so the real error is shown at the command line instead of only when the debug switch is used.
