### PR TITLE
Let auto selection of remote (`-I`) works in empty repository

### DIFF
--- a/GitTfs/GitTfs.cs
+++ b/GitTfs/GitTfs.cs
@@ -59,7 +59,18 @@ namespace Sep.Git.Tfs
                 var remotes = _globals.Repository.GetLastParentTfsCommits("HEAD");
                 if (!remotes.Any())
                 {
-                    throw new Exception("No TFS parents found!");
+                    var allRemotes = _globals.Repository.ReadAllTfsRemotes();
+                    if (!allRemotes.Any())
+                        throw new Exception("error: no tfs remotes defined in this repository!");
+
+                    if (allRemotes.Count() == 1)
+                    {
+                        _globals.UserSpecifiedRemoteId = allRemotes.First().Id;
+                        _stdout.WriteLine("Working with tfs remote: " + _globals.RemoteId);
+                        return;
+                    }
+                    throw new Exception("error: can't find a tfs remote to use\n   No TFS parents found and more than one tfs remote defined in the repository!"
+                        + "\n   Use '-i' option to define which one to use.");
                 }
                 var foundRemote = remotes.First().Remote;
                 if(foundRemote.IsDerived)


### PR DESCRIPTION
Using -I option now works when `init` a repository (instead of `clone`)
and when there is no commit (or just plain git commits).
- take the only one when only 1 tfs remote found (that should be `default`...)
- throw an error when there is no tfs remotes found (not a git-tfs repository!)
- threw an error if there is more than one branch (that should never happen
  except if the user add manually remotes in the .git/config file)
