### PR TITLE
Fix Regex when searching for changeset id

### DIFF
--- a/GitTfs/Core/GitRepository.cs
+++ b/GitTfs/Core/GitRepository.cs
@@ -497,7 +497,7 @@ namespace Sep.Git.Tfs.Core
             return commit.Sha;
         }
 
-        private readonly Regex tfsIdRegex = new Regex("^git-tfs-id: .*;C([0-9]+)$", RegexOptions.Singleline | RegexOptions.Compiled);
+        private readonly Regex _tfsIdRegex = new Regex("git-tfs-id: .*;C([0-9]+)", RegexOptions.Singleline | RegexOptions.Compiled);
 
         private Commit FindCommitByChangesetId(long changesetId, string remoteRef = null)
         {
@@ -525,7 +525,7 @@ namespace Sep.Git.Tfs.Core
             Commit commit = null;
             foreach (var c in commitsFromRemoteBranches)
             {
-                var match = tfsIdRegex.Match(c.Message);
+                var match = _tfsIdRegex.Match(c.Message);
                 if (match.Success)
                 {
                     int id = int.Parse(match.Groups[1].Value);


### PR DESCRIPTION
The match string was changed in an older refactoring, and it no longer found the changesets from the commit message.

Removing the start and end of line limiter fixes the problem.
#609 is a more robust solution, colsing this.
