### PR TITLE
fix issue #215 in TFSHelper.NonFatalError.

### DIFF
--- a/GitTfs.VsCommon/TfsHelper.Common.cs
+++ b/GitTfs.VsCommon/TfsHelper.Common.cs
@@ -85,9 +85,16 @@ namespace Sep.Git.Tfs.VsCommon
 
         private void NonFatalError(object sender, ExceptionEventArgs e)
         {
-            _stdout.WriteLine(e.Failure.Message);
-            Trace.WriteLine("Failure: " + e.Failure.Inspect(), "tfs non-fatal error");
-            Trace.WriteLine("Exception: " + e.Exception.Inspect(), "tfs non-fatal error");
+           if (e.Failure != null)
+           {
+              _stdout.WriteLine(e.Failure.Message);
+              Trace.WriteLine("Failure: " + e.Failure.Inspect(), "tfs non-fatal error");
+           }
+           if (e.Exception != null)
+           {
+              _stdout.WriteLine(e.Exception.Message);
+              Trace.WriteLine("Exception: " + e.Exception.Inspect(), "tfs non-fatal error");
+           }
         }
 
         private IGroupSecurityService GroupSecurityService


### PR DESCRIPTION
Fixes the issue in #215 where in some non fatal errors, there is no e.Failure, there is just the exception itself.  

This fix addresses the issue by writing out the two messages separately; each wrapped by a null check.
