### PR TITLE
Multiple git-tfs-id lines in a merge commit message lead to null reference errors; this change fixes the parsing

### DIFF
--- a/GitTfs/Core/GitRepository.cs
+++ b/GitTfs/Core/GitRepository.cs
@@ -276,15 +276,16 @@ namespace Sep.Git.Tfs.Core
                 var match = GitTfsConstants.CommitRegex.Match(line);
                 if (match.Success)
                 {
-                    if (lastChangesetInfo != null && currentCommit != null)
+                    if (lastChangesetInfo != null)
                     {
                         tfsCommits.Add(lastChangesetInfo);
-                        currentCommit = null;
                         lastChangesetInfo = null;
                     }
+
                     currentCommit = match.Groups[1].Value;
                     continue;
                 }
+
                 var changesetInfo = TryParseChangesetInfo(line, currentCommit, includeStubRemotes);
                 if (changesetInfo != null)
                 {
@@ -294,7 +295,7 @@ namespace Sep.Git.Tfs.Core
 
             // Add the final changesetinfo object; it won't be handled in the loop
             // if it was part of the last commit message.
-            if (lastChangesetInfo != null && currentCommit != null)
+            if (lastChangesetInfo != null)
                 tfsCommits.Add(lastChangesetInfo);
 
             //stdout.Close();


### PR DESCRIPTION
In my company's project, we get merge commits in git that can include multiple merges with a remote TFS repo. The log messages end up with more than one git-tfs-id line, where the last one represents a merge with TFS and the earlier ones are from earlier merges. The code that parses the commit message looking to associate TFS changeset ids with commit hashes doesn't handle this situation; it sets the commit hash to null after seeing the first git-tfs-id, and associates the rest of the git-tfs-ids with null instead of the commit hash. Instead, the code needs to look for the LAST git-tfs-id line in the message and only associate that one with the commit hash.

Here's an example log message which triggered the problem. In TFS, this commit is Changeset C1612.

SHA-1: 6d4487fa588873f1aa558e0884bd7f4e362a2524
- Merge remote-tracking branch 'refs/remotes/tfs/default'

Fixed Issues 47, 48
Reduced Size of bar above subbrowsers for machine operator

Merge remote-tracking branch 'refs/remotes/tfs/default'

Merge branch 'master' of XXX.com:Metals

Added conditioning to check if valid date returned from scheduling engine

Merge branch 'master' of XXX.com:Metals

Merge remote-tracking branch 'refs/remotes/tfs/default'

Conflicts:
    Modules/ProcJobHeader/WPF.ProcJobHeader/JobAcceptanceWindow.xaml.cs

Stop the Timer when cancel clicked

Merge branch 'master' of XXX.com:Metals

Added Exception Handling for closing the JobAcceptanceWindow.xaml.cs

Remove Serivces.config files in bin directories from version control; they're generated at build time

Case 2976: Reoccurrence with EndDateType.After and start date within periodOfInterest returns extra occurrence

Case 2974: Scheduling job with only NEST processes causes error instead of returning null

Add NUnit.Runners.2.6.2 package for running tests without separate NUnit installation

git-tfs-id: [http://YYY.com:8080/tfs/collection]$/Solutions Suite;C1594

git-tfs-id: [http://YYY.com:8080/tfs/collection]$/Solutions Suite;C1604

Merge branch 'master' of XXX.com:Metals

Added conditioning to check if valid date returned from scheduling engine

Merge branch 'master' of XXX.com:Metals

Merge remote-tracking branch 'refs/remotes/tfs/default'

Conflicts:
    Modules/ProcJobHeader/WPF.ProcJobHeader/JobAcceptanceWindow.xaml.cs

Stop the Timer when cancel clicked

Merge branch 'master' of XXX.com:Metals

Added Exception Handling for closing the JobAcceptanceWindow.xaml.cs

Remove Serivces.config files in bin directories from version control; they're generated at build time

Case 2976: Reoccurrence with EndDateType.After and start date within periodOfInterest returns extra occurrence

Case 2974: Scheduling job with only NEST processes causes error instead of returning null

Add NUnit.Runners.2.6.2 package for running tests without separate NUnit installation

git-tfs-id: [http://YYY.com:8080/tfs/collection]$/Solutions Suite;C1594

git-tfs-id: [http://YYY.com:8080/tfs/collection]$/Solutions Suite;C1612
