### PR TITLE
690 no metadata rcheckin

### DIFF
--- a/GitTfs/Commands/Fetch.cs
+++ b/GitTfs/Commands/Fetch.cs
@@ -138,46 +138,16 @@ namespace Sep.Git.Tfs.Commands
             // The process is similar to bootstrapping.
             if (!ForceFetch)
                 globals.Repository.MoveTfsRefForwardIfNeeded(remote);
-            var exportMetadatasFilePath = Path.Combine(globals.GitDir, "git-tfs_workitem_mapping.txt");
+
+            var metadataExportInitializer = new ExportMetadatasInitializer(globals);
+            bool shouldExport = ExportMetadatas || remote.Repository.GetConfig(GitTfsConstants.ExportMetadatasConfigKey) == "true";
+
             if (ExportMetadatas)
             {
-                remote.ExportMetadatas = true;
-                remote.Repository.SetConfig(GitTfsConstants.ExportMetadatasConfigKey, "true");
-                if (!string.IsNullOrEmpty(ExportMetadatasFile))
-                {
-                    if (File.Exists(ExportMetadatasFile))
-                    {
-                        File.Copy(ExportMetadatasFile, exportMetadatasFilePath);
-                    }
-                    else
-                        throw new GitTfsException("error: the work items mapping file doesn't exist!");
-                }
+                metadataExportInitializer.InitializeConfig(remote.Repository, ExportMetadatasFile);
             }
-            else
-            {
-                if(remote.Repository.GetConfig(GitTfsConstants.ExportMetadatasConfigKey) == "true")
-                    remote.ExportMetadatas = true;
-            }
-            remote.ExportWorkitemsMapping = new Dictionary<string, string>();
-            if (remote.ExportMetadatas && File.Exists(exportMetadatasFilePath))
-            {
-                try
-                {
-                    foreach (var lineRead in File.ReadAllLines(exportMetadatasFilePath))
-                    {
-                        if (string.IsNullOrWhiteSpace(lineRead))
-                            continue;
-                        var values = lineRead.Split('|');
-                        var oldWorkitem = values[0].Trim();
-                        if(!remote.ExportWorkitemsMapping.ContainsKey(oldWorkitem))
-                            remote.ExportWorkitemsMapping.Add(oldWorkitem, values[1].Trim());
-                    }
-                }
-                catch (Exception)
-                {
-                    throw new GitTfsException("error: bad format of workitems mapping file! One line format should be: OldWorkItemId|NewWorkItemId");
-                }
-            }
+
+            metadataExportInitializer.InitializeRemote(remote, shouldExport);
 
             try
             {

--- a/GitTfs/Commands/Rcheckin.cs
+++ b/GitTfs/Commands/Rcheckin.cs
@@ -112,7 +112,16 @@ namespace Sep.Git.Tfs.Commands
             if (!String.IsNullOrWhiteSpace(_globals.Repository.CommandOneline("rev-list", tfsLatest, "^" + refToCheckin)))
                 throw new GitTfsException("error: latest TFS commit should be parent of commits being checked in");
 
+            SetupMetadataExport(parentChangeset.Remote);
+
             return (!Old || _globals.Repository.IsBare) ? _PerformRCheckinQuick(parentChangeset, refToCheckin) : _PerformRCheckin(parentChangeset, refToCheckin);
+        }
+
+        private void SetupMetadataExport(IGitTfsRemote remote)
+        {
+            var exportInitializer = new ExportMetadatasInitializer(_globals);
+            var shouldExport = _globals.Repository.GetConfig(GitTfsConstants.ExportMetadatasConfigKey) == "true";
+            exportInitializer.InitializeRemote(remote, shouldExport);
         }
 
         private int _PerformRCheckinQuick(TfsChangesetInfo parentChangeset, string refToCheckin)

--- a/GitTfs/GitTfs.csproj
+++ b/GitTfs/GitTfs.csproj
@@ -194,6 +194,7 @@
     <Compile Include="Util\Bouncer.cs" />
     <Compile Include="Util\ChangeSieve.cs" />
     <Compile Include="Util\ConfigPropertyLoader.cs" />
+    <Compile Include="Util\ExportMetadatasInitializer.cs" />
     <Compile Include="Util\PathResolver.cs" />
     <Compile Include="Util\CommitSpecificCheckinOptionsFactory.cs" />
     <Compile Include="Core\GitTfsVersionProvider.cs" />

--- a/GitTfs/Util/ExportMetadatasInitializer.cs
+++ b/GitTfs/Util/ExportMetadatasInitializer.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Sep.Git.Tfs.Core;
+
+namespace Sep.Git.Tfs.Util
+{
+    /// <summary>
+    /// An object that can help initialize a repository or a remote for exporting
+    /// TFS metadata
+    /// </summary>
+    public class ExportMetadatasInitializer
+    {
+        private readonly Globals globals;
+        private readonly string exportMetadatasFilePath;
+
+        public ExportMetadatasInitializer(Globals globals)
+        {
+            exportMetadatasFilePath = Path.Combine(globals.GitDir, "git-tfs_workitem_mapping.txt");
+        }
+
+        /// <summary>
+        /// Initializes a repository to always export meta data
+        /// </summary>
+        /// <param name="repository"></param>
+        /// <param name="mappingFile"></param>
+        public void InitializeConfig(IGitRepository repository, string mappingFile = null)
+        {
+            repository.SetConfig(GitTfsConstants.ExportMetadatasConfigKey, "true");
+            if (!string.IsNullOrEmpty(mappingFile))
+            {
+                if (File.Exists(mappingFile))
+                {
+                    File.Copy(mappingFile, exportMetadatasFilePath);
+                }
+                else
+                    throw new GitTfsException("error: the work items mapping file doesn't exist!");
+            }
+        }
+
+        /// <summary>
+        /// Configures a IGitTfsRemote to export metadata
+        /// </summary>
+        /// <param name="remote"></param>
+        /// <param name="shouldExportMetadata"></param>
+        public void InitializeRemote(IGitTfsRemote remote, bool shouldExportMetadata)
+        {
+            remote.ExportMetadatas = shouldExportMetadata;
+            remote.ExportWorkitemsMapping = new Dictionary<string, string>();
+
+            if (shouldExportMetadata && File.Exists(exportMetadatasFilePath))
+            {
+                try
+                {
+                    foreach (var lineRead in File.ReadAllLines(exportMetadatasFilePath))
+                    {
+                        if (string.IsNullOrWhiteSpace(lineRead))
+                            continue;
+                        var values = lineRead.Split('|');
+                        var oldWorkitem = values[0].Trim();
+                        if (!remote.ExportWorkitemsMapping.ContainsKey(oldWorkitem))
+                            remote.ExportWorkitemsMapping.Add(oldWorkitem, values[1].Trim());
+                    }
+                }
+                catch (Exception)
+                {
+                    throw new GitTfsException("error: bad format of workitems mapping file! One line format should be: OldWorkItemId|NewWorkItemId");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Initial attempt at fixing #690. The rcheckin command does not inherit from Checkin and thus doesn't appear to obey the config field `git-tfs.export-metadatas`.

My approach is twofold:

1. extract from `Fetch.cs` the code which sets up repositories and remotes for metadata
2. Call this logic from `Rcheckin.cs` as well as `Fetch.cs`

I wasn't sure how to really get this under test.

Please let me know if my contribution can be improved in anyway.