### PR TITLE
Do not delete a directory that is already deleted

### DIFF
--- a/GitTfs/Core/DirectoryTidier.cs
+++ b/GitTfs/Core/DirectoryTidier.cs
@@ -37,12 +37,25 @@ namespace Sep.Git.Tfs.Core
             if (dirName == null)
                 return;
             var downcasedDirName = dirName.ToLowerInvariant();
-            if (!HasEntryInDir(downcasedDirName) && !deletedDirs.Contains(downcasedDirName))
+            if (!HasEntryInDir(downcasedDirName) && !IsDeletedDirectory(downcasedDirName, deletedDirs))
             {
                 _workspace.Delete(dirName);
                 deletedDirs.Add(downcasedDirName);
                 DeleteEmptyDir(GetDirectoryName(dirName), deletedDirs);
             }
+        }
+
+        bool IsDeletedDirectory(string downcasedDirName, List<string> deletedDirs)
+        {
+            // this directory is deleted if it or an ancestor directory is deleted
+            foreach (var deletedDir in deletedDirs)
+            {
+                if (downcasedDirName == deletedDir || downcasedDirName.StartsWith(deletedDir + "/"))
+                {
+                    return true;
+                }
+            }
+            return false;
         }
 
         string GetDirectoryName(string path)


### PR DESCRIPTION
In some cases a directory that needs to be deleted was already deleted
because an ancestor directory was deleted. Consequently, TFS would
complain about it not existing in the workspace.

For example:
root/dir1/deleteme.txt
root/dir1/dir2/deleteme.txt

Because of the deletion of 'root/dir1/deleteme.txt', 'root/dir1' becomes a
candidate for deletion. It is deleted because it no longer contains any
items.
However, because of the deletion of 'root/dir1/dir2/deleteme.txt',
'root/dir1/dir2' also is a canditate for deletion. It also needs to be
deleted, but this is already taken care of with the deletion of its parent
directory.
