### PR TITLE
Download correct files for unshelve

### DIFF
--- a/GitTfs.VsCommon/TfsHelper.Common.cs
+++ b/GitTfs.VsCommon/TfsHelper.Common.cs
@@ -344,6 +344,15 @@ namespace Sep.Git.Tfs.VsCommon
             {
                 get { return _versionControlServer; }
             }
+
+            public void Get(IWorkspace workspace)
+            {
+                foreach (var change in _changes)
+                {
+                    var item = (FakeItem)change.Item;
+                    item.Get(workspace);
+                }
+            }
         }
 
         private class FakeChange : IChange
@@ -445,6 +454,12 @@ namespace Sep.Git.Tfs.VsCommon
                 _contentLength = new FileInfo(temp).Length;
                 return temp;
             }
+
+            public void Get(IWorkspace workspace)
+            {
+                _pendingChange.DownloadShelvedFile(workspace.GetLocalItemForServerItem(_pendingChange.ServerItem));
+            }
+
         }
 
         #endregion

--- a/GitTfs.VsCommon/Wrappers.cs
+++ b/GitTfs.VsCommon/Wrappers.cs
@@ -105,6 +105,11 @@ namespace Sep.Git.Tfs.VsCommon
         {
             get { return _bridge.Wrap<WrapperForVersionControlServer, VersionControlServer>(_changeset.VersionControlServer); }
         }
+
+        public void Get(IWorkspace workspace)
+        {
+            workspace.GetSpecificVersion(this);
+        }
     }
 
     public class WrapperForChange : WrapperFor<Change>, IChange
@@ -459,8 +464,13 @@ namespace Sep.Git.Tfs.VsCommon
         public void GetSpecificVersion(IChangeset changeset)
         {
             var requests = from change in changeset.Changes
-                           select new GetRequest(new ItemSpec(change.Item.ServerItem, RecursionType.None, change.Item.DeletionId), changeset.ChangesetId == -1 ? change.Item.ChangesetId : changeset.ChangesetId);
+                           select new GetRequest(new ItemSpec(change.Item.ServerItem, RecursionType.None, change.Item.DeletionId), changeset.ChangesetId);
             _workspace.Get(requests.ToArray(), GetOptions.Overwrite);
+        }
+
+        public string GetLocalItemForServerItem(string serverItem)
+        {
+            return _workspace.GetLocalItemForServerItem(serverItem);
         }
 
         public string OwnerName

--- a/GitTfs.VsFake/TfsHelper.VsFake.cs
+++ b/GitTfs.VsFake/TfsHelper.VsFake.cs
@@ -103,6 +103,11 @@ namespace Sep.Git.Tfs.VsFake
             {
                 get { throw new NotImplementedException(); }
             }
+
+            public void Get(IWorkspace workspace)
+            {
+                workspace.GetSpecificVersion(this);
+            }
         }
 
         class Change : IChange, IItem
@@ -261,6 +266,11 @@ namespace Sep.Git.Tfs.VsFake
             }
 
             public void GetSpecificVersion(int changeset)
+            {
+                throw new NotImplementedException();
+            }
+
+            public string GetLocalItemForServerItem(string serverItem)
             {
                 throw new NotImplementedException();
             }

--- a/GitTfs/Core/TfsInterop/IChangeset.cs
+++ b/GitTfs/Core/TfsInterop/IChangeset.cs
@@ -10,5 +10,6 @@ namespace Sep.Git.Tfs.Core.TfsInterop
         string Comment { get; }
         int ChangesetId { get; }
         IVersionControlServer VersionControlServer { get; }
+        void Get(IWorkspace workspace);
     }
 }

--- a/GitTfs/Core/TfsInterop/IWorkspace.cs
+++ b/GitTfs/Core/TfsInterop/IWorkspace.cs
@@ -15,6 +15,7 @@ namespace Sep.Git.Tfs.Core.TfsInterop
         void ForceGetFile(string path, int changeset);
         void GetSpecificVersion(int changeset);
         void GetSpecificVersion(IChangeset changeset);
+        string GetLocalItemForServerItem(string serverItem);
         string OwnerName { get; }
     }
 }

--- a/GitTfs/Core/TfsWorkspace.cs
+++ b/GitTfs/Core/TfsWorkspace.cs
@@ -170,7 +170,7 @@ namespace Sep.Git.Tfs.Core
 
         public void Get(IChangeset changeset)
         {
-            _workspace.GetSpecificVersion(changeset);
+            changeset.Get(_workspace);
         }
 
         private IEnumerable<IWorkItemCheckinInfo> GetWorkItemInfos(CheckinOptions options = null)


### PR DESCRIPTION
Downloading of files was the responsibility of the items themselves,
but to optimize this, it was changed to requesting entire changesets
at once. However, this optimization broke downloading of shelvesets.

The changeset is now responsible for populating the workspace with the
correct files. This allows for different download strategies for real
changesets and shelvesets.
