### PR TITLE
Feature Request - #118 + Bug fix for removed AD users

### DIFF
--- a/GitTfs.VsCommon/TfsHelper.Common.cs
+++ b/GitTfs.VsCommon/TfsHelper.Common.cs
@@ -201,7 +201,7 @@ namespace Sep.Git.Tfs.VsCommon
                 _bridge.Wrap<WrapperForVersionControlServer, VersionControlServer>(VersionControl);
             // TODO - containerify this (no `new`)!
             var fakeChangeset = new FakeChangeset(shelveset, change, wrapperForVersionControlServer, _bridge);
-            var tfsChangeset = new TfsChangeset(remote.Tfs, fakeChangeset, _stdout) { Summary = new TfsChangesetInfo { Remote = remote } };
+            var tfsChangeset = new TfsChangeset(remote.Tfs, fakeChangeset, _stdout, null) { Summary = new TfsChangesetInfo { Remote = remote } };
             return tfsChangeset;
         }
 

--- a/GitTfs/Commands/Fetch.cs
+++ b/GitTfs/Commands/Fetch.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using NDesk.Options;
 using Sep.Git.Tfs.Core;
+using Sep.Git.Tfs.Util;
 using StructureMap;
 
 namespace Sep.Git.Tfs.Commands
@@ -18,18 +19,20 @@ namespace Sep.Git.Tfs.Commands
     {
         private readonly RemoteOptions remoteOptions;
         private readonly Globals globals;
+        private readonly AuthorsFile authors;
 
-        public Fetch(Globals globals, RemoteOptions remoteOptions)
+        public Fetch(Globals globals, RemoteOptions remoteOptions, AuthorsFile authors)
         {
             this.remoteOptions = remoteOptions;
             this.globals = globals;
+            this.authors = authors;
         }
 
 //        public int? RevisionToFetch { get; set; }
 
         bool FetchAll { get; set; }
         bool FetchParents { get; set; }
-
+        string AuthorsFilePath { get; set; }
         public virtual OptionSet OptionSet
         {
             get
@@ -40,6 +43,8 @@ namespace Sep.Git.Tfs.Commands
                         v => FetchAll = v != null },
                     { "parents",
                         v => FetchParents = v != null },
+                    { "authors=", "Path to an Authors file to map TFS users to Git users",
+                        v => AuthorsFilePath = v },
 //                    { "r|revision=",
 //                        v => RevisionToFetch = Convert.ToInt32(v) },
                 }.Merge(remoteOptions.OptionSet);
@@ -53,7 +58,21 @@ namespace Sep.Git.Tfs.Commands
 
         public int Run(params string[] args)
         {
-            foreach(var remote in GetRemotesToFetch(args))
+            if (!String.IsNullOrWhiteSpace(AuthorsFilePath))
+            {
+                if (!File.Exists(AuthorsFilePath))
+                {
+                    throw new GitTfsException("Authors file cannot be found: '" + AuthorsFilePath + "'");
+                }
+                else
+                {
+                    using (StreamReader sr = new StreamReader(AuthorsFilePath))
+                    {
+                        authors.Parse(sr);
+                    }
+                }
+            }
+            foreach (var remote in GetRemotesToFetch(args))
             {
                 Trace.WriteLine("Fetching from TFS remote " + remote.Id);
                 DoFetch(remote);

--- a/GitTfs/Commands/QuickFetch.cs
+++ b/GitTfs/Commands/QuickFetch.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using NDesk.Options;
 using Sep.Git.Tfs.Core;
+using Sep.Git.Tfs.Util;
 
 namespace Sep.Git.Tfs.Commands
 {
@@ -14,7 +15,7 @@ namespace Sep.Git.Tfs.Commands
     //  2. Load the correct set of extant casing.
     public class QuickFetch : Fetch
     {
-        public QuickFetch(Globals globals, RemoteOptions remoteOptions) : base(globals, remoteOptions)
+        public QuickFetch(Globals globals, RemoteOptions remoteOptions, AuthorsFile authors) : base(globals, remoteOptions, authors)
         {
         }
 

--- a/GitTfs/GitTfs.csproj
+++ b/GitTfs/GitTfs.csproj
@@ -167,6 +167,7 @@
     <Compile Include="Core\TfsWorkspace.cs" />
     <Compile Include="Core\TfsWriter.cs" />
     <Compile Include="Core\GitTfsException.cs" />
+    <Compile Include="Util\AuthorsFile.cs" />
     <Compile Include="Util\ExceptionFormattingExtensions.cs" />
     <Compile Include="Util\GitTfsCommandFactory.cs" />
     <Compile Include="Util\GitTfsCommandRunner.cs" />

--- a/GitTfs/Util/AuthorsFile.cs
+++ b/GitTfs/Util/AuthorsFile.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using Sep.Git.Tfs.Core;
+
+namespace Sep.Git.Tfs.Util
+{
+    public class Author
+    {
+        public string Name;
+        public string Email;
+    }
+
+    [StructureMapSingleton]
+    public class AuthorsFile
+    {
+        private Dictionary<string, Author> authors = new Dictionary<string, Author>();
+
+        public AuthorsFile()
+        { }
+
+
+        public Dictionary<string, Author> Authors
+        {
+            get
+            {
+                return this.authors;
+            }
+        }
+
+        public void Parse(TextReader authorsFileStream)
+        {
+            if (authorsFileStream != null)
+            {
+                int lineCount = 0;
+                string line = authorsFileStream.ReadLine();
+                while (line != null)
+                {
+                    lineCount++;
+                    //regex pulled from git svn script here: https://github.com/git/git/blob/master/git-svn.perl
+                    Regex ex = new Regex(@"^(.+?|\(no author\))\s*=\s*(.+?)\s*<(.+)>\s*$");
+                    Match match = ex.Match(line);
+                    if (match.Groups.Count != 4 || String.IsNullOrWhiteSpace(match.Groups[1].Value) || String.IsNullOrWhiteSpace(match.Groups[2].Value) || String.IsNullOrWhiteSpace(match.Groups[3].Value))
+                    {
+                        throw new GitTfsException("Invalid format of Authors file on line " + lineCount + ".");
+                    }
+                    else
+                    {
+                        if (!authors.ContainsKey(match.Groups[1].Value))
+                        {
+                            //git svn doesn't trim, but maybe this should?
+                            authors.Add(match.Groups[1].Value, new Author() { Name = match.Groups[2].Value, Email = match.Groups[3].Value });
+                        }
+                    }
+
+                    line = authorsFileStream.ReadLine();
+                }
+            }
+        }
+
+
+    }
+}

--- a/GitTfsTest/GitTfsTest.csproj
+++ b/GitTfsTest/GitTfsTest.csproj
@@ -99,6 +99,7 @@
     <Compile Include="Integration\IntegrationHelper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestHelpers\ExtensionMethods.cs" />
+    <Compile Include="Util\AuthorsFileUnitTest.cs" />
     <Compile Include="Util\GitTfsCommandRunnerTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/GitTfsTest/Util/AuthorsFileUnitTest.cs
+++ b/GitTfsTest/Util/AuthorsFileUnitTest.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Text;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+using Sep.Git.Tfs.Util;
+using Sep.Git.Tfs.Core;
+
+namespace Sep.Git.Tfs.Test.Util
+{
+    /// <summary>
+    /// Summary description for AuthorsFileUnitTest
+    /// </summary>
+    [TestClass]
+    public class AuthorsFileUnitTest
+    {
+        public AuthorsFileUnitTest()
+        {
+            //
+            // TODO: Add constructor logic here
+            //
+        }
+
+        private TestContext testContextInstance;
+
+        /// <summary>
+        ///Gets or sets the test context which provides
+        ///information about and functionality for the current test run.
+        ///</summary>
+        public TestContext TestContext
+        {
+            get
+            {
+                return testContextInstance;
+            }
+            set
+            {
+                testContextInstance = value;
+            }
+        }
+
+
+        [TestMethod]
+        public void TestEmptyFile()
+        {
+            MemoryStream ms = new MemoryStream();
+            StreamReader sr = new StreamReader(ms);
+            AuthorsFile authFile = new AuthorsFile();
+            authFile.Parse(sr);
+            Assert.IsNotNull(authFile.Authors);
+            Assert.AreEqual<int>(0, authFile.Authors.Count);
+        }
+
+        [TestMethod]
+        public void TestSimpleRecord()
+        {
+            string author = @"Domain\Test.User = Test User <TestUser@example.com>";
+            AuthorsFile authFile = new AuthorsFile();
+            authFile.Parse(new StreamReader(new MemoryStream(Encoding.ASCII.GetBytes(author))));
+            Assert.IsNotNull(authFile.Authors);
+            Assert.AreEqual<int>(1, authFile.Authors.Count);
+            Assert.IsTrue(authFile.Authors.ContainsKey(@"Domain\Test.User"));
+            Author auth = authFile.Authors[@"Domain\Test.User"];
+            Assert.AreEqual<string>("Test User", auth.Name);
+            Assert.AreEqual<string>("TestUser@example.com", auth.Email);
+        }
+
+        [TestMethod]
+        public void TestMultiLineRecord()
+        {
+            string author = 
+@"Domain\Test.User = Test User <TestUser@example.com>
+Domain\Different.User = Three Name User < TestUser@example.com >";
+            AuthorsFile authFile = new AuthorsFile();
+            authFile.Parse(new StreamReader(new MemoryStream(Encoding.ASCII.GetBytes(author))));
+            Assert.IsNotNull(authFile.Authors);
+            Assert.AreEqual<int>(2, authFile.Authors.Count);
+            
+            Assert.IsTrue(authFile.Authors.ContainsKey(@"Domain\Test.User"));
+            Author auth = authFile.Authors[@"Domain\Test.User"];
+            Assert.AreEqual<string>("Test User", auth.Name);
+            Assert.AreEqual<string>("TestUser@example.com", auth.Email);
+            
+            Assert.IsTrue(authFile.Authors.ContainsKey(@"Domain\Different.User"));
+            auth = authFile.Authors[@"Domain\Different.User"];
+            Assert.AreEqual<string>("Three Name User", auth.Name);
+            Assert.AreEqual<string>(" TestUser@example.com ", auth.Email);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(GitTfsException))]
+        public void TestMultiLineRecordWithBlankLine()
+        {
+            string author =
+@"Domain\Test.User = Test User <TestUser@example.com>
+
+Domain\Different.User = Three Name User < TestUser@example.com >";
+            AuthorsFile authFile = new AuthorsFile();
+            authFile.Parse(new StreamReader(new MemoryStream(Encoding.ASCII.GetBytes(author))));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(GitTfsException))]
+        public void TestBadRecord()
+        {
+            string author =
+@"Domain\Test.User = Test User";
+            AuthorsFile authFile = new AuthorsFile();
+            authFile.Parse(new StreamReader(new MemoryStream(Encoding.ASCII.GetBytes(author))));
+        }
+    }
+}


### PR DESCRIPTION
This is a pull request for feature #118 and a bug fix for the default behavior for AD users that have been deleted.

--AuthorsFile parameter added to the Fetch command and is registered as a singleton.
--Unit tests test the regex of the line parsing.
Updated logic around parsing the original changeset owner.  This was needed to properly identify a user who had been deleted from TFS without the need for an AuthorsFile.
