### PR TITLE
Prevent InitHistory() to fail if a TFSRemote is lacking 

### DIFF
--- a/GitTfs/Core/GitTfsRemote.cs
+++ b/GitTfs/Core/GitTfsRemote.cs
@@ -156,7 +156,7 @@ namespace Sep.Git.Tfs.Core
         {
             if (maxChangesetId == null)
             {
-                var mostRecentUpdate = Repository.GetLastParentTfsCommits(RemoteRef).FirstOrDefault();
+                var mostRecentUpdate = Repository.GetLastParentTfsCommits(RemoteRef, true).FirstOrDefault();
                 if (mostRecentUpdate != null)
                 {
                     MaxCommitHash = mostRecentUpdate.GitCommit;


### PR DESCRIPTION
(because we don't need them)

InitHistory() is used only to get MaxChangesetId and MaxCommitHash, so no need to fail if a branch have not been bootstrapped
TfsRemote are of no use so we don't absolutely need it!
should fix #543 where we can't fetch if we have deleted a TFS remote
