### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,11 @@ You need .NET 4 and either the 2008 or 2010 version of Team Explorer installed.
 
 ### Building
 
-Use `msbuild GitTfs.sln /p:Configuration=Vs2010_Debug` to build for the 2010 version only.
+#### Building With MSBuild
+1. Update submodules. `git submodule update`  to get the libgit2sharp dependencies.
+2. Build with `msbuild GitTfs.sln /p:Configuration=debug` for the default debug build.
 
+####Building With Rake
 You can also do `rake build:debug`.
 
 ## Contributing


### PR DESCRIPTION
Fixing build notes for what worked (from checkout to build)

Adding note about submodules.
Config Vs2010_Debug doesn't appear to exist, removing
Could not build with /p:Configuration=VS11_Debug, setting default action to just the debug build (similar to rake command I guess?)
