### PR TITLE
Minor fix of associating multiple workitems

### DIFF
--- a/GitTfs/GitTfsConstants.cs
+++ b/GitTfs/GitTfsConstants.cs
@@ -24,7 +24,7 @@ namespace Sep.Git.Tfs
                           "\\s*$", RegexOptions.Multiline);
         // e.g. git-tfs-work-item: 24 associate
         public static readonly Regex TfsWorkItemRegex =
-                new Regex(GitTfsPrefix + @"-work-item:\s*(?<item_id>\d+)\s*(?<action>.+)");
+                new Regex(GitTfsPrefix + @"-work-item:\s*(?<item_id>\d+)\s*(?<action>associate|resolve)");
 
         // e.g. git-tfs-code-reviewer: John Smith
         public static readonly Regex TfsReviewerRegex =

--- a/GitTfsTest/Util/CommitSpecificCheckinOptionsFactoryTests.cs
+++ b/GitTfsTest/Util/CommitSpecificCheckinOptionsFactoryTests.cs
@@ -88,6 +88,39 @@ namespace Sep.Git.Tfs.Test.Util
         }
 
         [Fact]
+        public void Adds_multiple_work_items_and_removes_checkin_command_comment()
+        {
+            StringWriter textWriter = new StringWriter();
+            CommitSpecificCheckinOptionsFactory factory = new CommitSpecificCheckinOptionsFactory(textWriter);
+
+            CheckinOptions singletonCheckinOptions = new CheckinOptions();
+
+            string commitMessage =
+@"test message
+
+		formatted git commit message
+
+		git-tfs-work-item: 1234 resolve
+        git-tfs-work-item: 5678 associate
+
+";
+
+            string expectedCheckinComment =
+@"test message
+
+		formatted git commit message
+
+		";
+
+            var specificCheckinOptions = factory.BuildCommitSpecificCheckinOptions(singletonCheckinOptions, commitMessage);
+            Assert.Equal(1, specificCheckinOptions.WorkItemsToResolve.Count);
+            Assert.Equal(1, specificCheckinOptions.WorkItemsToAssociate.Count);
+            Assert.Contains("1234", specificCheckinOptions.WorkItemsToResolve);
+            Assert.Contains("5678", specificCheckinOptions.WorkItemsToAssociate);
+            Assert.Equal(expectedCheckinComment.Replace(Environment.NewLine, "NEWLINE"), specificCheckinOptions.CheckinComment.Replace(Environment.NewLine, "NEWLINE"));
+        }
+
+        [Fact]
         public void Adds_reviewers_and_removes_checkin_command_comment()
         {
             StringWriter textWriter = new StringWriter();


### PR DESCRIPTION
When multiple workitems are specified in the commit message, if they are not written back to back and ending with EOF (e.g. git-tfs-work-item: 1234 associategit-tfs-work-item: 5678 resolve<eof>) they won't be understood correctly.

I tweaked the regex pattern a bit and added a simple unit test.

Thanks.
