### PR TITLE
Add author option to checkin commands.

### DIFF
--- a/GitTfs/Commands/CheckinOptions.cs
+++ b/GitTfs/Commands/CheckinOptions.cs
@@ -35,6 +35,7 @@ namespace Sep.Git.Tfs.Commands
                     { "no-gate", "Disables gated checkin.",
                         v => { OverrideGatedCheckIn = true; } },
                     { "A|authors=", "Path to an Authors file to map TFS users to Git users", v => AuthorsFilePath = v },
+                    { "author=", "TFS User ID to check in on behalf of", var => AuthorTfsUserId = var },
                 };
             }
         }


### PR DESCRIPTION
Exposes an additional option (--author) to checkin commands to specify the original author for the commit (TFS' check in other user's changes).  This can be used with checkin and checkintool to specify the single user rather than having to specify an author's file.

Tested with VS10 libraries.
