### PR TITLE
Fix issue #123

### DIFF
--- a/GitTfs/Core/GitRepository.cs
+++ b/GitTfs/Core/GitRepository.cs
@@ -242,7 +242,7 @@ namespace Sep.Git.Tfs.Core
             try
             {
                 CommandOutputPipe(stdout => FindTfsCommits(stdout, tfsCommits, includeStubRemotes),
-                                  "log", "--no-color", "--pretty=medium", head);
+                                  "log", "--no-color", @"--pretty=format:'commit %H%n%b'", head );
             }
             catch (GitCommandException e)
             {
@@ -260,7 +260,7 @@ namespace Sep.Git.Tfs.Core
                 var match = GitTfsConstants.CommitRegex.Match(line);
                 if (match.Success)
                 {
-                    currentCommit = match.Groups[1].Value;
+                    currentCommit = match.Groups["commit"].Value;
                     continue;
                 }
                 var changesetInfo = TryParseChangesetInfo(line, currentCommit, includeStubRemotes);

--- a/GitTfs/GitTfsConstants.cs
+++ b/GitTfs/GitTfsConstants.cs
@@ -6,7 +6,7 @@ namespace Sep.Git.Tfs
     {
         public static readonly Regex Sha1 = new Regex("[a-f\\d]{40}", RegexOptions.IgnoreCase);
         public static readonly Regex Sha1Short = new Regex("[a-f\\d]{4,40}", RegexOptions.IgnoreCase);
-        public static readonly Regex CommitRegex = new Regex("^commit (" + Sha1 + ")\\s*$");
+        public static readonly Regex CommitRegex = new Regex(string.Concat(@"^commit (?<commit>", Sha1, @")"), RegexOptions.Compiled);
 
         public const string DefaultRepositoryId = "default";
 


### PR DESCRIPTION
Update git log output to use a consistent format, despite any local
changes made by the user.
Update commit regex to correctly parse the new log format.
Update commit regex to use a named capture.
