### PR TITLE
git tfs rcheckin --auto-stash

### DIFF
--- a/GitTfs/GitTfs.csproj
+++ b/GitTfs/GitTfs.csproj
@@ -202,6 +202,7 @@
     <Compile Include="Util\GitTfsCommandRunner.cs" />
     <Compile Include="Core\IGitTfsVersionProvider.cs" />
     <Compile Include="Util\TemporaryFile.cs" />
+    <Compile Include="Util\TemporaryStash.cs" />
     <Compile Include="Util\WhenDynamicDoesntWork.cs" />
     <Compile Include="Util\PluggableWithAliases.cs" />
     <Compile Include="Util\ConfiguresStructureMap.cs" />

--- a/GitTfs/GitTfsConstants.cs
+++ b/GitTfs/GitTfsConstants.cs
@@ -69,5 +69,7 @@ namespace Sep.Git.Tfs
         public const string IgnoreNotInitBranches = GitTfsPrefix + ".ignore-not-init-branches";
 
         public const string BatchSize = GitTfsPrefix + ".batch-size";
+
+        public const string RCheckinAutoStashConfigKey = GitTfsPrefix + ".rcheckin-autostash";
     }
 }

--- a/GitTfs/Util/TemporaryStash.cs
+++ b/GitTfs/Util/TemporaryStash.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Sep.Git.Tfs.Core;
+
+namespace Sep.Git.Tfs.Util
+{
+    /// <summary>
+    /// Uses the IDisposable pattern to wrap a block of code in `git stash` and `git stash pop`
+    /// </summary>
+    public class TemporaryStash : IDisposable
+    {
+        private readonly IGitRepository _repo;
+        private readonly bool _workingCopyWasDirty;
+
+        public TemporaryStash(IGitRepository repo)
+        {
+            if (repo == null) throw new ArgumentNullException("repo");
+
+            _repo = repo;
+            _workingCopyWasDirty = _repo.WorkingCopyHasUnstagedOrUncommitedChanges;
+
+            Stash();
+        }
+
+        private void Stash()
+        {
+            if (_workingCopyWasDirty)
+                _repo.CommandNoisy("stash");
+        }
+
+        void IDisposable.Dispose()
+        {
+            if (_workingCopyWasDirty)
+                _repo.CommandNoisy("stash", "pop");
+        }
+    }
+}

--- a/GitTfsTest/GitTfsTest.csproj
+++ b/GitTfsTest/GitTfsTest.csproj
@@ -124,6 +124,7 @@
     <Compile Include="Util\CommitSpecificCheckinOptionsFactoryTests.cs" />
     <Compile Include="Util\GitTfsCommandRunnerTests.cs" />
     <Compile Include="Util\BouncerTest.cs" />
+    <Compile Include="Util\TemporaryStashTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\GitTfs.VsFake\GitTfs.VsFake.csproj">

--- a/GitTfsTest/Util/TemporaryStashTests.cs
+++ b/GitTfsTest/Util/TemporaryStashTests.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Rhino.Mocks;
+using Sep.Git.Tfs.Core;
+using Sep.Git.Tfs.Util;
+using StructureMap.AutoMocking;
+using Xunit;
+
+namespace Sep.Git.Tfs.Test.Util
+{
+    public class TemporaryStashTests
+    {
+        private RhinoAutoMocker<TemporaryStash> _mocks;
+
+        public TemporaryStashTests()
+        {
+            _mocks = new RhinoAutoMocker<TemporaryStash>();
+        }
+        
+        [Fact]
+        public void On_Consutruction_It_Executes_Git_Stash()
+        {
+            var repo = _mocks.Get<IGitRepository>();
+            repo.Stub(r => r.WorkingCopyHasUnstagedOrUncommitedChanges).Return(true);
+
+            using (new TemporaryStash(repo))
+            {
+                // Do some git stuff
+            }
+
+            repo.AssertWasCalled(r => r.CommandNoisy("stash"));
+        }
+
+        [Fact]
+        public void On_Dispose_It_Executes_Git_Stash_Pop()
+        {
+            var repo = _mocks.Get<IGitRepository>();
+            repo.Stub(r => r.WorkingCopyHasUnstagedOrUncommitedChanges).Return(true);
+
+            var stash = new TemporaryStash(repo);
+
+            ((IDisposable)stash).Dispose();
+
+            repo.AssertWasCalled(r => r.CommandNoisy("stash", "pop"));
+        }
+
+        [Fact]
+        public void If_Working_Copy_Is_Not_Dirty_Dont_Stash()
+        {
+            var repo = _mocks.Get<IGitRepository>();
+            repo.Stub(r => r.WorkingCopyHasUnstagedOrUncommitedChanges).Return(false);
+
+            using (new TemporaryStash(repo))
+            {
+                
+            }
+
+            repo.AssertWasNotCalled(r => r.CommandNoisy("stash"));
+            repo.AssertWasNotCalled(r => r.CommandNoisy("stash", "pop"));
+        }
+
+        [Fact]
+        public void If_Working_Copy_Status_Changes_In_The_Middle_That_Stash_Is_Still_Dropped()
+        {
+            var repo = _mocks.Get<IGitRepository>();
+            repo.Stub(r => r.WorkingCopyHasUnstagedOrUncommitedChanges).Return(false);
+
+            using (new TemporaryStash(repo))
+            {
+                repo.Stub(r => r.WorkingCopyHasUnstagedOrUncommitedChanges).Return(true);
+            }
+
+            repo.AssertWasNotCalled(r => r.CommandNoisy("stash"));
+            repo.AssertWasNotCalled(r => r.CommandNoisy("stash", "pop"));
+        }
+    }
+}


### PR DESCRIPTION
Enables `--auto-stash` option for `git tfs rcheckin` that, if the working directory is dirty, will automatically wrap the `rcheckin` operation in `git stash` and `git stash pop`.

One can also add an option to the git config to enable the feature without needing to pass the command line switch.

```bash
git config git-tfs.rcheckin-autostash true
```

I tried to add integration tests for `rcheckin` to go along with this, but I think the fake VS provider needs a bit more work. I'll keep plugging away at getting that class under test: I'd like to refactor it further in later PRs.

Thanks for all you do with this project, its a life saver for me at work :smile: 

