### PR TITLE
Fix a couple of markdown links in documentation

### DIFF
--- a/doc/commands/list-remote-branches.md
+++ b/doc/commands/list-remote-branches.md
@@ -48,8 +48,8 @@ To display all the remotes of a TFS server, do this:
 		
 	Cloning root branches (marked by [*]) is recommended!
 
-Then you can use the `[clone](clone.md)` command with the good remote branch of your choice!
-However, it is recommended to clone the root branch and then use the `[branch](branch.md)` command to manage branches.
+Then you can use the [`clone`](clone.md) command with the good remote branch of your choice!
+However, it is recommended to clone the root branch and then use the [`branch`](branch.md) command to manage branches.
 
 ### Authentication
 


### PR DESCRIPTION
Backticks surrounding the entire text of a link will cause it to be rendered `[like this](http://)` instead of [`like this`](http://).
