### PR TITLE
Use a custom workspace, if desired.

### DIFF
--- a/GitTfs.VsCommon/TfsHelper.Common.cs
+++ b/GitTfs.VsCommon/TfsHelper.Common.cs
@@ -139,6 +139,7 @@ namespace Sep.Git.Tfs.VsCommon
 
         public void WithWorkspace(string localDirectory, IGitTfsRemote remote, TfsChangesetInfo versionToFetch, Action<ITfsWorkspace> action)
         {
+            Trace.WriteLine("Setting up a TFS workspace at " + localDirectory);
             var workspace = GetWorkspace(localDirectory, remote.TfsRepositoryPath);
             try
             {

--- a/GitTfs.VsFake/TfsHelper.VsFake.cs
+++ b/GitTfs.VsFake/TfsHelper.VsFake.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Sep.Git.Tfs.Commands;
@@ -185,6 +186,7 @@ namespace Sep.Git.Tfs.VsFake
 
         public void WithWorkspace(string directory, IGitTfsRemote remote, TfsChangesetInfo versionToFetch, Action<ITfsWorkspace> action)
         {
+            Trace.WriteLine("Setting up a TFS workspace at " + directory);
             var fakeWorkspace = new FakeWorkspace(directory, remote.TfsRepositoryPath);
             var workspace = new TfsWorkspace(fakeWorkspace, directory, _stdout, versionToFetch, remote, null, this, null);
             action(workspace);

--- a/GitTfs/Core/GitRepository.cs
+++ b/GitTfs/Core/GitRepository.cs
@@ -52,6 +52,11 @@ namespace Sep.Git.Tfs.Core
                 gitCommand.WorkingDirectory = Path.Combine(gitCommand.WorkingDirectory, WorkingCopySubdir);
         }
 
+        public string GetConfig(string key)
+        {
+            return _repository.Config.Get<string>(key, null);
+        }
+
         public IEnumerable<IGitTfsRemote> ReadAllTfsRemotes()
         {
             return GetTfsRemotes().Values;

--- a/GitTfs/Core/GitTfsRemote.cs
+++ b/GitTfs/Core/GitTfsRemote.cs
@@ -114,7 +114,7 @@ namespace Sep.Git.Tfs.Core
         {
             get
             {
-                return Path.Combine(Dir, "workspace");
+                return Repository.GetConfig("git-tfs.workspace-dir") ?? Path.Combine(Dir, "workspace");
             }
         }
 

--- a/GitTfs/Core/IGitRepository.cs
+++ b/GitTfs/Core/IGitRepository.cs
@@ -7,6 +7,7 @@ namespace Sep.Git.Tfs.Core
     public interface IGitRepository : IGitHelpers
     {
         string GitDir { get; set; }
+        string GetConfig(string key);
         IEnumerable<IGitTfsRemote> ReadAllTfsRemotes();
         IGitTfsRemote ReadTfsRemote(string remoteId);
         void /*or IGitTfsRemote*/ CreateTfsRemote(string remoteId, string tfsUrl, string tfsRepositoryPath, RemoteOptions remoteOptions);

--- a/GitTfs/GitTfs.cs
+++ b/GitTfs/GitTfs.cs
@@ -44,6 +44,7 @@ namespace Sep.Git.Tfs
 
         public void Main(GitTfsCommand command, IList<string> unparsedArgs)
         {
+            Trace.WriteLine(_gitTfsVersionProvider.GetVersionString());
             if(_globals.ShowHelp)
             {
                 Environment.ExitCode = _help.ShowHelp(command);


### PR DESCRIPTION
Let users set a custom workspace directory for fetching.

Usage:

```
> git tfs init http://server/tfs $/Project project
> cd project
> git config git-tfs.workspace-dir c:\ws
> git tfs fetch
```

re #265
