### PR TITLE
Fix Neverending Processes

### DIFF
--- a/GitTfs/Core/GitHelpers.cs
+++ b/GitTfs/Core/GitHelpers.cs
@@ -34,7 +34,7 @@ namespace Sep.Git.Tfs.Core
         public string CommandOneline(params string[] command)
         {
             string retVal = null;
-            CommandOutputPipe(stdout => retVal = stdout.ReadLine(), command);
+            CommandOutputPipe(stdout => {retVal = stdout.ReadLine(); stdout.Close();}, command);
             return retVal;
         }
 


### PR DESCRIPTION
I was recently dealing with a huge number of commits that needed to be checked in to TFS.  It seems that when dealing with so many commits, the process hangs and git-tfs assumes it never exited and throws an exception.  Closing the piped stream seems to fix the problem.
