### PR TITLE
Fix newline for branch checkout warning

### DIFF
--- a/GitTfs/Commands/Clone.cs
+++ b/GitTfs/Commands/Clone.cs
@@ -114,7 +114,7 @@ namespace Sep.Git.Tfs.Commands
                         return;
                     }
                     var cloneMsg = "   => If you want to manage branches with git-tfs, clone one of this branch instead :\n"
-                                    + " - " + tfsRootBranches.Aggregate((s1, s2) => s1 + @"\n - " + s2);
+                                    + " - " + tfsRootBranches.Aggregate((s1, s2) => s1 + "\n - " + s2);
                     
                     if (withBranches)
                         throw new GitTfsException("error: cloning the whole repository or too high in the repository path doesn't permit to manage branches!\n" + cloneMsg);


### PR DESCRIPTION
When git-tfs detects you are cloning a whole TFS repo rather than a branch, it gives a list of branches as suggestions. Each listed branch should be on its own line, but because a verbatim string is specified, the newline is not interpreted properly.
