### PR TITLE
Fix missing merge parent

### DIFF
--- a/GitTfs.VsCommon/TfsHelper.Common.cs
+++ b/GitTfs.VsCommon/TfsHelper.Common.cs
@@ -133,7 +133,7 @@ namespace Sep.Git.Tfs.VsCommon
         {
             var targetVersion = new ChangesetVersionSpec((int)targetChangeset);
             var mergeInfo = VersionControl.QueryMerges(null, null, path, targetVersion, targetVersion, targetVersion, RecursionType.Full);
-            if (mergeInfo.Length == 0) return 0;
+            if (mergeInfo.Length == 0) return -1;
             return mergeInfo.Max(x => x.SourceVersion);
         }
 

--- a/GitTfs/Core/GitTfsRemote.cs
+++ b/GitTfs/Core/GitTfsRemote.cs
@@ -354,7 +354,7 @@ namespace Sep.Git.Tfs.Core
         private bool ProcessMergeChangeset(ITfsChangeset changeset, bool stopOnFailMergeCommit, ref string parentCommit)
         {
             var parentChangesetId = Tfs.FindMergeChangesetParent(TfsRepositoryPath, changeset.Summary.ChangesetId, this);
-            if (parentChangesetId == 0)
+            if (parentChangesetId < 1)  // Handle missing merge parent info
             {
                 if (stopOnFailMergeCommit)
                 {


### PR DESCRIPTION
This pull request fixes issue #627 (and also #590,of which it is a duplicate).

In some cases (probably involving a badly formed TFS changeset, or  a merge changeset in which the merge parent has been deleted), the VersionControl.QueryMerges call in FindMergeChangesetParent can return an empty array.  In such cases, the subsequent merginfo.Max(x => x.SourceVersion) call will throw a "Sequence contains no objects" InvalidOperationException.

This patch avoids that error by checking for a zero-length array, and returning -1 to the caller, which then checks for that and handles it with a warning message that git-tfs can't locate the parent.
