### PR TITLE
Add a warning if the clone is made from a TFS path that is not the trunk

### DIFF
--- a/GitTfs/Commands/QuickClone.cs
+++ b/GitTfs/Commands/QuickClone.cs
@@ -7,7 +7,7 @@ namespace Sep.Git.Tfs.Commands
     [Description("quick-clone [options] tfs-url-or-instance-name repository-path <git-repository-path>")]
     public class QuickClone : Clone
     {
-        public QuickClone(Globals globals, Init init, QuickFetch fetch) : base(globals, fetch, init, null)
+        public QuickClone(Globals globals, Init init, QuickFetch fetch) : base(globals, fetch, init, null, null)
         {
         }
     }


### PR DESCRIPTION
 Display informations (info, warning or error) if the clone is not made from a TFS path different from the trunk

... preventing to use `init-branch` later (it's better to warn the earliest possible)
