### PR TITLE
Improved error message for branch --init when branch doesn't exist

### DIFF
--- a/GitTfs.VsCommon/TfsHelper.PostVs2010.Common.cs
+++ b/GitTfs.VsCommon/TfsHelper.PostVs2010.Common.cs
@@ -49,8 +49,7 @@ namespace Sep.Git.Tfs.VsCommon
                 var tfsBranchToCreate = allTfsBranches.FirstOrDefault(b => b.Properties.RootItem.Item.ToLower() == tfsPathBranchToCreate.ToLower());
                 if (tfsBranchToCreate == null)
                 {
-                    Trace.WriteLine("error: TFS branches "+ tfsPathBranchToCreate +" not found!");
-                    return -1;
+                    throw new GitTfsException("error: TFS branches "+ tfsPathBranchToCreate +" not found!");
                 }
 
                 if (tfsBranchToCreate.Properties.ParentBranch == null)

--- a/GitTfs/Commands/InitBranch.cs
+++ b/GitTfs/Commands/InitBranch.cs
@@ -186,8 +186,6 @@ namespace Sep.Git.Tfs.Commands
 
                 rootChangeSetId = defaultRemote.Tfs.GetRootChangesetForBranch(tfsRepositoryPath, tfsRepositoryPathParentBranchFound.TfsRepositoryPath);
             }
-            if (rootChangeSetId == -1)
-                throw new GitTfsException("error: No root changeset found :( \n");
             Trace.WriteLine("Found root changeset : " + rootChangeSetId);
 
             Trace.WriteLine("Try to find changeset in git repository...");

--- a/GitTfsTest/Commands/InitBranchTest.cs
+++ b/GitTfsTest/Commands/InitBranchTest.cs
@@ -144,7 +144,7 @@ namespace Sep.Git.Tfs.Test.Commands
             InitMocks4Tests(GIT_BRANCH_TO_INIT, out gitRepository, out remote, out newBranchRemote);
 
             remote.Tfs = mocks.Get<ITfsHelper>();
-            remote.Tfs.Stub(t => t.GetRootChangesetForBranch("$/MyProject/MyBranch")).Return(-1);
+            remote.Tfs.Stub(t => t.GetRootChangesetForBranch("$/MyProject/MyBranch")).Throw(new GitTfsException(""));
 
             gitRepository.Expect(x => x.ReadTfsRemote("default")).Return(remote).Repeat.Once();
             gitRepository.Expect(x => x.ReadAllTfsRemotes()).Return(new List<IGitTfsRemote> { remote }).Repeat.Once();


### PR DESCRIPTION
Fix of #425.
- Removed magic value -1 returned from GetRootChangesetForBranch. Now throws instead.
- Updated calling code and a test case accordingly.

Old output:
The name of the local branch will be : asdf
error: No root changeset found :(

New output:
The name of the local branch will be : asdf
error: TFS branches $/MyProject/asdf not found!
