### PR TITLE
AuthorsFile Updates - Allow Commented line, international tests.

### DIFF
--- a/GitTfs/Util/AuthorsFile.cs
+++ b/GitTfs/Util/AuthorsFile.cs
@@ -38,22 +38,24 @@ namespace Sep.Git.Tfs.Util
                 while (line != null)
                 {
                     lineCount++;
-                    //regex pulled from git svn script here: https://github.com/git/git/blob/master/git-svn.perl
-                    Regex ex = new Regex(@"^(.+?|\(no author\))\s*=\s*(.+?)\s*<(.+)>\s*$");
-                    Match match = ex.Match(line);
-                    if (match.Groups.Count != 4 || String.IsNullOrWhiteSpace(match.Groups[1].Value) || String.IsNullOrWhiteSpace(match.Groups[2].Value) || String.IsNullOrWhiteSpace(match.Groups[3].Value))
+                    if (!line.StartsWith("#"))
                     {
-                        throw new GitTfsException("Invalid format of Authors file on line " + lineCount + ".");
-                    }
-                    else
-                    {
-                        if (!authors.ContainsKey(match.Groups[1].Value))
+                        //regex pulled from git svn script here: https://github.com/git/git/blob/master/git-svn.perl
+                        Regex ex = new Regex(@"^(.+?|\(no author\))\s*=\s*(.+?)\s*<(.+)>\s*$");
+                        Match match = ex.Match(line);
+                        if (match.Groups.Count != 4 || String.IsNullOrWhiteSpace(match.Groups[1].Value) || String.IsNullOrWhiteSpace(match.Groups[2].Value) || String.IsNullOrWhiteSpace(match.Groups[3].Value))
                         {
-                            //git svn doesn't trim, but maybe this should?
-                            authors.Add(match.Groups[1].Value, new Author() { Name = match.Groups[2].Value, Email = match.Groups[3].Value });
+                            throw new GitTfsException("Invalid format of Authors file on line " + lineCount + ".");
+                        }
+                        else
+                        {
+                            if (!authors.ContainsKey(match.Groups[1].Value))
+                            {
+                                //git svn doesn't trim, but maybe this should?
+                                authors.Add(match.Groups[1].Value, new Author() { Name = match.Groups[2].Value, Email = match.Groups[3].Value });
+                            }
                         }
                     }
-
                     line = authorsFileStream.ReadLine();
                 }
             }


### PR DESCRIPTION
*Added ability to comment a line in AuthorsFile. (Was requested in the comments on the initial pull request by @rbirkby)
*Renamed tests to start with AuthorsFile instead of "Test" (seemed a lot more in sync with the rest of the code base)
*Added tests for international characters. (was requested in a pull request for issue #210 )
