### PR TITLE
Fix unshelve

### DIFF
--- a/GitTfs.VsCommon/TfsHelper.Common.cs
+++ b/GitTfs.VsCommon/TfsHelper.Common.cs
@@ -506,9 +506,9 @@ namespace Sep.Git.Tfs.VsCommon
                 get { return _versionControlServer; }
             }
 
-            public void Get(IWorkspace workspace)
+            public void Get(ITfsWorkspace workspace, IEnumerable<IChange> changes)
             {
-                foreach (var change in _changes)
+                foreach (var change in changes)
                 {
                     var item = (UnshelveItem)change.Item;
                     item.Get(workspace);
@@ -616,7 +616,7 @@ namespace Sep.Git.Tfs.VsCommon
                 return temp;
             }
 
-            public void Get(IWorkspace workspace)
+            public void Get(ITfsWorkspace workspace)
             {
                 _pendingChange.DownloadShelvedFile(workspace.GetLocalItemForServerItem(_pendingChange.ServerItem));
             }

--- a/GitTfs.VsCommon/Wrappers.cs
+++ b/GitTfs.VsCommon/Wrappers.cs
@@ -107,6 +107,11 @@ namespace Sep.Git.Tfs.VsCommon
         {
             get { return _bridge.Wrap<WrapperForVersionControlServer, VersionControlServer>(_changeset.VersionControlServer); }
         }
+
+        public void Get(ITfsWorkspace workspace, IEnumerable<IChange> changes)
+        {
+            workspace.Get(this.ChangesetId, changes);
+        }
     }
 
     public class WrapperForChange : WrapperFor<Change>, IChange

--- a/GitTfs.VsFake/TfsHelper.VsFake.cs
+++ b/GitTfs.VsFake/TfsHelper.VsFake.cs
@@ -132,9 +132,9 @@ namespace Sep.Git.Tfs.VsFake
                 get { throw new NotImplementedException(); }
             }
 
-            public void Get(IWorkspace workspace)
+            public void Get(ITfsWorkspace workspace, IEnumerable<IChange> changes)
             {
-                workspace.GetSpecificVersion(this);
+                workspace.Get(this.ChangesetId, changes);
             }
         }
 

--- a/GitTfs/Core/ITfsWorkspace.cs
+++ b/GitTfs/Core/ITfsWorkspace.cs
@@ -42,6 +42,11 @@ namespace Sep.Git.Tfs.Core
         /// Gets the files changed in the given changes.
         /// </summary>
         void Get(int changesetId, IEnumerable<IChange> change);
+        /// <summary>
+        /// Find path where the server item is mapped to in the
+        /// local workspace.
+        /// </summary>
+        string GetLocalItemForServerItem(string serverItem);
 
         long CheckinTool(Func<string> generateCheckinComment);
         void Merge(string sourceTfsPath, string tfsRepositoryPath);

--- a/GitTfs/Core/TfsChangeset.cs
+++ b/GitTfs/Core/TfsChangeset.cs
@@ -32,7 +32,7 @@ namespace Sep.Git.Tfs.Core
                 Summary.Remote.Repository.GetObjects(lastCommit, initialTree);
             var resolver = new PathResolver(Summary.Remote, initialTree);
             var sieve = new ChangeSieve(_changeset, resolver);
-            workspace.Get(_changeset.ChangesetId, sieve.GetChangesToFetch());
+            _changeset.Get(workspace, sieve.GetChangesToFetch());
             foreach (var change in sieve.GetChangesToApply())
             {
                 Apply(change, treeBuilder, workspace, initialTree);

--- a/GitTfs/Core/TfsInterop/IChangeset.cs
+++ b/GitTfs/Core/TfsInterop/IChangeset.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace Sep.Git.Tfs.Core.TfsInterop
 {
@@ -10,5 +11,6 @@ namespace Sep.Git.Tfs.Core.TfsInterop
         string Comment { get; }
         int ChangesetId { get; }
         IVersionControlServer VersionControlServer { get; }
+        void Get(ITfsWorkspace workspace, IEnumerable<IChange> changes);
     }
 }

--- a/GitTfs/Core/TfsWorkspace.cs
+++ b/GitTfs/Core/TfsWorkspace.cs
@@ -190,6 +190,11 @@ namespace Sep.Git.Tfs.Core
             }
         }
 
+        public string GetLocalItemForServerItem(string serverItem)
+        {
+            return _workspace.GetLocalItemForServerItem(serverItem);
+        }
+
         private IEnumerable<IWorkItemCheckinInfo> GetWorkItemInfos(CheckinOptions options = null)
         {
             return GetWorkItemInfosHelper<IWorkItemCheckinInfo>(_tfsHelper.GetWorkItemInfos, options);

--- a/GitTfsTest/Core/ChangeSieveTests.cs
+++ b/GitTfsTest/Core/ChangeSieveTests.cs
@@ -54,6 +54,11 @@ namespace Sep.Git.Tfs.Test.Core
                 public DateTime CreationDate { get; set; }
                 public string Committer { get; set; }
                 public IChange[] Changes { get; set; }
+
+                public void Get(ITfsWorkspace workspace, IEnumerable<IChange> changes)
+                {
+                    throw new NotImplementedException();
+                }
             }
 
             private IGitTfsRemote _remote;


### PR DESCRIPTION
The optimization to prevent downloading of ignored files broke
unshelving[1]. A shelveset is treated as a changeset by git-tfs, but there
is no changeset version for it, so you can't ask the workspace to get a
shelveset by version, instead the shelveset itself needs to be responsible
for populating the workspace with the correct files[2].

[1] 351ed3d69faf6a110253a052c4c94cf331b846ce
[2] 26fe4ad2697530bdf9c6b70162eb6e413ee0df44
