### PR TITLE
Detect rename changeset

### DIFF
--- a/GitTfs/Util/ChangeSieve.cs
+++ b/GitTfs/Util/ChangeSieve.cs
@@ -60,13 +60,16 @@ namespace Sep.Git.Tfs.Util
                         c.Change.Item.ItemType == TfsItemType.Folder
                             && c.GitPath == string.Empty
                             && c.Change.ChangeType.IncludesOneOf(TfsChangeType.Delete, TfsChangeType.Rename));
-                }
+        }
                 return _renameBranchCommmit.Value;
             }
         }
 
         public IEnumerable<IChange> GetChangesToFetch()
         {
+            if (DeletesProject)
+                return Enumerable.Empty<IChange>();
+
             if (RenameBranchCommmit)
                 return new List<IChange>();
 
@@ -75,6 +78,9 @@ namespace Sep.Git.Tfs.Util
 
         public IEnumerable<ApplicableChange> GetChangesToApply()
         {
+            if (DeletesProject)
+                return Enumerable.Empty<ApplicableChange>();
+
             if (RenameBranchCommmit)
                 return new List<ApplicableChange>();
 
@@ -84,11 +90,6 @@ namespace Sep.Git.Tfs.Util
             };
             foreach (var change in NamedChanges)
             {
-                if (change.Change.Item.ItemType == TfsItemType.Folder
-                   && change.GitPath == string.Empty
-                   && change.Change.ChangeType.IncludesOneOf(TfsChangeType.Delete))
-                    return new List<ApplicableChange>();
-
                 // We only need the file changes because git only cares about files and if you make
                 // changes to a folder in TFS, the changeset includes changes for all the descendant files anyway.
                 if (change.Change.Item.ItemType != TfsItemType.File)
@@ -117,6 +118,23 @@ namespace Sep.Git.Tfs.Util
                 }
             }
             return compartments.Deleted.Concat(compartments.Updated);
+        }
+
+        bool? _deletesProject;
+        private bool DeletesProject
+        {
+            get
+            {
+                if (!_deletesProject.HasValue)
+                {
+                    _deletesProject =
+                        NamedChanges.Any(change =>
+                            change.Change.Item.ItemType == TfsItemType.Folder
+                               && change.GitPath == string.Empty
+                               && change.Change.ChangeType.IncludesOneOf(TfsChangeType.Delete));
+                }
+                return _deletesProject.Value;
+            }
         }
 
         class NamedChange

--- a/GitTfsTest/Core/ChangeSieveTests.cs
+++ b/GitTfsTest/Core/ChangeSieveTests.cs
@@ -551,6 +551,13 @@ namespace Sep.Git.Tfs.Test.Core
             {
                 Assert.Equal(0, Subject.GetChangesToApply().Count());
             }
+
+            [Fact]
+            public void DoNotFetch()
+            {
+                // Because we're not going to apply changes, don't waste time fetching any.
+                Assert.Equal(0, Subject.GetChangesToFetch().Count());
+            }
         }
 
         public class WithDeleteOtherFolder : Base<WithDeleteOtherFolder.Fixture>
@@ -574,6 +581,12 @@ namespace Sep.Git.Tfs.Test.Core
             {
                 AssertChanges(Subject.GetChangesToApply(),
                     ApplicableChange.Update("file1.txt"));
+            }
+
+            [Fact]
+            public void FetchesChangesInThisProject()
+            {
+                Assert.Equal(new string[] { "$/Project/file1.txt" }, Subject.GetChangesToFetch().Select(c => c.Item.ServerItem));
             }
         }
     }


### PR DESCRIPTION
Part of #480 that could be merged without problem... it manage a case not managed for the moment by git-tfs...

It prevent creating a commit that delete all the source code which is how tfs handle a rename but make no sense in git...
