### PR TITLE
[NeedReview]Rename branch and add file

### DIFF
--- a/GitTfs/Commands/InitBranch.cs
+++ b/GitTfs/Commands/InitBranch.cs
@@ -295,7 +295,7 @@ namespace Sep.Git.Tfs.Commands
                 foreach (var tfsBranch in branchesToFetch)
                 {
                     _stdout.WriteLine("=> Working on TFS branch : " + tfsBranch.TfsRepositoryPath);
-                    if (tfsBranch.TfsRemote == null)
+                    if (tfsBranch.TfsRemote == null || tfsBranch.TfsRemote.MaxChangesetId == 0)
                     {
                         try
                         {

--- a/GitTfs/Core/GitTfsRemote.cs
+++ b/GitTfs/Core/GitTfsRemote.cs
@@ -346,7 +346,7 @@ namespace Sep.Git.Tfs.Core
                     }
                     var parentSha = LastParentCommitBeforeRename ?? MaxCommitHash;
                     var log = Apply(parentSha, changeset, objects);
-                    if (changeset.IsRenameChangeset)
+                    if (changeset.IsRenameChangeset && parentSha != null)
                     {
                         if (LastParentCommitBeforeRename == null)
                         {

--- a/GitTfs/Core/GitTfsRemote.cs
+++ b/GitTfs/Core/GitTfsRemote.cs
@@ -344,7 +344,17 @@ namespace Sep.Git.Tfs.Core
                         fetchResult.IsSuccess = false;
                         return fetchResult;
                     }
-                    var log = Apply(MaxCommitHash, changeset, objects);
+                    var parentSha = LastParentCommitBeforeRename ?? MaxCommitHash;
+                    var log = Apply(parentSha, changeset, objects);
+                    if (changeset.IsRenameChangeset)
+                    {
+                        if (LastParentCommitBeforeRename == null)
+                        {
+                            LastParentCommitBeforeRename = MaxCommitHash;
+                            return fetchResult;
+                        }
+                        LastParentCommitBeforeRename = null;
+                    }
                     if (parentCommitSha != null)
                         log.CommitParents.Add(parentCommitSha);
                     if (changeset.Summary.ChangesetId == mergeChangesetId)
@@ -365,6 +375,8 @@ namespace Sep.Git.Tfs.Core
             } while (fetchedChangesets.Any() && latestChangesetId > fetchResult.LastFetchedChangesetId);
             return fetchResult;
         }
+
+        public static string LastParentCommitBeforeRename { get; set; }
 
         private Dictionary<string, GitObject> BuildEntryDictionary()
         {

--- a/GitTfs/Core/ITfsChangeset.cs
+++ b/GitTfs/Core/ITfsChangeset.cs
@@ -29,5 +29,7 @@ namespace Sep.Git.Tfs.Core
         /// Get parent that not was fetched
         /// </summary>
         string OmittedParentBranch { get; set; }
+
+        bool IsRenameChangeset { get; set; }
     }
 }

--- a/GitTfs/Core/TfsChangeset.cs
+++ b/GitTfs/Core/TfsChangeset.cs
@@ -32,6 +32,10 @@ namespace Sep.Git.Tfs.Core
                 Summary.Remote.Repository.GetObjects(lastCommit, initialTree);
             var resolver = new PathResolver(Summary.Remote, initialTree);
             var sieve = new ChangeSieve(_changeset, resolver);
+            if (sieve.RenameBranchCommmit)
+            {
+                IsRenameChangeset = true;
+            }
             _changeset.Get(workspace, sieve.GetChangesToFetch(), ignorableErrorHandler);
             foreach (var change in sieve.GetChangesToApply())
             {
@@ -210,5 +214,6 @@ namespace Sep.Git.Tfs.Core
         }
 
         public string OmittedParentBranch { get; set; }
+        public bool IsRenameChangeset { get; set; }
     }
 }

--- a/GitTfs/Util/ChangeSieve.cs
+++ b/GitTfs/Util/ChangeSieve.cs
@@ -51,7 +51,7 @@ namespace Sep.Git.Tfs.Util
         /// <summary>
         /// Is the top-level folder deleted or renamed?
         /// </summary>
-        private bool RenameBranchCommmit
+        public bool RenameBranchCommmit
         {
             get
             {

--- a/GitTfs/Util/ChangeSieve.cs
+++ b/GitTfs/Util/ChangeSieve.cs
@@ -71,9 +71,6 @@ namespace Sep.Git.Tfs.Util
             if (DeletesProject)
                 return Enumerable.Empty<IChange>();
 
-            if (RenameBranchCommmit)
-                return new List<IChange>();
-
             return NamedChanges.Where(c => IncludeInFetch(c)).Select(c => c.Change);
         }
 
@@ -81,9 +78,6 @@ namespace Sep.Git.Tfs.Util
         {
             if (DeletesProject)
                 return Enumerable.Empty<ApplicableChange>();
-
-            if (RenameBranchCommmit)
-                return new List<ApplicableChange>();
 
             var compartments = new {
                 Deleted = new List<ApplicableChange>(),


### PR DESCRIPTION
Should fix #660 and #650...

The main goal of this PR, is to manage a rename changeset
as a changeset belonging to the new renamed branch and not
as belonging to the old branch (as done before).

This way, other changes than the rename could be included in the 
newly created commit (and not be ignored as done before
because the changes are made inside the $/new/tfs/branch/path)