### PR TITLE
git-tfs tries to authenticate against all TFS instances in the branch no matter how old they are

### DIFF
--- a/GitTfs.Vs11/TfsHelper.Vs11.cs
+++ b/GitTfs.Vs11/TfsHelper.Vs11.cs
@@ -69,6 +69,7 @@ namespace Sep.Git.Tfs.Vs11
 
         protected override T GetService<T>()
         {
+            if (_server == null) EnsureAuthenticated();
             return (T) _server.GetService(typeof (T));
         }
 

--- a/GitTfs.Vs2010/TfsHelper.Vs2010.cs
+++ b/GitTfs.Vs2010/TfsHelper.Vs2010.cs
@@ -68,7 +68,8 @@ namespace Sep.Git.Tfs.Vs2010
 
         protected override T GetService<T>()
         {
-            return (T) _server.GetService(typeof (T));
+            if (_server == null) EnsureAuthenticated();
+            return (T)_server.GetService(typeof(T));
         }
 
         protected override string GetAuthenticatedUser()

--- a/GitTfs/Core/GitRepository.cs
+++ b/GitTfs/Core/GitRepository.cs
@@ -95,9 +95,7 @@ namespace Sep.Git.Tfs.Core
                             .WithRecommendation("Try setting a legacy-url for an existing remote.");
                     return new DerivedGitTfsRemote(tfsUrl, tfsRepositoryPath);
                 case 1:
-                    Trace.WriteLine("One remote matched");
                     var remote = matchingRemotes.First();
-                    remote.EnsureTfsAuthenticated();
                     return remote;
                 default:
                     Trace.WriteLine("More than one remote matched!");


### PR DESCRIPTION
Our TFS instance recently changed URL and without this change it is required to filter-branch entire repository and change every git-tfs-id line in comments just to make git-tfs stop going to old URL to check. With it one should just keep config section for old branch and change the very last commit's comment (for each TFS branch). Also theoretically should save some time if several TFS instances are used as only specified with -i option is authenticated against.
