### PR TITLE
TfsAuthenticated remotes only when needed to not authenticate all the re...

### DIFF
--- a/GitTfs/Core/GitRepository.cs
+++ b/GitTfs/Core/GitRepository.cs
@@ -60,7 +60,11 @@ namespace Sep.Git.Tfs.Core
 
         public IEnumerable<IGitTfsRemote> ReadAllTfsRemotes()
         {
-            return GetTfsRemotes().Values;
+            var remotes = GetTfsRemotes().Values;
+            foreach (var remote in remotes)
+                remote.EnsureTfsAuthenticated();
+
+            return remotes;
         }
 
         public IGitTfsRemote ReadTfsRemote(string remoteId)
@@ -68,7 +72,9 @@ namespace Sep.Git.Tfs.Core
             if (!HasRemote(remoteId))
                 throw new GitTfsException("Unable to locate git-tfs remote with id = " + remoteId)
                     .WithRecommendation("Try using `git tfs bootstrap` to auto-init TFS remotes.");
-            return GetTfsRemotes()[remoteId];
+            var remote = GetTfsRemotes()[remoteId];
+            remote.EnsureTfsAuthenticated();
+            return remote;
         }
 
         private IGitTfsRemote ReadTfsRemote(string tfsUrl, string tfsRepositoryPath, bool includeStubRemotes)
@@ -87,7 +93,9 @@ namespace Sep.Git.Tfs.Core
                     return new DerivedGitTfsRemote(tfsUrl, tfsRepositoryPath);
                 case 1:
                     Trace.WriteLine("One remote matched");
-                    return matchingRemotes.First();
+                    var remote = matchingRemotes.First();
+                    remote.EnsureTfsAuthenticated();
+                    return remote;
                 default:
                     Trace.WriteLine("More than one remote matched!");
                     goto case 1;
@@ -177,7 +185,6 @@ namespace Sep.Git.Tfs.Core
             foreach (var gitTfsRemotePair in remotes)
             {
                 var remote = gitTfsRemotePair.Value;
-                remote.EnsureTfsAuthenticated();
             }
         }
 

--- a/GitTfs/Core/GitTfsRemote.cs
+++ b/GitTfs/Core/GitTfsRemote.cs
@@ -19,6 +19,7 @@ namespace Sep.Git.Tfs.Core
         private readonly RemoteOptions remoteOptions;
         private long? maxChangesetId;
         private string maxCommitHash;
+        private bool IsTfsAuthenticated { get; set; }
 
         public GitTfsRemote(RemoteOptions remoteOptions, Globals globals, ITfsHelper tfsHelper, TextWriter stdout)
         {
@@ -26,11 +27,15 @@ namespace Sep.Git.Tfs.Core
             this.globals = globals;
             this.stdout = stdout;
             Tfs = tfsHelper;
+            IsTfsAuthenticated = false;
         }
 
         public void EnsureTfsAuthenticated()
         {
+            if (IsTfsAuthenticated)
+                return;
             Tfs.EnsureAuthenticated();
+            IsTfsAuthenticated = true;
         }
 
         public bool IsDerived


### PR DESCRIPTION
...motes not used (takes time!!)
Not every commands need to use all tfs remotes (in fact, not the most used, fetch and rcheckin). Before this patch, all the remote are TfsAuthenticated. I have timed and it takes a long time for the first remote and after 1.5 seconds for each other remote.
With this patch, I launch the TFS authentication only when the remote is returned.

For exemple, I have a repository with 5 remotes and to do only a fetch, I reduce the fetch by about 4*1.5= 6s.
