### PR TITLE
Generic fix (for VS2010/VS2008 and VS2011) of 'ConnectionException: TF26...

### DIFF
--- a/GitTfs.Vs11/TfsHelper.Vs11.cs
+++ b/GitTfs.Vs11/TfsHelper.Vs11.cs
@@ -78,6 +78,11 @@ namespace Sep.Git.Tfs.Vs11
             return VersionControl.AuthorizedUser;
         }
 
+        protected override bool HasWorkItems(Changeset changeset)
+        {
+            return changeset.AssociatedWorkItems.Length > 0;
+        }
+
         public override bool CanShowCheckinDialog { get { return true; } }
 
         public override long ShowCheckinDialog(IWorkspace workspace, IPendingChange[] pendingChanges, IEnumerable<IWorkItemCheckedInfo> checkedInfos, string checkinComment)

--- a/GitTfs.Vs2008/TfsHelper.Vs2008.cs
+++ b/GitTfs.Vs2008/TfsHelper.Vs2008.cs
@@ -54,6 +54,25 @@ namespace Sep.Git.Tfs.Vs2008
             return VersionControl.AuthenticatedUser;
         }
 
+        protected override bool HasWorkItems(Changeset changeset)
+        {
+            // This method wraps changeset.WorkItems, because
+            // changeset.WorkItems might result to ConnectionException: TF26175: Team Foundation Core Services attribute 'AttachmentServerUrl' not found.
+            // in this case assume that it is initialized to null
+            // NB: in VS2011 a new property appeared (AssociatedWorkItems), which works correctly
+            WorkItem[] result = null;
+            try
+            {
+                result = changeset.WorkItems;
+            }
+            catch (ConnectionException exception)
+            {
+                Debug.Assert(exception.Message.StartsWith("TF26175:"), "Not expected exception from TFS.");
+            }
+
+            return result != null && result.Length > 0;
+        }
+
         public override bool CanShowCheckinDialog
         {
             get { return false; }

--- a/GitTfs.Vs2010/TfsHelper.Vs2010.cs
+++ b/GitTfs.Vs2010/TfsHelper.Vs2010.cs
@@ -77,6 +77,25 @@ namespace Sep.Git.Tfs.Vs2010
             return VersionControl.AuthorizedUser;
         }
 
+        protected override bool HasWorkItems(Changeset changeset)
+        {
+            // This method wraps changeset.WorkItems, because
+            // changeset.WorkItems might result to ConnectionException: TF26175: Team Foundation Core Services attribute 'AttachmentServerUrl' not found.
+            // in this case assume that it is initialized to null
+            // NB: in VS2011 a new property appeared (AssociatedWorkItems), which works correctly
+            WorkItem[] result = null;
+            try
+            {
+                result = changeset.WorkItems;
+            }
+            catch (ConnectionException exception)
+            {
+                Debug.Assert(exception.Message.StartsWith("TF26175:"), "Not expected exception from TFS.");
+            }
+
+            return result != null && result.Length > 0;
+        }
+
         public override bool CanShowCheckinDialog { get { return true; } }
 
         public override long ShowCheckinDialog(IWorkspace workspace, IPendingChange[] pendingChanges, IEnumerable<IWorkItemCheckedInfo> checkedInfos, string checkinComment)

--- a/GitTfs.VsCommon/TfsHelper.Common.cs
+++ b/GitTfs.VsCommon/TfsHelper.Common.cs
@@ -192,7 +192,7 @@ namespace Sep.Git.Tfs.VsCommon
             var tfsChangeset = _container.With<ITfsHelper>(this).With<IChangeset>(_bridge.Wrap<WrapperForChangeset, Changeset>(changeset)).GetInstance<TfsChangeset>();
             tfsChangeset.Summary = new TfsChangesetInfo { ChangesetId = changeset.ChangesetId, Remote = remote };
 
-            if (changeset.WorkItems != null)
+            if (HasWorkItems(changeset))
             {
                 tfsChangeset.Summary.Workitems = changeset.WorkItems.Select(wi => new TfsWorkitem
                     {
@@ -205,6 +205,8 @@ namespace Sep.Git.Tfs.VsCommon
 
             return tfsChangeset;
         }
+
+        protected abstract bool HasWorkItems(Changeset changeset);
 
         Dictionary<string, Workspace> _workspaces = new Dictionary<string, Workspace>();
 


### PR DESCRIPTION
...175: Team Foundation Core Services attribute 'AttachmentServerUrl' not found.' on getting workitems

I have faced following problem:

```
$ git tfs pull
TF26175: Team Foundation Core Services attribute 'AttachmentServerUrl' not found.


$ git tfs pull --debug
git-tfs version 0.16.1.0 (TFS client library 10.0.0.0 (MS)) (64-bit)
No authors file used.
git command: Starting process: git config --list --local
git command time: [00:00:00.0450000] config --list --local
Fetching from TFS remote default
git command: Starting process: git log --no-color --pretty=medium refs/remotes/tfs/default
git stderr: fatal: ambiguous argument 'refs/remotes/tfs/default': unknown revision or path not in the working tree.
git stderr: Use '--' to separate paths from revisions, like this:
git stderr: 'git <command> [<revision>...] -- [<file>...]'
git command time: [00:00:00.0550000] log --no-color --pretty=medium refs/remotes/tfs/default
An error occurred while loading head refs/remotes/tfs/default (maybe it doesn't exist?): Sep.Git.Tfs.Core.GitCommandExce
ption: Command exited with error code: 128
   at Sep.Git.Tfs.Core.GitHelpers.Close(Process process)
   at Sep.Git.Tfs.Core.GitHelpers.<>c__DisplayClass8.<CommandOutputPipe>b__7()
   at Sep.Git.Tfs.Core.GitHelpers.Time(String[] command, Action action)
   at Sep.Git.Tfs.Core.GitHelpers.CommandOutputPipe(Action`1 handleOutput, String[] command)
   at Sep.Git.Tfs.Core.GitRepository.GetParentTfsCommits(String head, Boolean includeStubRemotes)
git command: Starting process: git log --no-color --pretty=medium refs/remotes/tfs/default..HEAD
git stderr: fatal: ambiguous argument 'refs/remotes/tfs/default..HEAD': unknown revision or path not in the working tree
.
git stderr: Use '--' to separate paths from revisions, like this:
git stderr: 'git <command> [<revision>...] -- [<file>...]'
git command time: [00:00:00.0370000] log --no-color --pretty=medium refs/remotes/tfs/default..HEAD
An error occurred while loading head refs/remotes/tfs/default..HEAD (maybe it doesn't exist?): Sep.Git.Tfs.Core.GitComma
ndException: Command exited with error code: 128
   at Sep.Git.Tfs.Core.GitHelpers.Close(Process process)
   at Sep.Git.Tfs.Core.GitHelpers.<>c__DisplayClass8.<CommandOutputPipe>b__7()
   at Sep.Git.Tfs.Core.GitHelpers.Time(String[] command, Action action)
   at Sep.Git.Tfs.Core.GitHelpers.CommandOutputPipe(Action`1 handleOutput, String[] command)
   at Sep.Git.Tfs.Core.GitRepository.GetParentTfsCommits(String head, Boolean includeStubRemotes)
info: refs/remotes/tfs/default: Getting changesets from 1 to current ...
System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> Microsoft.Te
amFoundation.WorkItemTracking.Client.ConnectionException: TF26175: Team Foundation Core Services attribute 'AttachmentSe
rverUrl' not found.
   at Microsoft.TeamFoundation.WorkItemTracking.Client.WorkItemStore.ReadRegistrationData()
   at Microsoft.TeamFoundation.WorkItemTracking.Client.WorkItemStore.InitializeInternal()
   at Microsoft.TeamFoundation.Client.TfsTeamProjectCollection.InitializeTeamFoundationObject(String fullName, Object in
stance)
   at Microsoft.TeamFoundation.Client.TfsConnection.CreateServiceInstance(Assembly assembly, String fullName)
   at Microsoft.TeamFoundation.Client.TfsConnection.GetService(Type serviceType)
   at Microsoft.TeamFoundation.VersionControl.Client.Changeset.get_WorkItemStore()
   at Microsoft.TeamFoundation.VersionControl.Client.Changeset.get_WorkItems()
   at Sep.Git.Tfs.VsCommon.TfsHelperBase.BuildTfsChangeset(Changeset changeset, GitTfsRemote remote)
   at Sep.Git.Tfs.VsCommon.TfsHelperBase.GetLatestChangeset(GitTfsRemote remote)
   at Sep.Git.Tfs.Core.GitTfsRemote.FetchChangesets()
   at Sep.Git.Tfs.Core.GitTfsRemote.FetchWithMerge(Int64 mergeChangesetId, String[] parentCommitsHashes)
   at Sep.Git.Tfs.Core.GitTfsRemote.Fetch()
   at Sep.Git.Tfs.Commands.Fetch.DoFetch(IGitTfsRemote remote)
   at Sep.Git.Tfs.Commands.Fetch.Run(String[] args)
   at Sep.Git.Tfs.Commands.Pull.Run(String remoteId)
   at Sep.Git.Tfs.Commands.Pull.Run()
   --- End of inner exception stack trace ---
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor)
   at System.Reflection.RuntimeMethodInfo.UnsafeInvokeInternal(Object obj, Object[] parameters, Object[] arguments)
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters
, CultureInfo culture)
   at System.Reflection.MethodBase.Invoke(Object obj, Object[] parameters)
   at Sep.Git.Tfs.Util.GitTfsCommandRunner.Run(GitTfsCommand command, IList`1 args)
   at Sep.Git.Tfs.GitTfs.Main(GitTfsCommand command, IList`1 unparsedArgs)
   at Sep.Git.Tfs.GitTfs.Run(IList`1 args)
   at Sep.Git.Tfs.Program.MainCore(String[] args)
   at Sep.Git.Tfs.Program.Main(String[] args)
TF26175: Team Foundation Core Services attribute 'AttachmentServerUrl' not found.
```
