### PR TITLE
Apply fix for Vs2008

### DIFF
--- a/GitTfs.Vs2008/TfsHelper.Vs2008.cs
+++ b/GitTfs.Vs2008/TfsHelper.Vs2008.cs
@@ -45,6 +45,7 @@ namespace Sep.Git.Tfs.Vs2008
 
         protected override T GetService<T>()
         {
+            if (_server == null) EnsureAuthenticated();
             return (T) _server.GetService(typeof (T));
         }
 


### PR DESCRIPTION
416543 Fix: git-tfs tries to authenticate against all TFS instances in the branch no matter how old they were in use and if they needed at all.
