### PR TITLE
Avoid including spaces in tfs remote names as these are illegal in git.

### DIFF
--- a/GitTfs/Commands/Bootstrap.cs
+++ b/GitTfs/Commands/Bootstrap.cs
@@ -87,7 +87,7 @@ namespace Sep.Git.Tfs.Commands
             var indexOfSlash = expectedRemoteId.IndexOf('/');
             if (indexOfSlash != 0)
                 expectedRemoteId = expectedRemoteId.Substring(indexOfSlash + 1);
-            var remoteId = expectedRemoteId;
+            var remoteId = expectedRemoteId.Replace(' ', '-');
             var suffix = 0;
             while (!IsAvailable(remoteId))
                 remoteId = expectedRemoteId + "-" + (suffix++);


### PR DESCRIPTION
Resolves a problem with bootstrapping branches that have spaces in the
TFS branch name as mentioned in issue #454

Signed-off-by: Pat Thoyts patthoyts@users.sourceforge.net
