### PR TITLE
Shorten workspace to mitigate ntfs path length limit

### DIFF
--- a/GitTfs/Core/GitTfsRemote.cs
+++ b/GitTfs/Core/GitTfsRemote.cs
@@ -169,16 +169,7 @@ namespace Sep.Git.Tfs.Core
             }
         }
 
-        private string Dir
-        {
-            get
-            {
-                return Ext.CombinePaths(globals.GitDir, "tfs", Id);
-            }
-        }
-
-        
-
+        private const string WorkspaceDirectory = "~w";
         private string WorkingDirectory
         {
             get
@@ -193,7 +184,7 @@ namespace Sep.Git.Tfs.Core
                     }
 
                     //find the relative path to the owning remote
-                    return Ext.CombinePaths(globals.GitDir, "tfs", this.OwningRemoteId, "workspace", this.Prefix);
+                    return Ext.CombinePaths(globals.GitDir, WorkspaceDirectory, OwningRemoteId, Prefix);
                 }
 
                 return dir ?? DefaultWorkingDirectory;
@@ -204,7 +195,7 @@ namespace Sep.Git.Tfs.Core
         {
             get
             {
-                return Path.Combine(Dir, "workspace");
+                return Path.Combine(globals.GitDir, WorkspaceDirectory);
             }
         }
 


### PR DESCRIPTION
(See https://github.com/git-tfs/git-tfs/blob/master/doc/Set-custom-workspace.md
for problem description)

Now that the ".git\tfs\RemoteId\" directory is only used
to create a "workspace" directory and is cleaned after
each command run, we could instead use a unique and
common directory with a shorter path (".git~w")!

This way we are less likely to hit the ntfs path length limit
because we are not dependent of the remote id. If we
successfully clone the trunk, we will be able to fetch all the branches
(except if there is files deeper needless to say)
