### PR TITLE
Prevent a first GC when not needed

### DIFF
--- a/GitTfs/Commands/Clone.cs
+++ b/GitTfs/Commands/Clone.cs
@@ -34,6 +34,7 @@ namespace Sep.Git.Tfs.Commands
             if (initBranch != null)
                 initBranch.DontDisplayObsoleteMessage = true;
             this.stdout = stdout;
+            globals.GcCountdown = globals.GcPeriod;
         }
 
         public OptionSet OptionSet


### PR DESCRIPTION
After first action, GC is always launch (even if not needed)
because the counter has never been set.
