### PR TITLE
Normalize commit message line endings to CR+LF style.

### DIFF
--- a/GitTfs/Core/GitRepository.cs
+++ b/GitTfs/Core/GitRepository.cs
@@ -313,9 +313,19 @@ namespace Sep.Git.Tfs.Core
             foreach (LibGit2Sharp.Commit comm in
                 _repository.Commits.QueryBy(new LibGit2Sharp.Filter { Since = head, Until = parentCommitish }))
             {
-                message.AppendLine(comm.Message);
+                // Normalize commit message line endings to CR+LF style, so that message
+                // would be correctly shown in TFS commit dialog.
+                message.AppendLine(NormalizeLineEndings(comm.Message));
             }
+
             return GitTfsConstants.TfsCommitInfoRegex.Replace(message.ToString(), "").Trim(' ', '\r', '\n');
+        }
+
+        private static string NormalizeLineEndings(string input)
+        {
+            return string.IsNullOrEmpty(input)
+                ? input
+                : input.Replace("\r\n", "\n").Replace("\r", "\n").Replace("\n", "\r\n");
         }
 
         private void ParseEntries(IDictionary<string, GitObject> entries, Tree treeInfo, string commit)


### PR DESCRIPTION
Hi!

After upgrading to latest version of git-tfs, I've noticed that multi-line commit 
messages in TFS check-in dialog are shown incorrectly (after using `git tfs checkintool`).
They are displayed as single line message. In fact they have the same line endings as
original commit message in git - `LF`. I guess TFS does handle them.

This commit should fix that issue by normalizing commit messages to `CRLF` format.

Not sure I've found correct place for fix. Feel free to discard this pull request if you find it wrong.

Thank you.
