### PR TITLE
Improved diagnostics for errors during file download

### DIFF
--- a/GitTfs.Vs2010/TfsHelper.Vs2010.cs
+++ b/GitTfs.Vs2010/TfsHelper.Vs2010.cs
@@ -153,7 +153,15 @@ namespace Sep.Git.Tfs.Vs2010
 
         public Stream DownloadFile(IItem item)
         {
-            return _bridge.Unwrap<Item>(item).DownloadFile();
+            try
+            {
+                return _bridge.Unwrap<Item>(item).DownloadFile();
+            }
+            catch (Exception e)
+            {
+                Trace.WriteLine(String.Format("Something went wrong downloading \"{0}\" in changeset {1}", item.ServerItem, item.ChangesetId));
+                throw;
+            }
         }
     }
 }


### PR DESCRIPTION
Will provide trace of ServerItem and ChangesetId. I found this helpful when pin-pointing the TFS bug discussed in issue #107 (https://github.com/spraints/git-tfs/issues/107)
