### PR TITLE
Prevent a crash during path verification

### DIFF
--- a/GitTfs/Commands/Clone.cs
+++ b/GitTfs/Commands/Clone.cs
@@ -103,7 +103,9 @@ namespace Sep.Git.Tfs.Commands
 
         private void VerifyTfsPathToClone(string tfsRepositoryPath)
         {
-            if (initBranch != null)
+            if (initBranch == null)
+                return;
+            try
             {
                 var remote = globals.Repository.ReadTfsRemote(GitTfsConstants.DefaultRepositoryId);
 
@@ -144,6 +146,15 @@ namespace Sep.Git.Tfs.Commands
                         stdout.WriteLine("warning: you are going to clone a subdirectory of a branch and won't be able to manage branches :(\n"
                             + "   => If you want to manage branches with git-tfs, clone " + tfsTrunkRepositoryPath + " with '--with-branches' option instead...)");
                 }
+            }
+            catch (GitTfsException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                stdout.WriteLine("warning: a server error occurs when trying to verify the tfs path cloned:\n   " + ex.Message
+                    + "\n   try to continue anyway...");
             }
         }
 

--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -5,4 +5,4 @@
 * Use LibGit2Sharp to create commits (#534, #546)
 * Correct Tfs remote returned when using option `rcheckin -I` in the case of a merge commit
  and fix #543 where unable to fetch after deleting a tfs branch (#548)
-* Other documentation and bug fixes (#487, #521, #523, #527)
+* Other documentation and bug fixes (#487, #521, #523, #527, #557)


### PR DESCRIPTION
Swallow TFS exceptions for this non critical part of the clone process...

Permit to clone a branch and use git-tfs even when, due to a bug in TFS,
TFS is broken and return an error TF14045 when asking for branches.
