### PR TITLE
Fix issue #181 by tamasarpad

### DIFF
--- a/GitTfs/Core/GitHelpers.cs
+++ b/GitTfs/Core/GitHelpers.cs
@@ -208,7 +208,7 @@ namespace Sep.Git.Tfs.Core
         private void RedirectStdout(ProcessStartInfo startInfo)
         {
             startInfo.RedirectStandardOutput = true;
-            startInfo.StandardOutputEncoding = Encoding.Default;
+            startInfo.StandardOutputEncoding = new UTF8Encoding(false);
         }
 
         private void RedirectStdin(ProcessStartInfo startInfo)


### PR DESCRIPTION
Based on the work of tamasarpad described in the issue #181, this pull request must fix that a non-ascii char in a commit message is not well transcibe when commited in Tfs (throught the checkintool or rcheckin
