### PR TITLE
Fix the check-in generated commits to include only recent messages

### DIFF
--- a/GitTfs/Core/GitRepository.cs
+++ b/GitTfs/Core/GitRepository.cs
@@ -331,9 +331,19 @@ namespace Sep.Git.Tfs.Core
         public string GetCommitMessage(string head, string parentCommitish)
         {
             var message = new System.Text.StringBuilder();
+
+            var parentCommit = (Commit)_repository.Lookup(parentCommitish, GitObjectType.Commit);
+
             foreach (LibGit2Sharp.Commit comm in
                 _repository.Commits.QueryBy(new LibGit2Sharp.Filter { Since = head, Until = parentCommitish }))
             {
+                // Filter out irrelevant commit messages. 
+                // This is needed if the parentCommit is not on the same branch as the head.
+                if (comm.Committer.When < parentCommit.Committer.When)
+                {
+                    break;
+                }
+
                 // Normalize commit message line endings to CR+LF style, so that message
                 // would be correctly shown in TFS commit dialog.
                 message.AppendLine(NormalizeLineEndings(comm.Message));


### PR DESCRIPTION
Right now, if the common ancestor is on a different branch, than the one you check-in, the generated check-in message includes irrelevant messages.

This happens since this is the code that generates commit messages:

```
            foreach (LibGit2Sharp.Commit comm in
                _repository.Commits.QueryBy(new LibGit2Sharp.Filter { Since = head, Until = parentCommitish }))
```

When the until code is on a different branch, there is, in effect, no stopping condition.

I fixed the issue by limiting the commit with the message to always have a newer date than the ancestor commit.
