### PR TITLE
Limit version scope for querying merge information

### DIFF
--- a/GitTfs.VsCommon/TfsHelper.Common.cs
+++ b/GitTfs.VsCommon/TfsHelper.Common.cs
@@ -130,9 +130,10 @@ namespace Sep.Git.Tfs.VsCommon
             } 
         }
 
-        public virtual int FindMergeChangesetParent(string path, long firstChangeset, GitTfsRemote remote)
+        public virtual int FindMergeChangesetParent(string path, long targetChangeset, GitTfsRemote remote)
         {
-            var mergeInfo = VersionControl.QueryMerges(null, null, path, LatestVersionSpec.Latest, null, new ChangesetVersionSpec((int)firstChangeset), RecursionType.Full);
+            var targetVersion = new ChangesetVersionSpec((int)targetChangeset);
+            var mergeInfo = VersionControl.QueryMerges(null, null, path, targetVersion, targetVersion, targetVersion, RecursionType.Full);
             return mergeInfo.Max(x => x.SourceVersion);
         }
 

--- a/GitTfs.VsCommon/TfsHelper.PostVs2010.Common.cs
+++ b/GitTfs.VsCommon/TfsHelper.PostVs2010.Common.cs
@@ -32,12 +32,6 @@ namespace Sep.Git.Tfs.VsCommon
             }
         }
 
-        public override int FindMergeChangesetParent(string path, long firstChangeset, GitTfsRemote remote)
-        {
-            return VersionControl.QueryMerges(null, null, new ItemSpec(path, RecursionType.Full), LatestVersionSpec.Latest,
-              null, new ChangesetVersionSpec((int)firstChangeset)).Max(x => x.SourceVersion);
-        }
-
         public override IEnumerable<string> GetAllTfsRootBranchesOrderedByCreation()
         {
             return VersionControl.QueryRootBranchObjects(RecursionType.Full)


### PR DESCRIPTION
When querying the merge information to determine the source changeset of a
merge, limit the version scope of the query to the bare minimum to improve
performance.

Since the QueryMerges overload taking strings for source and target calls
the overload with ItemSpecs, there is also no need to have a seperate post
VS2010 implementation. At least this is the case for v12.020827.3 of
Microsoft.TeamFoundation.VersionControl.Client.dll.
