### PR TITLE
Fixed memory leaks by proper disposing references

### DIFF
--- a/GitTfs.VsCommon/TfsHelper.Common.cs
+++ b/GitTfs.VsCommon/TfsHelper.Common.cs
@@ -114,12 +114,16 @@ namespace Sep.Git.Tfs.VsCommon
         public IEnumerable<ITfsChangeset> GetChangesets(string path, long startVersion, GitTfsRemote remote)
         {
             var changesets = VersionControl.QueryHistory(path, VersionSpec.Latest, 0, RecursionType.Full,
-                                                         null, new ChangesetVersionSpec((int) startVersion), VersionSpec.Latest, int.MaxValue, true,
-                                                         true, true);
+                null, new ChangesetVersionSpec((int)startVersion), VersionSpec.Latest, int.MaxValue, true, true, true)
+                .Cast<Changeset>().OrderBy(changeset => changeset.ChangesetId).ToArray();
 
-            return changesets.Cast<Changeset>()
-                .OrderBy(changeset => changeset.ChangesetId)
-                .Select(changeset => BuildTfsChangeset(changeset, remote));
+            // don't take the enumerator produced by a foreach statement or a yield statement, as there are references 
+            // to the old (iterated) elements and thus the referenced changesets won't be disposed until all elements were iterated.
+            for (int i = 0; i < changesets.Length; i++)
+            {
+                yield return BuildTfsChangeset(changesets[i], remote);
+                changesets[i] = null;
+            } 
         }
 
         public virtual bool CanGetBranchInformation { get { return false; } }


### PR DESCRIPTION
I have tried to import a TFS repository containing ~23.000 changesets which in total has a size of ~17 GB.  Unfortunately the import always stopped with an "out of memory" exception (even though I have 8 GB RAM). So I used the .NET Memory Profiler from Scitech for finding the problems.

With the included changes the import works fine and doesn't consume more than 270 MB of memory, so the import "streams" propertly the way it should. From this change both the clone and fetch operations are affected.

Kind Regards,
Oliver
