### PR TITLE
Manage Add ChangeType to correct fail when `init-branch` call

### DIFF
--- a/GitTfs.VsCommon/TfsHelper.PostVs2010.Common.cs
+++ b/GitTfs.VsCommon/TfsHelper.PostVs2010.Common.cs
@@ -98,26 +98,26 @@ namespace Sep.Git.Tfs.VsCommon
                 throw new GitTfsException("An unexpected error occured when trying to find the root changeset.\nFailed to find root changeset for " + tfsPathBranchToCreate + " branch in " + tfsPathParentBranch + " branch");
             }
 
-            switch (merge.SourceItem.ChangeType)
+            if (merge.SourceItem.ChangeType.HasFlag(ChangeType.Branch)
+                || merge.SourceItem.ChangeType.HasFlag(ChangeType.Merge)
+                || merge.SourceItem.ChangeType.HasFlag(ChangeType.Add))
             {
-                case ChangeType.Branch:
-                case ChangeType.Merge:
-                case ChangeType.Add | ChangeType.Encoding:
-                    Trace.WriteLine("Found C" + merge.SourceChangeset.ChangesetId + " on branch " + merge.SourceItem.Item.ServerItem);
-                    return merge.SourceChangeset;
-                case ChangeType.Rename:
-                    Trace.WriteLine("Found C" + merge.TargetChangeset.ChangesetId + " on branch " + merge.TargetItem.Item);
-                    return merge.TargetChangeset;
-                default:
-                    throw new GitTfsException(
-                        "Don't know (yet) how to find the root changeset for an ExtendedMerge of type " +
-                        merge.SourceItem.ChangeType,
-                        new string[]
+                Trace.WriteLine("Found C" + merge.SourceChangeset.ChangesetId + " on branch " + merge.SourceItem.Item.ServerItem);
+                return merge.SourceChangeset;
+            }
+            if(merge.SourceItem.ChangeType.HasFlag(ChangeType.Rename))
+            {
+                Trace.WriteLine("Found C" + merge.TargetChangeset.ChangesetId + " on branch " + merge.TargetItem.Item);
+                return merge.TargetChangeset;
+            }
+            throw new GitTfsException(
+                "Don't know (yet) how to find the root changeset for an ExtendedMerge of type " +
+                merge.SourceItem.ChangeType,
+                new string[]
                             {
                                 "Open an Issue on Github to notify the community that you need support for '" +
                                 merge.SourceItem.ChangeType + "': https://github.com/git-tfs/git-tfs/issues"
                             });
-            }
         }
     }
 


### PR DESCRIPTION
@davidalpert all my branches are of the type "Add | Encoding" so I did this patch to correct it.
But don't you think it will be better to replace the switch by if()?
if (merge.SourceItem.ChangeType.HasFlag(ChangeType.Branch)
                || merge.SourceItem.ChangeType.HasFlag(ChangeType.Merge)
                || merge.SourceItem.ChangeType.HasFlag(ChangeType.Add))
{
//do...
}
