### PR TITLE
Read stdout to end of stream

### DIFF
--- a/GitTfs/Core/GitHelpers.cs
+++ b/GitTfs/Core/GitHelpers.cs
@@ -197,12 +197,13 @@ namespace Sep.Git.Tfs.Core
         {
             // if caller doesn't read entire stdout to the EOF - it is possible that 
             // child process will hang waiting until there will be free space in stdout
-            // buffer to write the rest of the output. To prevent such situation we'll
-            // close stdout to indicate we're no more interested in it, thus allowing
-            // child process to proceed.
+            // buffer to write the rest of the output.
             // See https://github.com/git-tfs/git-tfs/issues/121 for details.
             if (process.StartInfo.RedirectStandardOutput)
+            {
+                process.StandardOutput.BaseStream.CopyTo(Stream.Null);
                 process.StandardOutput.Close();
+            }
 
             if (!process.WaitForExit((int)TimeSpan.FromSeconds(10).TotalMilliseconds))
                 throw new GitCommandException("Command did not terminate.", process);


### PR DESCRIPTION
Git (version 1.8.3-preview20130601) exits with error code when stdout is
closed without reading to the end.

I ran into this problem when trying to rcheckin a couple of changes after I recently upgraded my git.

```
me@COMPUTER /c/git/Example (main)
$ git tfs rcheckin -d -i main
git-tfs version 0.16.1.0 (TFS client library 11.0.0.0 (MS)) (64-bit)
git command: Starting process: git log --no-color --pretty=medium HEAD
git command time: [00:00:00.1070642] log --no-color --pretty=medium HEAD
Fetching changes from TFS to minimize possibility of late conflict...
git command: Starting process: git log --no-color --pretty=medium refs/remotes/tfs/main
git command time: [00:00:00.0480288] log --no-color --pretty=medium refs/remotes/tfs/main
info: refs/remotes/tfs/main: Getting changesets from 17338 to current ...
git command: Starting process: git rev-list 66b8804c2cafb31a1f383ce08e37ee334016c92a ^HEAD
git command time: [00:00:00.0170102] rev-list 66b8804c2cafb31a1f383ce08e37ee334016c92a ^HEAD
git command: Starting process: git rev-list --parents --ancestry-path --first-parent --reverse 66b8804c2cafb31a1f383ce08e37ee334016c92a..HEAD
git command time: [00:00:00.0170102] rev-list --parents --ancestry-path --first-parent --reverse 66b8804c2cafb31a1f383ce08e37ee334016c92a..HEAD
System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> Sep.Git.Tfs.Core.GitCommandException: Comm
and exited with error code: 141
   at Sep.Git.Tfs.Core.GitHelpers.Close(Process process) in C:\git\git-tfs\GitTfs\Core\GitHelpers.cs:line 208
   at Sep.Git.Tfs.Core.GitHelpers.Time(String[] command, Action action) in C:\git\git-tfs\GitTfs\Core\GitHelpers.cs:line 187
   at Sep.Git.Tfs.Core.GitHelpers.CommandOneline(String[] command) in C:\git\git-tfs\GitTfs\Core\GitHelpers.cs:line 44
   at Sep.Git.Tfs.Commands.Rcheckin.PerformRCheckin(TfsChangesetInfo parentChangeset) in C:\git\git-tfs\GitTfs\Commands\Rcheckin.cs:line 145
   at Sep.Git.Tfs.Core.TfsWriter.Write(String refToWrite, Func`2 write) in C:\git\git-tfs\GitTfs\Core\TfsWriter.cs:line 29
   --- End of inner exception stack trace ---
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor)
   at System.Reflection.RuntimeMethodInfo.UnsafeInvokeInternal(Object obj, Object[] parameters, Object[] arguments)
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at Sep.Git.Tfs.Util.GitTfsCommandRunner.Run(GitTfsCommand command, IList`1 args) in C:\git\git-tfs\GitTfs\Util\GitTfsCommandRunner.cs:line 36
   at Sep.Git.Tfs.Program.Main(String[] args) in C:\git\git-tfs\GitTfs\Program.cs:line 22
Command exited with error code: 141

me@COMPUTER /c/git/Example (main)
$ git rev-list --parents --ancestry-path --first-parent --reverse 66b8804c2cafb31a1f383ce08e37ee334016c92a..HEAD
9d93d18f875919d26036d2082493fd42a73e1e7a 66b8804c2cafb31a1f383ce08e37ee334016c92a
d20593f7d64ac2df749d4a5d082bcc72441ff208 9d93d18f875919d26036d2082493fd42a73e1e7a
9f9624ad288382bc98278ab95c95c2f61270222c d20593f7d64ac2df749d4a5d082bcc72441ff208
5ceba697a51738b48baab34e7400bab629d0426b 9f9624ad288382bc98278ab95c95c2f61270222c
ade8660362f4597cccc31d410e3479eaed75e575 5ceba697a51738b48baab34e7400bab629d0426b
9672037e7732ce6238e25416209137afb09e874f ade8660362f4597cccc31d410e3479eaed75e575
a2f3ffd94e755869a288ad6ba266e993fbc3e246 9672037e7732ce6238e25416209137afb09e874f
dc3524134e884a2edd9f83827b5700961755c881 a2f3ffd94e755869a288ad6ba266e993fbc3e246
c6738eea85c236815e4e806733db4c2e648428f8 dc3524134e884a2edd9f83827b5700961755c881

me@COMPUTER /c/git/Example (main)
$ echo $?
0
```
