### PR TITLE
Use saved author file for rcheckin commits

### DIFF
--- a/GitTfs/Commands/Rcheckin.cs
+++ b/GitTfs/Commands/Rcheckin.cs
@@ -22,11 +22,11 @@ namespace Sep.Git.Tfs.Commands
         private bool Quick { get; set; }
         private bool AutoRebase { get; set; }
 
-        public Rcheckin(TextWriter stdout, CheckinOptions checkinOptions, TfsWriter writer)
+        public Rcheckin(TextWriter stdout, CheckinOptions checkinOptions, TfsWriter writer, Globals globals)
         {
             _stdout = stdout;
             _checkinOptions = checkinOptions;
-            _checkinOptionsFactory = new CommitSpecificCheckinOptionsFactory(_stdout);
+            _checkinOptionsFactory = new CommitSpecificCheckinOptionsFactory(_stdout, globals);
             _writer = writer;
         }
 

--- a/GitTfs/Util/CommitSpecificCheckinOptionsFactory.cs
+++ b/GitTfs/Util/CommitSpecificCheckinOptionsFactory.cs
@@ -18,11 +18,13 @@ namespace Sep.Git.Tfs.Util
     /// </remarks>
     public class CommitSpecificCheckinOptionsFactory
     {
-        TextWriter writer;
+        private readonly TextWriter writer;
+        private readonly Globals globals;
 
-        public CommitSpecificCheckinOptionsFactory(TextWriter writer)
+        public CommitSpecificCheckinOptionsFactory(TextWriter writer, Globals globals)
         {
             this.writer = writer;
+            this.globals = globals;
         }
 
         public CheckinOptions BuildCommitSpecificCheckinOptions(CheckinOptions sourceCheckinOptions, string commitMessage)
@@ -152,16 +154,10 @@ namespace Sep.Git.Tfs.Util
 
         private void ProcessAuthor(CheckinOptions checkinOptions, TextWriter writer, GitCommit commit)
         {
-            if (checkinOptions.AuthorsFilePath == null)
-            {
-                writer.WriteLine("Author file was not set.");
-                return;
-            }
-
             // get authors file FIXME
             AuthorsFile af = new AuthorsFile();
-            TextReader tr = new StreamReader(checkinOptions.AuthorsFilePath);
-            af.Parse(tr);
+            if (!af.Parse(checkinOptions.AuthorsFilePath, globals.GitDir))
+                return;
 
             Author a = af.FindAuthor(commit.AuthorAndEmail);
             if (a == null)

--- a/GitTfsTest/Util/CommitSpecificCheckinOptionsFactoryTests.cs
+++ b/GitTfsTest/Util/CommitSpecificCheckinOptionsFactoryTests.cs
@@ -13,7 +13,7 @@ namespace Sep.Git.Tfs.Test.Util
         public void Sets_commit_message_as_checkin_comments()
         {
             TextWriter writer = new StringWriter();
-            CommitSpecificCheckinOptionsFactory factory = new CommitSpecificCheckinOptionsFactory(writer);
+            CommitSpecificCheckinOptionsFactory factory = new CommitSpecificCheckinOptionsFactory(writer, new Globals());
 
             string originalCheckinComment = "command-line input";
             CheckinOptions singletonCheckinOptions = new CheckinOptions()
@@ -34,7 +34,7 @@ namespace Sep.Git.Tfs.Test.Util
         public void Adds_work_item_to_associate_and_removes_checkin_command_comment()
         {
             StringWriter textWriter = new StringWriter();
-            CommitSpecificCheckinOptionsFactory factory = new CommitSpecificCheckinOptionsFactory(textWriter);
+            CommitSpecificCheckinOptionsFactory factory = new CommitSpecificCheckinOptionsFactory(textWriter, new Globals());
 
             CheckinOptions singletonCheckinOptions = new CheckinOptions();
 
@@ -63,7 +63,7 @@ namespace Sep.Git.Tfs.Test.Util
         public void Adds_work_item_to_resolve_and_removes_checkin_command_comment()
         {
             StringWriter textWriter = new StringWriter();
-            CommitSpecificCheckinOptionsFactory factory = new CommitSpecificCheckinOptionsFactory(textWriter);
+            CommitSpecificCheckinOptionsFactory factory = new CommitSpecificCheckinOptionsFactory(textWriter, new Globals());
 
             CheckinOptions singletonCheckinOptions = new CheckinOptions();
 
@@ -91,7 +91,7 @@ namespace Sep.Git.Tfs.Test.Util
         public void Adds_multiple_work_items_and_removes_checkin_command_comment()
         {
             StringWriter textWriter = new StringWriter();
-            CommitSpecificCheckinOptionsFactory factory = new CommitSpecificCheckinOptionsFactory(textWriter);
+            CommitSpecificCheckinOptionsFactory factory = new CommitSpecificCheckinOptionsFactory(textWriter, new Globals());
 
             CheckinOptions singletonCheckinOptions = new CheckinOptions();
 
@@ -124,7 +124,7 @@ namespace Sep.Git.Tfs.Test.Util
         public void Adds_reviewers_and_removes_checkin_command_comment()
         {
             StringWriter textWriter = new StringWriter();
-            CommitSpecificCheckinOptionsFactory factory = new CommitSpecificCheckinOptionsFactory(textWriter);
+            CommitSpecificCheckinOptionsFactory factory = new CommitSpecificCheckinOptionsFactory(textWriter, new Globals());
 
             CheckinOptions checkinOptions = new CheckinOptions();
 


### PR DESCRIPTION
There is already a way to save and use an author file when cloning and fetching.
This PR should permit to use this saved author file even with rcheckin (normal and quick)

This is the following of #357 ! Thanks @l3m I have tested today and it works great ;) Even better with the quick version ;D
