### PR TITLE
Correct crash when clone the whole repository

### DIFF
--- a/GitTfs/Commands/Clone.cs
+++ b/GitTfs/Commands/Clone.cs
@@ -114,6 +114,7 @@ namespace Sep.Git.Tfs.Commands
                     if (withBranches)
                         throw new GitTfsException("error: cloning the whole repository or too high in the repository path doesn't permit to manage branches!\n" + cloneMsg);
                     stdout.WriteLine("warning: you are going to clone the whole repository or too high in the repository path !\n" + cloneMsg);
+                    return;
                 }
 
                 var tfsBranchesPath = tfsTrunkRepository.GetAllChildren();


### PR DESCRIPTION
Forget to exit after displaying the warning.
Should fix #330
