### PR TITLE
Closes #99: Fix VS 2008 support.

### DIFF
--- a/GitTfs.Vs2008/TfsHelper.Vs2008.cs
+++ b/GitTfs.Vs2008/TfsHelper.Vs2008.cs
@@ -72,9 +72,7 @@ namespace Sep.Git.Tfs.Vs2008
 
         public Stream DownloadFile(IItem item)
         {
-            var tempfile = TemporaryFileStream.Acquire();
-            _bridge.Unwrap<Item>(item).DownloadFile(tempfile.Filename);
-            return tempfile;
+			return _bridge.Unwrap<Item>(item).DownloadFile();
         }
     }
 }


### PR DESCRIPTION
Downloading files from TFS was failing because the TFS Item.DownloadFile(filename) method was trying to access the file that was already opened by TemporaryFileStream. There is no need for TemporaryFileStream since Item.DownloadFile() returns a stream anyway.
