### PR TITLE
Display git-tfs command in the console when debug log is enable

### DIFF
--- a/GitTfs/GitTfs.cs
+++ b/GitTfs/GitTfs.cs
@@ -39,6 +39,7 @@ namespace Sep.Git.Tfs
             var command = ExtractCommand(args);
             if(RequiresValidGitRepository(command)) AssertValidGitRepository();
             var unparsedArgs = ParseOptions(command, args);
+            Trace.WriteLine("Command run:git tfs " + string.Join(" ", args)); 
             return Main(command, unparsedArgs);
         }
 


### PR DESCRIPTION
(to help support when someone report an error)
