### PR TITLE
Only close stdout if it has been redirected.

### DIFF
--- a/GitTfs/Core/GitHelpers.cs
+++ b/GitTfs/Core/GitHelpers.cs
@@ -196,7 +196,8 @@ namespace Sep.Git.Tfs.Core
             // close stdout to indicate we're no more interested in it, thus allowing
             // child process to proceed.
             // See https://github.com/git-tfs/git-tfs/issues/121 for details.
-            process.StandardOutput.Close();
+            if (process.StartInfo.RedirectStandardOutput)
+                process.StandardOutput.Close();
 
             if (!process.WaitForExit((int)TimeSpan.FromSeconds(10).TotalMilliseconds))
                 throw new GitCommandException("Command did not terminate.", process);


### PR DESCRIPTION
This is a follow up of #121 

git-tfs will crash if it attempts to close stdout from a process from
which stdout has not been redirected.  This adds a guard against closing
process's stdout that has not been redirected.
