### PR TITLE
Fix work-item option ( -w1234 is now supported)

### DIFF
--- a/GitTfs/Commands/CheckinOptions.cs
+++ b/GitTfs/Commands/CheckinOptions.cs
@@ -22,7 +22,7 @@ namespace Sep.Git.Tfs.Commands
                         v => NoMerge = v != null },
                     { "f|force=", "The policy override reason.",
                         v => { Force = true; OverrideReason = v; } },
-                    { "w|work-item=:", "Associated work items\ne.g. -w12345 to associate with 12345\nor -w12345:resolve to resolve 12345",
+                    { "w|work-item:", "Associated work items\ne.g. -w12345 to associate with 12345\nor -w12345:resolve to resolve 12345",
                         (n, opt) => { if(n == null) throw new OptionException("Missing work item number for option -w.", "-w");
                             (opt == "resolve" ? WorkItemsToResolve : WorkItemsToAssociate).Add(n); } },
                     { "c|code-reviewer=", "Set code reviewer\ne.g. -c \"John Smith\"",

--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -16,5 +16,5 @@
 * Do a better job at finding the most recent fetched TFS changeset (#592)
 * Remove old `init-branch` command. Use `branch --init` instead (#393)
 * Use libgit2sharp to merge commits (#601)
-* Other documentation and bug fixes (#487, #521, #523, #527, #557)
+* Other documentation and bug fixes (#487, #521, #523, #527, #557, #613)
 


### PR DESCRIPTION
to work how the help say...
Before this fix, only `-w1234:` or `-w1234:associate` was supported

Should fix #612
