### PR TITLE
fix issue with matching changesets with comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ obj
 # 3rd-party stuff copied during build
 /packages
 GitTfs/git2.*
+# MSTest test Results
+[Tt]est[Rr]esult*/
+[Bb]uild[Ll]og.*

--- a/GitTfs/Core/GitRepository.cs
+++ b/GitTfs/Core/GitRepository.cs
@@ -497,7 +497,7 @@ namespace Sep.Git.Tfs.Core
             return commit.Sha;
         }
 
-        private readonly Regex tfsIdRegex = new Regex("^git-tfs-id: .*;C([0-9]+)$", RegexOptions.Singleline | RegexOptions.Compiled);
+        private readonly Regex tfsIdRegex = new Regex(@".*^git-tfs-id: .*;C(?<id>[0-9]+)\s*$", RegexOptions.Singleline | RegexOptions.Compiled | RegexOptions.Multiline);
 
         private Commit FindCommitByChangesetId(long changesetId, string remoteRef = null)
         {
@@ -528,7 +528,7 @@ namespace Sep.Git.Tfs.Core
                 var match = tfsIdRegex.Match(c.Message);
                 if (match.Success)
                 {
-                    int id = int.Parse(match.Groups[1].Value);
+                    int id = int.Parse(match.Groups["id"].Value);
                     changesetsCache[id] = c.Sha;
                     if (id == changesetId)
                     {


### PR DESCRIPTION
The current implementation assume the message is only one line and it started with "git-tfs-id:". in cases I am working with there always some comments above that line. basically by current implementation that message does not match the regex and skipped even it contains right change set ID.
I enable Multiline and added skipping everything before "git-tfs-id" and skipping spaces after the number
