### PR TITLE
Remove unallowed chars in label names

### DIFF
--- a/GitTfs/Commands/Init.cs
+++ b/GitTfs/Commands/Init.cs
@@ -105,5 +105,17 @@ namespace Sep.Git.Tfs.Commands
             else
                 yield return "Try using $/" + tfsPath;
         }
+
+        public static string ToGitRefName(this string expectedRefName)
+        {
+            expectedRefName = System.Text.RegularExpressions.Regex.Replace(expectedRefName, @"[!~$?[*^: \\]", string.Empty);
+            expectedRefName = expectedRefName.Replace("@{", string.Empty);
+            expectedRefName = expectedRefName.Replace("..", string.Empty);
+            expectedRefName = expectedRefName.Replace("//", string.Empty);
+            expectedRefName = expectedRefName.Replace("/.", "/");
+            expectedRefName = expectedRefName.TrimEnd('.', '/');
+            return expectedRefName.Trim('/');
+        }
+
     }
 }

--- a/GitTfs/Commands/InitBranch.cs
+++ b/GitTfs/Commands/InitBranch.cs
@@ -188,17 +188,6 @@ namespace Sep.Git.Tfs.Commands
             return GitTfsExitCodes.OK;
         }
 
-        private string RemoveNotAllowedChars(string expectedBranchName)
-        {
-            expectedBranchName = expectedBranchName.Replace("@{", string.Empty);
-            expectedBranchName = expectedBranchName.Replace("..", string.Empty);
-            expectedBranchName = expectedBranchName.Replace("//", string.Empty);
-            expectedBranchName = expectedBranchName.Replace("/.", "/");
-            expectedBranchName = expectedBranchName.TrimEnd('.');
-            expectedBranchName = expectedBranchName.Trim('/');
-            return System.Text.RegularExpressions.Regex.Replace(expectedBranchName, @"[!~$?[*^: \\]", string.Empty);
-        }
-
         protected string ExtractGitBranchNameFromTfsRepositoryPath(string tfsRepositoryPath)
         {
             string gitBranchNameExpected;
@@ -210,8 +199,8 @@ namespace Sep.Git.Tfs.Commands
             {
                 gitBranchNameExpected = tfsRepositoryPath;
             }
-            gitBranchNameExpected = gitBranchNameExpected.TrimEnd('/', '.');
-            var gitBranchName = _globals.Repository.AssertValidBranchName(RemoveNotAllowedChars(gitBranchNameExpected.Trim()));
+            gitBranchNameExpected = gitBranchNameExpected.ToGitRefName();
+            var gitBranchName = _globals.Repository.AssertValidBranchName(gitBranchNameExpected);
             _stdout.WriteLine("The name of the local branch will be : " + gitBranchName);
             return gitBranchName;
         }

--- a/GitTfs/Commands/Labels.cs
+++ b/GitTfs/Commands/Labels.cs
@@ -84,8 +84,9 @@ namespace Sep.Git.Tfs.Commands
         private int CreateLabelsForTfsBranch(IGitTfsRemote tfsRemote)
         {
             UpdateRemote(tfsRemote);
-            Trace.WriteLine("Looking for label on " + tfsRemote.TfsRepositoryPath);
+            _stdout.WriteLine("Looking for label on " + tfsRemote.TfsRepositoryPath + "...");
             var labels = tfsRemote.Tfs.GetLabels(tfsRemote.TfsRepositoryPath);
+            _stdout.WriteLine(labels.Count() +" labels found!");
             foreach (var label in labels)
             {
                 Trace.WriteLine("LabelId:" + label.Id + "/ChangesetId:" + label.ChangesetId + "/LabelName:" + label.Name + "/Owner:" + label.Owner);
@@ -111,7 +112,7 @@ namespace Sep.Git.Tfs.Commands
                     ownerName = label.Owner;
                     ownerEmail = label.Owner;
                 }
-                var labelName = label.IsTransBranch ? label.Name + "(" + tfsRemote.Id + ")" : label.Name;
+                var labelName = (label.IsTransBranch ? label.Name + "(" + tfsRemote.Id + ")" : label.Name).ToGitRefName();
                 _stdout.WriteLine("Writing label '" + labelName + "'...");
                 _globals.Repository.CreateTag(labelName, sha1TagCommit, label.Comment, ownerName, ownerEmail ,label.Date);
             }

--- a/GitTfsTest/Commands/ExtTest.cs
+++ b/GitTfsTest/Commands/ExtTest.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using Rhino.Mocks;
+using Sep.Git.Tfs.Commands;
+using Sep.Git.Tfs.Core;
+using Sep.Git.Tfs.Core.TfsInterop;
+using StructureMap.AutoMocking;
+using Xunit;
+using Sep.Git.Tfs.Util;
+
+namespace Sep.Git.Tfs.Test.Commands
+{
+    public class ExtTest
+    {
+        [Fact]
+        public void AssertValidTfsPathTest()
+        {
+            Assert.DoesNotThrow(() => "$/test".AssertValidTfsPath());
+            Assert.Throws(typeof(GitTfsException), () => "$test".AssertValidTfsPath());
+            Assert.Throws(typeof(GitTfsException), () => "/test".AssertValidTfsPath());
+            Assert.Throws(typeof(GitTfsException), () => "test".AssertValidTfsPath());
+        }
+
+        [Fact]
+        public void ToGitRefNameTest()
+        {
+            Assert.Equal("test", "test".ToGitRefName());
+            Assert.Equal("test", "te^st".ToGitRefName());
+            Assert.Equal("test", "te~st".ToGitRefName());
+            Assert.Equal("test", "te st".ToGitRefName());
+            Assert.Equal("test", "te:st".ToGitRefName());
+            Assert.Equal("test", "te*st".ToGitRefName());
+            Assert.Equal("test", "te?st".ToGitRefName());
+            Assert.Equal("test", "te[st".ToGitRefName());
+            Assert.Equal("test", "test/".ToGitRefName());
+            Assert.Equal("test", "test.".ToGitRefName());
+            Assert.Equal("test", "te..st".ToGitRefName());
+            Assert.Equal("test", "test.".ToGitRefName());
+            Assert.Equal("test", "te\\st.".ToGitRefName());
+            Assert.Equal("test", "te@{st.".ToGitRefName());
+            Assert.Equal("test", "/test././".ToGitRefName());
+            Assert.Equal("bugs/nameOfTheBug", "/bu$gs/name:OfTheBug".ToGitRefName());
+            Assert.Equal("repo/test/test2", "$/repo/te:st/test2".ToGitRefName());
+        }
+    }
+}

--- a/GitTfsTest/GitTfsTest.csproj
+++ b/GitTfsTest/GitTfsTest.csproj
@@ -107,6 +107,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Commands\ExtTest.cs" />
     <Compile Include="Commands\InitOptionsTest.cs" />
     <Compile Include="Commands\InitBranchTest.cs" />
     <Compile Include="FactExceptOnUnix.cs" />


### PR DESCRIPTION
TFS permit chars that are not allowed in Git tag name (for exemple space)
