### PR TITLE
Fix deprecation warnings

### DIFF
--- a/GitTfs.VsCommon/TfsHelper.Common.cs
+++ b/GitTfs.VsCommon/TfsHelper.Common.cs
@@ -188,7 +188,7 @@ namespace Sep.Git.Tfs.VsCommon
         [Obsolete("TODO: un-spike-ify this.")]
         public int Unshelve(Unshelve unshelve, IGitTfsRemote remote, IList<string> args)
         {
-            var shelvesetOwner = unshelve.Owner == "all" ? null : (unshelve.Owner ?? VersionControl.AuthenticatedUser);
+            var shelvesetOwner = unshelve.Owner == "all" ? null : (unshelve.Owner ?? GetAuthenticatedUser());
             if (args.Count != 2)
             {
                 _stdout.WriteLine("ERROR: usage: unshelve -u <shelve-owner-name> <shelve-name> <git-branch-name>");
@@ -227,7 +227,7 @@ namespace Sep.Git.Tfs.VsCommon
 
         public int ListShelvesets(ShelveList shelveList, IGitTfsRemote remote)
         {
-            var shelvesetOwner = shelveList.Owner == "all" ? null : (shelveList.Owner ?? VersionControl.AuthenticatedUser);
+            var shelvesetOwner = shelveList.Owner == "all" ? null : (shelveList.Owner ?? GetAuthenticatedUser());
             IEnumerable<Shelveset> shelvesets;
             try
             {


### PR DESCRIPTION
Replace calls that used the deprecated AuthenticatedUser property, to use the abstract method GetAuthenticatedUser()
that is implemented by the VS2008 and VS2010 TFSHelper classes.

More Info:
http://msdn.microsoft.com/en-us/library/microsoft.teamfoundation.versioncontrol.client.versioncontrolserver.authenticateduser.aspx
