### PR TITLE
Added --nofetch option to init-branch

### DIFF
--- a/GitTfsTest/Commands/InitBranchTest.cs
+++ b/GitTfsTest/Commands/InitBranchTest.cs
@@ -374,6 +374,16 @@ namespace Sep.Git.Tfs.Test.Commands
         }
 
         [Fact]
+        public void ShouldFailInitAllBranchesBecauseNoFetchWasSpecified()
+        {
+            mocks.ClassUnderTest.CloneAllBranches = true;
+            mocks.ClassUnderTest.NoFetch = true;
+
+            var ex = Assert.Throws(typeof(GitTfsException), () => mocks.ClassUnderTest.Run());
+            Assert.Equal("error: --nofetch cannot be used with --all", ex.Message);
+        }
+
+        [Fact]
         public void ShouldFailInitAllBranchesBecauseCloneWasNotMadeFromABranch()
         {
             const string GIT_BRANCH_TO_INIT1 = "MyBranch1";


### PR DESCRIPTION
Added a --nofetch option to the init-branch command.  This keeps git-tfs from fetching any changesets from TFS until you explicitly fetch them with git tfs fetch.  This allows you to check the config file to verify everything is correct before fetching the changesets.  

The --nofetch option cannot be used with the --all option, 
