### PR TITLE
Bugfix to allow check-in with merge from bare repository (#285)

### DIFF
--- a/GitTfs/Core/GitRepository.cs
+++ b/GitTfs/Core/GitRepository.cs
@@ -423,6 +423,10 @@ namespace Sep.Git.Tfs.Core
 
         public string HashAndInsertObject(string filename)
         {
+            if (_repository.Info.IsBare)
+            {
+                filename = Path.GetFullPath(filename);
+            }
             return _repository.ObjectDatabase.CreateBlob(filename).Id.Sha;
         }
 


### PR DESCRIPTION
This change gets the full path name for a file, when calling GitRepository.HashAndInsertObject on a bare repository. This fixes #285.
