### PR TITLE
Handle error case  where no merge info is returned by QueryMerges

### DIFF
--- a/GitTfs.VsCommon/TfsHelper.Common.cs
+++ b/GitTfs.VsCommon/TfsHelper.Common.cs
@@ -220,6 +220,7 @@ namespace Sep.Git.Tfs.VsCommon
         {
             var targetVersion = new ChangesetVersionSpec((int)targetChangeset);
             var mergeInfo = VersionControl.QueryMerges(null, null, path, targetVersion, targetVersion, targetVersion, RecursionType.Full);
+            if (mergeInfo.Length == 0) return -1;
             return mergeInfo.Max(x => x.SourceVersion);
         }
 

--- a/GitTfs/Core/GitTfsRemote.cs
+++ b/GitTfs/Core/GitTfsRemote.cs
@@ -381,6 +381,16 @@ namespace Sep.Git.Tfs.Core
             else if (Repository.GetConfig(GitTfsConstants.IgnoreBranches) != true.ToString())
             {
                 var parentChangesetId = Tfs.FindMergeChangesetParent(TfsRepositoryPath, changeset.Summary.ChangesetId, this);
+                if (parentChangesetId < 1)  // Handle missing merge parent info
+                {
+                    if (stopOnFailMergeCommit)
+                    {
+                        return false;
+                    }
+                    stdout.WriteLine("warning: this changeset " + changeset.Summary.ChangesetId +
+                                     " is a merge changeset. But git-tfs is unable to determine the parent changeset.");
+                    return true;
+                }
                 var shaParent = Repository.FindCommitHashByChangesetId(parentChangesetId);
                 if (shaParent == null)
                 {


### PR DESCRIPTION
rebase of the work made in #628.

Need a test by someone that has the error....
