### PR TITLE
Create a tfs branch from an existing git branch

### DIFF
--- a/GitTfs/Core/GitRepository.cs
+++ b/GitTfs/Core/GitRepository.cs
@@ -549,5 +549,10 @@ namespace Sep.Git.Tfs.Core
         {
             _repository.Refs.UpdateTarget(remoteToReset.RemoteRef, target);
         }
+
+        public string GetCurrentBranch()
+        {
+            return _repository.Head.CanonicalName;
+        }
     }
 }

--- a/GitTfs/Core/IGitRepository.cs
+++ b/GitTfs/Core/IGitRepository.cs
@@ -48,7 +48,7 @@ namespace Sep.Git.Tfs.Core
         /// If the given remote is itself a subtree, an empty enumerable is returned.
         /// </summary>
         IEnumerable<IGitTfsRemote> GetSubtrees(IGitTfsRemote owner);
-
         void ResetRemote(IGitTfsRemote remoteToReset, string target);
+        string GetCurrentBranch();
     }
 }


### PR DESCRIPTION
This PR permit to checkin an entire local branch in a TFS branch (that will be created).

With this feature, there is no need to create a TFS branch first and then work in this TFS branch.
You could just create a git branch and create a posteriori a TFS branch.
Creating a TFS from a work done in a git branch is much more easier!
