### PR TITLE
Fix link for running the unit tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Here are some tips on creating a pull request:
 1. Write that awesome code. :sparkles:
 
 2. Make sure the existing unit tests don't break. We try to keep the unit tests
-[easy to run](https://github.com/git-tfs/git-tfs/blob/master/doc/Running-the-Unit-Tests.md).
+[easy to run](https://github.com/git-tfs/git-tfs/blob/master/doc/running-the-unit-tests.md).
 
 3. We like new unit tests. If you can unit test your code, do so.
 One of the pain points of the current git-tfs codebase is that parts of it are very difficult to unit test.


### PR DESCRIPTION
Noticed the link to the "running the unit tests" page was broken in contributing.md.  The page is actually there, but the casing didn't match - maybe this worked before, but it looks like these URLs are case-sensitive now.
