### PR TITLE
Do not query shelved changes outside of our tree

### DIFF
--- a/GitTfs.VsCommon/TfsHelper.Common.cs
+++ b/GitTfs.VsCommon/TfsHelper.Common.cs
@@ -377,7 +377,8 @@ namespace Sep.Git.Tfs.VsCommon
             }
             var shelveset = shelvesets.First();
 
-            var change = VersionControl.QueryShelvedChanges(shelveset).Single();
+            var itemSpec = new ItemSpec(remote.TfsRepositoryPath, RecursionType.Full);
+            var change = VersionControl.QueryShelvedChanges(shelveset, new ItemSpec[] { itemSpec }).Single();
             var wrapperForVersionControlServer =
                 _bridge.Wrap<WrapperForVersionControlServer, VersionControlServer>(VersionControl);
             // TODO - containerify this (no `new`)!


### PR DESCRIPTION
Because changes outside of the tree are ignored anyway, don't bother
querying them from TFS in the first place.
