### PR TITLE
"Command exited with error code" message now includes the error code

### DIFF
--- a/GitTfs/Core/GitHelpers.cs
+++ b/GitTfs/Core/GitHelpers.cs
@@ -202,7 +202,7 @@ namespace Sep.Git.Tfs.Core
             if (!process.WaitForExit((int)TimeSpan.FromSeconds(10).TotalMilliseconds))
                 throw new GitCommandException("Command did not terminate.", process);
             if(process.ExitCode != 0)
-                throw new GitCommandException("Command exited with error code.", process);
+                throw new GitCommandException(string.Format("Command exited with error code: {0}", process.ExitCode), process);
         }
 
         private void RedirectStdout(ProcessStartInfo startInfo)


### PR DESCRIPTION
If there was an error cloning a repository causing the exit code to be
non-zero, the message output to the terminal didn't include the exit
code.

I've added process.ExitCode to the GitCommandException message. This now
gets output to the terminal if there is an error.
