### PR TITLE
Optimize fetching of a branch changeset

### DIFF
--- a/GitTfs/Core/Ext.cs
+++ b/GitTfs/Core/Ext.cs
@@ -14,6 +14,11 @@ namespace Sep.Git.Tfs.Core
 {
     public static partial class Ext
     {
+        public static IEnumerable<T> Without<T>(this IEnumerable<T> source, Predicate<T> predicate)
+        {
+            return source.Where(o => !predicate(o));
+        }
+
         public static T Tap<T>(this T o, Action<T> block)
         {
             block(o);


### PR DESCRIPTION
If a change is only a branch operation and we already have a file at the
target path, then there is nothing to do for that change.

close #303