### PR TITLE
Fix download link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ git-tfs is a two-way bridge between TFS and git, similar to git-svn.
 
 ## Installing
 
-[Download](https://github.com/spraints/git-tfs/downloads#uploaded_downloads) or build.
+[Download](https://github.com/git-tfs/git-tfs/downloads#uploaded_downloads) or build.
 
 Add the directory that contains git-tfs.exe to your path. 
 


### PR DESCRIPTION
The link points to spraints/git-tfs which no longer exists.
