### PR TITLE
Add a 'labels' command to fetch tfs labels

### DIFF
--- a/GitTfs.VsCommon/TfsHelper.Common.cs
+++ b/GitTfs.VsCommon/TfsHelper.Common.cs
@@ -555,5 +555,20 @@ namespace Sep.Git.Tfs.VsCommon
         {
             return new WorkItemCheckedInfo(Convert.ToInt32(workitem), true, checkinAction);
         }
+
+        public IEnumerable<TfsLabel> GetLabels(string tfsPathBranch)
+        {
+            var labels = VersionControl.QueryLabels(null, tfsPathBranch, null, true, tfsPathBranch, VersionSpec.Latest);
+            return labels.Select(e => new TfsLabel {
+                Id = e.LabelId,
+                Name = e.Name,
+                Comment = e.Comment,
+                ChangesetId = e.Items.Where(i=>i.ServerItem.IndexOf(tfsPathBranch) == 0).OrderByDescending(i=>i.ChangesetId).First().ChangesetId,
+                Owner = e.OwnerName,
+                Date = e.LastModifiedDate,
+                IsTransBranch = (e.Items.FirstOrDefault(i => i.ServerItem.IndexOf(tfsPathBranch) != 0) != null)
+            });
+        }
+
     }
 }

--- a/GitTfs.VsFake/TfsHelper.VsFake.cs
+++ b/GitTfs.VsFake/TfsHelper.VsFake.cs
@@ -351,6 +351,11 @@ namespace Sep.Git.Tfs.VsFake
         {
             throw new NotImplementedException();
         }
+
+        public IEnumerable<TfsLabel> GetLabels(string tfsPathBranch)
+        {
+            throw new NotImplementedException();
+        }
         #endregion
     }
 }

--- a/GitTfs/Commands/Fetch.cs
+++ b/GitTfs/Commands/Fetch.cs
@@ -20,17 +20,20 @@ namespace Sep.Git.Tfs.Commands
         private readonly RemoteOptions remoteOptions;
         private readonly Globals globals;
         private readonly AuthorsFile authors;
+        private readonly Labels labels;
 
-        public Fetch(Globals globals, RemoteOptions remoteOptions, AuthorsFile authors)
+        public Fetch(Globals globals, RemoteOptions remoteOptions, AuthorsFile authors, Labels labels)
         {
             this.remoteOptions = remoteOptions;
             this.globals = globals;
             this.authors = authors;
+            this.labels = labels;
         }
 
 //        public int? RevisionToFetch { get; set; }
 
         bool FetchAll { get; set; }
+        bool FetchLabels { get; set; }
         bool FetchParents { get; set; }
         string AuthorsFilePath { get; set; }
         public virtual OptionSet OptionSet
@@ -45,6 +48,8 @@ namespace Sep.Git.Tfs.Commands
                         v => FetchParents = v != null },
                     { "authors=", "Path to an Authors file to map TFS users to Git users",
                         v => AuthorsFilePath = v },
+                    { "l|with-labels|fetch-labels", "Fetch the labels also when fetching TFS changesets",
+                        v => FetchLabels = v != null },
 //                    { "r|revision=",
 //                        v => RevisionToFetch = Convert.ToInt32(v) },
                 }.Merge(remoteOptions.OptionSet);
@@ -64,6 +69,11 @@ namespace Sep.Git.Tfs.Commands
             {
                 Trace.WriteLine("Fetching from TFS remote " + remote.Id);
                 DoFetch(remote);
+                if (labels != null && FetchLabels)
+                {
+                    Trace.WriteLine("Fetching labels from TFS remote " + remote.Id);
+                    labels.Run(remote);
+                }
             }
             return 0;
         }

--- a/GitTfs/Commands/Labels.cs
+++ b/GitTfs/Commands/Labels.cs
@@ -1,0 +1,130 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using NDesk.Options;
+using Sep.Git.Tfs.Core;
+using StructureMap;
+using Sep.Git.Tfs.Util;
+
+namespace Sep.Git.Tfs.Commands
+{
+    [Pluggable("labels")]
+    [Description("labels [options] [tfsRemoteId]\n ex : git tfs labels\n      git tfs labels -i myRemoteBranche\n      git tfs labels --all")]
+    [RequiresValidGitRepository]
+    public class Labels : GitTfsCommand
+    {
+        private readonly TextWriter _stdout;
+        private readonly Globals _globals;
+        private readonly AuthorsFile _authors;
+
+        private RemoteOptions _remoteOptions;
+        public string TfsUsername { get; set; }
+        public string TfsPassword { get; set; }
+        public string ParentBranch { get; set; }
+        public bool LabelAllBranches { get; set; }
+        string AuthorsFilePath { get; set; }
+
+        public Labels(TextWriter stdout, Globals globals, AuthorsFile authors)
+        {
+            this._stdout = stdout;
+            this._globals = globals;
+            this._authors = authors;
+        }
+
+        public OptionSet OptionSet
+        {
+            get
+            {
+                return new OptionSet
+                {
+                    { "all|fetch-all", "Fetch all the labels on all the TFS remotes (For TFS 2010 and later)", v => LabelAllBranches = v != null },
+                    { "u|username=", "TFS username", v => TfsUsername = v },
+                    { "p|password=", "TFS password", v => TfsPassword = v },
+                    { "a|authors=", "Path to an Authors file to map TFS users to Git users", v => AuthorsFilePath = v },
+                };
+            }
+        }
+
+        public int Run(IGitTfsRemote remote)
+        {
+            return CreateLabelsForTfsBranch(remote);
+        }
+
+        private int Run(string remoteId)
+        {
+            var tfsRemote = _globals.Repository.ReadTfsRemote(remoteId);
+            if (tfsRemote == null)
+                throw new GitTfsException("error: No git-tfs repository found. Please try to clone first...\n");
+
+            _authors.Parse(AuthorsFilePath, _globals.GitDir);
+
+            return CreateLabelsForTfsBranch(tfsRemote);
+        }
+
+        public int Run()
+        {
+            if (!LabelAllBranches)
+            {
+                return Run(_globals.RemoteId);
+            }
+
+            var allRemotes = _globals.Repository.ReadAllTfsRemotes();
+
+            _authors.Parse(AuthorsFilePath, _globals.GitDir);
+
+            foreach (var tfsRemote in allRemotes)
+            {
+                CreateLabelsForTfsBranch(tfsRemote);
+            }
+            return GitTfsExitCodes.OK;
+        }
+
+        private int CreateLabelsForTfsBranch(IGitTfsRemote tfsRemote)
+        {
+            UpdateRemote(tfsRemote);
+            Trace.WriteLine("Looking for label on " + tfsRemote.TfsRepositoryPath);
+            var labels = tfsRemote.Tfs.GetLabels(tfsRemote.TfsRepositoryPath);
+            foreach (var label in labels)
+            {
+                Trace.WriteLine("LabelId:" + label.Id + "/ChangesetId:" + label.ChangesetId + "/LabelName:" + label.Name + "/Owner:" + label.Owner);
+                Trace.WriteLine("Try to find changeset in git repository...");
+                string sha1TagCommit = _globals.Repository.FindCommitHashByCommitMessage("git-tfs-id: .*;C" + label.ChangesetId + "[^0-9]");
+                if (string.IsNullOrWhiteSpace(sha1TagCommit))
+                {
+                    Trace.WriteLine("This label does not match an existing commit...");
+                    continue;
+                }
+                Trace.WriteLine("Commit found! sha1 : " + sha1TagCommit);
+
+                string ownerName;
+                string ownerEmail;
+                if(_authors.Authors.ContainsKey(label.Owner))
+                {
+                    var author = _authors.Authors[label.Owner];
+                    ownerName = author.Name;
+                    ownerEmail = author.Email;
+                }
+                else
+                {
+                    ownerName = label.Owner;
+                    ownerEmail = label.Owner;
+                }
+                var labelName = label.IsTransBranch ? label.Name + "(" + tfsRemote.Id + ")" : label.Name;
+                _stdout.WriteLine("Writing label '" + labelName + "'...");
+                _globals.Repository.CreateTag(labelName, sha1TagCommit, label.Comment, ownerName, ownerEmail ,label.Date);
+            }
+            return GitTfsExitCodes.OK;
+        }
+
+        private void UpdateRemote(IGitTfsRemote tfsRemote)
+        {
+            if (!string.IsNullOrWhiteSpace(TfsUsername))
+            {
+                tfsRemote.TfsUsername = TfsUsername;
+                tfsRemote.TfsPassword = TfsPassword;
+            }
+        }
+    }
+}

--- a/GitTfs/Commands/QuickFetch.cs
+++ b/GitTfs/Commands/QuickFetch.cs
@@ -15,7 +15,7 @@ namespace Sep.Git.Tfs.Commands
     //  2. Load the correct set of extant casing.
     public class QuickFetch : Fetch
     {
-        public QuickFetch(Globals globals, RemoteOptions remoteOptions, AuthorsFile authors) : base(globals, remoteOptions, authors)
+        public QuickFetch(Globals globals, RemoteOptions remoteOptions, AuthorsFile authors) : base(globals, remoteOptions, authors, null)
         {
         }
 

--- a/GitTfs/Core/GitRepository.cs
+++ b/GitTfs/Core/GitRepository.cs
@@ -437,5 +437,11 @@ namespace Sep.Git.Tfs.Core
             }
             return null;
         }
+
+        public void CreateTag(string name, string sha, string comment, string Owner, string emailOwner, System.DateTime creationDate)
+        {
+            if (_repository.Tags[name] == null)
+                _repository.ApplyTag(name, sha, new Signature(Owner, emailOwner, new DateTimeOffset(creationDate)), comment);
+        }
     }
 }

--- a/GitTfs/Core/IGitRepository.cs
+++ b/GitTfs/Core/IGitRepository.cs
@@ -27,5 +27,6 @@ namespace Sep.Git.Tfs.Core
         string AssertValidBranchName(string gitBranchName);
         bool CreateBranch(string gitBranchName, string target);
         string FindCommitHashByCommitMessage(string patternToFind);
+        void CreateTag(string name, string sha, string comment, string Owner, string emailOwner, System.DateTime creationDate);
     }
 }

--- a/GitTfs/Core/TfsInterop/ITfsHelper.cs
+++ b/GitTfs/Core/TfsInterop/ITfsHelper.cs
@@ -29,6 +29,7 @@ namespace Sep.Git.Tfs.Core.TfsInterop
         long ShowCheckinDialog(IWorkspace workspace, IPendingChange[] pendingChanges, IEnumerable<IWorkItemCheckedInfo> checkedInfos, string checkinComment);
         void CleanupWorkspaces(string workingDirectory);
         int GetRootChangesetForBranch(string tfsPathBranchToCreate, string tfsPathParentBranch = null);
+        IEnumerable<TfsLabel> GetLabels(string tfsPathBranch);
         IEnumerable<string> GetAllTfsBranchesOrderedByCreation();
         void EnsureAuthenticated();
     }

--- a/GitTfs/Core/TfsLabel.cs
+++ b/GitTfs/Core/TfsLabel.cs
@@ -1,0 +1,14 @@
+﻿namespace Sep.Git.Tfs.Core
+{
+    public class TfsLabel
+    {
+        public int Id { get; set; }
+        public int ChangesetId { get; set; }
+        public string Name { get; set; }
+        public string Comment { get; set; }
+        public string Owner { get; set; }
+        public System.DateTime Date { get; set; }
+        public bool IsTransBranch { get; set; }
+    }
+
+}

--- a/GitTfs/GitTfs.csproj
+++ b/GitTfs/GitTfs.csproj
@@ -108,6 +108,7 @@
     <Compile Include="Commands\CheckinTool.cs" />
     <Compile Include="Commands\CheckinOptions.cs" />
     <Compile Include="Commands\CheckinBase.cs" />
+    <Compile Include="Commands\Labels.cs" />
     <Compile Include="Commands\InitBranch.cs" />
     <Compile Include="Commands\Info.cs" />
     <Compile Include="Commands\Cleanup.cs" />
@@ -135,6 +136,7 @@
     <Compile Include="Core\Changes\Git\Modify.cs" />
     <Compile Include="Core\Changes\Git\RenameEdit.cs" />
     <Compile Include="Core\CheckinPolicyEvaluator.cs" />
+    <Compile Include="Core\TfsLabel.cs" />
     <Compile Include="Core\DerivedGitTfsRemote.cs" />
     <Compile Include="Core\GitChangeInfo.cs" />
     <Compile Include="Core\GitCommit.cs" />


### PR DESCRIPTION
A first step to fetch tfs labels.

Some things could seems odd but it's to manage tfs labels that could be trans-branches :(

I hope it manage all use cases because tfs labels are very strange things (the more I discover tfs, the more I think tfs developpers take strange things!)

Give it a try!
