### PR TITLE
Unshelve tweak - Implement the TODO for multi-remote support in Unshelve.cs

### DIFF
--- a/GitTfs/Commands/Unshelve.cs
+++ b/GitTfs/Commands/Unshelve.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using CommandLine.OptParse;
 using Sep.Git.Tfs.Core;
-using Sep.Git.Tfs.Core.TfsInterop;
 using StructureMap;
-
 namespace Sep.Git.Tfs.Commands
 {
     [Pluggable("unshelve")]
@@ -35,8 +36,7 @@ namespace Sep.Git.Tfs.Commands
 
         public int Run(IList<string> args)
         {
-            // TODO -- let the remote be specified on the command line.
-            var remote = _globals.Repository.ReadAllTfsRemotes().First();
+            var remote = _globals.Repository.ReadTfsRemote(_globals.RemoteId);
             return remote.Tfs.Unshelve(this, remote, args);
         }
     }


### PR DESCRIPTION
At some point I needed to do an Unshelve from a specific remote, so I went in and implemented this.  It's based on the code in the Shelve.cs file, and I've been using it for a few months without issue.

It looks like my VS plugins sorted the usings at the top of the file, which is kinda crappy, but other than that this is a one-liner.
