### PR TITLE
Fixes #104: Case sensitivity was off by default

### DIFF
--- a/GitTfs/Commands/Init.cs
+++ b/GitTfs/Commands/Init.cs
@@ -85,6 +85,7 @@ namespace Sep.Git.Tfs.Commands
         private void GitTfsInit(string tfsUrl, string tfsRepositoryPath)
         {
             gitHelper.SetConfig("core.autocrlf", "false");
+            gitHelper.SetConfig("core.ignorecase", "false");
             globals.Repository.CreateTfsRemote(globals.RemoteId, tfsUrl, tfsRepositoryPath, remoteOptions);
         }
     }

--- a/GitTfs/Core/GitRepository.cs
+++ b/GitTfs/Core/GitRepository.cs
@@ -300,7 +300,7 @@ namespace Sep.Git.Tfs.Core
 
         public Dictionary<string, GitObject> GetObjects()
         {
-            return new Dictionary<string, GitObject>(StringComparer.InvariantCultureIgnoreCase);
+            return new Dictionary<string, GitObject>(StringComparer.InvariantCulture);
         }
 
         public string GetCommitMessage(string head, string parentCommitish)


### PR DESCRIPTION
This hardcodes case sensitivity and fixes #104 for `git tfs clone` - however, it may be good to allow other `git tfs` commands to be configurable with respect to case sensitivity in the future for better usability for some circumstances.
