### PR TITLE
Update rcheckin.md to make clear its distinction from checkin

### DIFF
--- a/doc/commands/rcheckin.md
+++ b/doc/commands/rcheckin.md
@@ -2,6 +2,9 @@
 
 Checkins path of commits from last found TFS-commit to HEAD with comments provided for corresponding git commits. Preserves merge commits.
 
+rcheckin differs from [checkin](checkin.md) in that the latter squashes the commits into a single TFS checkin, while rcheckin uses a series of commits.
+
+
 ## Features
 [Special actions in commit messages](../special-actions-in-commit-messages.md) can be inserted, to associate or resolve TFS work items or override checkin policies.
 


### PR DESCRIPTION
As a new user reading the rcheckin description it was difficult for me to understand how it was different from a regular checkin until I went to that page and saw the note. So I suggest having a similar note on the rcheckin page too.
