### PR TITLE
Disable git's pager.

### DIFF
--- a/GitTfs/Core/GitHelpers.cs
+++ b/GitTfs/Core/GitHelpers.cs
@@ -241,6 +241,7 @@ namespace Sep.Git.Tfs.Core
             startInfo.SetArguments(command);
             startInfo.CreateNoWindow = true;
             startInfo.UseShellExecute = false;
+            startInfo.EnvironmentVariables.Add("GIT_PAGER", "cat");
             RedirectStderr(startInfo);
             initialize(startInfo);
             Trace.WriteLine("Starting process: " + startInfo.FileName + " " + startInfo.Arguments, "git command");


### PR DESCRIPTION
Inspired by #415.

While I haven't reproduced the problem, I can imagine that git's pager could cause spurious error codes. `CommandOneLine` seems especially likely to trigger the error, as it may close the pager's stdout before it has a chance to do anything.

This (should) disable git's pager for everything that we still use `Process.Start` for. (Long-term, of course, the plan is to :fire: `GitHelpers` :fire:.)

cc @drewnoakes
