### PR TITLE
Use author file to manage author mapping in init-branch command

### DIFF
--- a/GitTfs/Commands/Fetch.cs
+++ b/GitTfs/Commands/Fetch.cs
@@ -58,7 +58,7 @@ namespace Sep.Git.Tfs.Commands
 
         public int Run(params string[] args)
         {
-            authors.Parse(AuthorsFilePath);
+            authors.Parse(AuthorsFilePath, globals.GitDir);
 
             foreach (var remote in GetRemotesToFetch(args))
             {

--- a/GitTfs/Commands/InitBranch.cs
+++ b/GitTfs/Commands/InitBranch.cs
@@ -122,7 +122,7 @@ namespace Sep.Git.Tfs.Commands
                 _remoteOptions.Password = defaultRemote.TfsPassword;
             }
 
-            _authors.Parse(AuthorsFilePath);
+            _authors.Parse(AuthorsFilePath, _globals.GitDir);
 
             return defaultRemote;
         }

--- a/GitTfs/Util/AuthorsFile.cs
+++ b/GitTfs/Util/AuthorsFile.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
 using Sep.Git.Tfs.Core;
+using System.Diagnostics;
 
 namespace Sep.Git.Tfs.Util
 {
@@ -61,8 +62,9 @@ namespace Sep.Git.Tfs.Util
             }
         }
 
-        public void Parse(string authorsFilePath)
+        public void Parse(string authorsFilePath, string gitDir)
         {
+            var savedAuthorFile = Path.Combine(gitDir, "git-tfs_authors");
             if (!String.IsNullOrWhiteSpace(authorsFilePath))
             {
                 if (!File.Exists(authorsFilePath))
@@ -71,7 +73,24 @@ namespace Sep.Git.Tfs.Util
                 }
                 else
                 {
+                    Trace.WriteLine("Reading authors file : " + authorsFilePath);
                     using (StreamReader sr = new StreamReader(authorsFilePath))
+                    {
+                        Parse(sr);
+                    }
+                    try
+                    {
+                        File.Copy(authorsFilePath, savedAuthorFile, true);
+                    }
+                    catch (Exception) { }
+                }
+            }
+            else
+            {
+                Trace.WriteLine("Reading cached authors file (" + savedAuthorFile+ ")...");
+                if (File.Exists(savedAuthorFile))
+                {
+                    using (StreamReader sr = new StreamReader(savedAuthorFile))
                     {
                         Parse(sr);
                     }

--- a/GitTfsTest/Commands/InitBranchTest.cs
+++ b/GitTfsTest/Commands/InitBranchTest.cs
@@ -27,6 +27,7 @@ namespace Sep.Git.Tfs.Test.Commands
         {
             gitRepository = mocks.Get<IGitRepository>();
             mocks.Get<Globals>().Repository = gitRepository;
+            mocks.Get<Globals>().GitDir = ".git";
             remote = MockRepository.GenerateStub<IGitTfsRemote>();
             remote.TfsUsername = "user";
             remote.TfsPassword = "pwd";


### PR DESCRIPTION
Now init-branch command accept an author file to map tfs changesets to git users.
But should be specified every time the command is called...

@ripern It should be a first step and let you do what you want...

The format you gave me was not the good one :( It's this one :
    DISSRVTFS03\peter.pan = Peter Pan <peter.pan@disney.com>

@spraints For the authors file saving, what do you think is the best? Save the file in the .git folder when cloning and use it afterwards (until another file is specified...)? 
