### PR TITLE
Correct fail load debug assembly

### DIFF
--- a/GitTfs.Vs11/GitTfs.Vs11.csproj
+++ b/GitTfs.Vs11/GitTfs.Vs11.csproj
@@ -23,7 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <PlatformTarget>x86</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>


### PR DESCRIPTION
Correct fail to load assembly GitTfs.Vs11.dll in debug and GitTfs.Vs2008.dll in debug and release.

I think no one use TFS2008 because that should not work...

Error thrown : "Could not load file or assembly 'GitTFs.Vs11.dll' or one of its dependencies. An attempt was made to load a program with an incorrect format."
