### PR TITLE
Add initial version to clone

### DIFF
--- a/GitTfs/Commands/Fetch.cs
+++ b/GitTfs/Commands/Fetch.cs
@@ -29,6 +29,7 @@ namespace Sep.Git.Tfs.Commands
 
         bool FetchAll { get; set; }
         bool FetchParents { get; set; }
+        internal int? StartWithChangesetId { get; set; }
 
         public virtual OptionSet OptionSet
         {
@@ -69,7 +70,11 @@ namespace Sep.Git.Tfs.Commands
             // TFS exists (by checking git-tfs-id mark in commit's comments).
             // The process is similar to bootstrapping.
             globals.Repository.MoveTfsRefForwardIfNeeded(remote);
-            remote.Fetch();
+            if (StartWithChangesetId.HasValue)
+            {
+                remote.MaxChangesetId = StartWithChangesetId.Value;
+            }
+            remote.Fetch(); 
         }
 
         private IEnumerable<IGitTfsRemote> GetRemotesToFetch(IList<string> args)


### PR DESCRIPTION
To address the slow clone issue, I added a flag to allow a user to pick which change set they want to start with when cloning their TFS repository.  This will allow users with long duration TFS projects to filter out ancient history that they don't care about in their local repository.
