### PR TITLE
Fix for issue #424

### DIFF
--- a/GitTfs/Commands/InitBranch.cs
+++ b/GitTfs/Commands/InitBranch.cs
@@ -196,7 +196,7 @@ namespace Sep.Git.Tfs.Commands
             Trace.WriteLine("Commit found! sha1 : " + sha1RootCommit);
 
             Trace.WriteLine("Try creating remote...");
-            var tfsRemote = _globals.Repository.CreateTfsRemote(new RemoteInfo { Id = gitBranchName, Url = defaultRemote.TfsUrl, Repository = tfsRepositoryPath, RemoteOptions = _remoteOptions });
+            var tfsRemote = _globals.Repository.CreateTfsRemote(new RemoteInfo { Id = gitBranchName, Url = defaultRemote.TfsUrl, Repository = tfsRepositoryPath, RemoteOptions = _remoteOptions }, System.String.Empty);
             if (!_globals.Repository.CreateBranch(tfsRemote.RemoteRef, sha1RootCommit))
                 throw new GitTfsException("error: Fail to create remote branch ref file!");
             Trace.WriteLine("Remote created!");

--- a/GitTfs/Core/GitRepository.cs
+++ b/GitTfs/Core/GitRepository.cs
@@ -124,8 +124,12 @@ namespace Sep.Git.Tfs.Core
             if (HasRemote(remote.Id))
                 throw new GitTfsException("A remote with id \"" + remote.Id + "\" already exists.");
 
-            // These help the new (if it's new) git repository to behave more sanely.
-            _repository.Config.Set("core.autocrlf", (autocrlf == null)?"false":autocrlf);
+            // The autocrlf default (as indicated by a null) is false and is set to override the system-wide setting.
+            // When creating branches we use the empty string to indicate that we do not want to set the value at all.
+            if (autocrlf == null)
+                autocrlf = "false";
+            if (autocrlf != String.Empty)
+                _repository.Config.Set("core.autocrlf", autocrlf);
 
             if (ignorecase != null)
                 _repository.Config.Set("core.ignorecase", ignorecase);


### PR DESCRIPTION
This is a patch on top of pull request #378 that avoids resetting the core.autocrlf setting when creating branches.
