### PR TITLE
Change `TfsWorkItemRegex` to allow any whitespace between the item id and the action.

### DIFF
--- a/GitTfs/GitTfsConstants.cs
+++ b/GitTfs/GitTfsConstants.cs
@@ -24,7 +24,7 @@ namespace Sep.Git.Tfs
                           "\\s*$");
         // e.g. git-tfs-work-item: 24 associate
         public static readonly Regex TfsWorkItemRegex =
-                new Regex(GitTfsPrefix + @"-work-item:\s+(?<item_id>\d+)\s(?<action>.+)");
+                new Regex(GitTfsPrefix + @"-work-item:\s+(?<item_id>\d+)\s+(?<action>.+)");
 
         // e.g. git-tfs-force: override reason
         public static readonly Regex TfsForceRegex =


### PR DESCRIPTION
Fixes #234
