### PR TITLE
Prevent from trying to delete an empty directory when moving out a file

### DIFF
--- a/GitTfs/Core/DirectoryTidier.cs
+++ b/GitTfs/Core/DirectoryTidier.cs
@@ -48,7 +48,7 @@ namespace Sep.Git.Tfs.Core
             if (dirName == null)
                 return;
             var downcasedDirName = dirName.ToLowerInvariant();
-            if (!HasEntryInDir(downcasedDirName) && !IsDirDeletedAlready(downcasedDirName, deletedDirs) && !cantDeleteDirs.Contains(downcasedDirName))
+            if (!HasEntryInDir(downcasedDirName) && !IsDirDeletedAlready(downcasedDirName, deletedDirs) && !CannotBeDeletedBecauseRenames(downcasedDirName, cantDeleteDirs))
             {
                 _workspace.Delete(dirName);
                 deletedDirs.Add(downcasedDirName);
@@ -59,6 +59,11 @@ namespace Sep.Git.Tfs.Core
         bool IsDirDeletedAlready(string downcasedDirName, IEnumerable<string> deletedDirs)
         {
             return deletedDirs.Any(t => downcasedDirName.StartsWith(t + "/") || t == downcasedDirName);
+        }
+
+        bool CannotBeDeletedBecauseRenames(string downcasedDirName, List<string> cantDeleteDirs)
+        {
+            return cantDeleteDirs.Any(t => t.StartsWith(downcasedDirName + "/") || t == downcasedDirName);
         }
 
         string GetDirectoryName(string path)

--- a/GitTfsTest/Core/DirectoryTidierTests.cs
+++ b/GitTfsTest/Core/DirectoryTidierTests.cs
@@ -147,6 +147,21 @@ namespace Sep.Git.Tfs.Test.Core
         }
 
         [Fact]
+        //TFS don't permit to delete an empty directory when the directory was emptied by moving outside a file (i.e. renaming)
+        //Until the changeset is done, tfs consider the file still belongs to the folder :( 
+        public void MovingFileAndDeletingFileInAParentDirectoryShouldLeaveAllDirectories()
+        {
+            mockWorkspace.Expect(x => x.Delete("dirA/file.txt"));
+            mockWorkspace.Expect(x => x.Rename("dirA/dirB/file.txt", "otherdir/otherdir2/newName1.txt", ScoreIsIrrelevant));
+            Tidy.Delete("dirA/file.txt");
+            Tidy.Rename("dirA/dirB/file.txt", "otherdir/otherdir2/newName1.txt", ScoreIsIrrelevant);
+            Tidy.Dispose();
+            mockWorkspace.Replay();
+            mockWorkspace.AssertWasNotCalled(x => x.Delete("dirA/dirB"));
+            mockWorkspace.AssertWasNotCalled(x => x.Delete("dirA"));
+        }
+
+        [Fact]
         public void DeletingFilesFromLessNestedDirToMostNestedDoesntRuinDirectoryTidying()
         {
             using (mocks.Ordered())


### PR DESCRIPTION
Moving a file outside a folder by a rename operation prevent tfs to
delete the containing directory with the error :
"TF14060: The item $/MyProject/Solution/FolderToDelete cannot be deleted. One or more children have pending changes."
The folder should not be deleted (and leave orphaned in tfs) if it is emptied
and that one of the previous contained files was renamed...

Fix #313
