### PR TITLE
Add --stash and --continue options for pull and rcheckin

### DIFF
--- a/GitTfs/Commands/Pull.cs
+++ b/GitTfs/Commands/Pull.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using NDesk.Options;
@@ -50,7 +50,7 @@ namespace Sep.Git.Tfs.Commands
                         throw new GitTfsException("error: You have local changes; rebase-workflow only possible with clean working directory.")
                             .WithRecommendation("Try 'git stash' to stash your local changes and pull again.");
                     }
-                    globals.Repository.CommandNoisy("rebase", remote.RemoteRef);
+                    globals.Repository.CommandNoisy("rebase", "--preserve-merges", remote.RemoteRef);
                 }
                 else
                     globals.Repository.CommandNoisy("merge", remote.RemoteRef);


### PR DESCRIPTION
Command `pull --rebase` and `rcheckin` can't work when there is changes in the working directory.
So I add an option `--stash` to automaticly do the stash if needed and stash pop after if all went good.

I also added an option `--continue` on the `rcheckin` command to continue checkin on TFS even if new changesets are discovered. In this case, rebase is done and if there is no merge conflicts, work continue. If there is merge conflicts, the command failed anyway (so there is no risk!).

Not sure if it is in the git and git-tfs philosophy to do that but it helps me a lot in my personal workflow (I always have changes like app.config and web.config modified and I hate when my command fail when I forgot to stash before calling commands) and nearly everytime, I rebase on new changesets and continue rcheckin.

If it could be usefull to someone...
