### PR TITLE
Being able to clone a sub branches and use of `--with-branches` option

### DIFF
--- a/GitTfs/Core/TfsInterop/IBranch.cs
+++ b/GitTfs/Core/TfsInterop/IBranch.cs
@@ -91,5 +91,20 @@ namespace Sep.Git.Tfs.Core.TfsInterop
             }
             return childrenBranches;
         }
+
+        public static IEnumerable<BranchTree> GetAllChildrenOfBranch(this BranchTree branch, string tfsPath)
+        {
+            if (branch == null) return Enumerable.Empty<BranchTree>();
+
+            if (string.Compare(branch.Path, tfsPath, StringComparison.InvariantCultureIgnoreCase) == 0)
+                return branch.GetAllChildren();
+
+            var childrenBranches = new List<BranchTree>();
+            foreach (var childBranch in branch.ChildBranches)
+            {
+                childrenBranches.AddRange(GetAllChildrenOfBranch(childBranch, tfsPath));
+            }
+            return childrenBranches;
+        }
     }
 }

--- a/GitTfsTest/Core/TfsInterop/BranchExtensionsTest.cs
+++ b/GitTfsTest/Core/TfsInterop/BranchExtensionsTest.cs
@@ -64,5 +64,66 @@ namespace Sep.Git.Tfs.Test.Core.TfsInterop
             Assert.Equal(2, result.Count());
             Assert.Equal(new List<BranchTree> { branch1_1, branch1_2 }, result);
         }
+
+        [Fact]
+        public void WhenGettingChildrenOfLowerBranch_ThenReturnNothing()
+        {
+            var trunk = CreateBranchTree("$/Project/Trunk");
+
+            var branch1 = CreateBranchTree("$/Project/Branch1", trunk);
+
+            IEnumerable<BranchTree> result = branch1.GetAllChildren();
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.Count());
+        }
+
+        [Fact]
+        public void WhenFindingChildrenOfTopBranchByPath_ThenReturnAllTheChildren()
+        {
+            var trunk = CreateBranchTree("$/Project/Trunk");
+
+            var branch1 = CreateBranchTree("$/Project/Branch1", trunk);
+            var branch2 = CreateBranchTree("$/Project/Branch2", trunk);
+            var branch3 = CreateBranchTree("$/Project/Branch3", trunk);
+
+            IEnumerable<BranchTree> result = trunk.GetAllChildrenOfBranch("$/Project/Trunk");
+
+            Assert.NotNull(result);
+            Assert.Equal(3, result.Count());
+            Assert.Equal(new List<BranchTree> { branch1, branch2, branch3 }, result);
+        }
+
+        [Fact]
+        public void WhenFindingChildrenOfOneBranchByPath_ThenReturnChildrenOfThisBranch()
+        {
+            var trunk = CreateBranchTree("$/Project/Trunk");
+
+            var branch1 = CreateBranchTree("$/Project/Branch1", trunk);
+            var branch1_1 = CreateBranchTree("$/Project/Branch1.1", branch1);
+            var branch1_2 = CreateBranchTree("$/Project/Branch1.2", branch1);
+
+            var branch2 = CreateBranchTree("$/Project/Branch2", trunk);
+            var branch3 = CreateBranchTree("$/Project/Branch3", trunk);
+
+            IEnumerable<BranchTree> result = trunk.GetAllChildrenOfBranch("$/Project/Branch1");
+
+            Assert.NotNull(result);
+            Assert.Equal(2, result.Count());
+            Assert.Equal(new List<BranchTree> { branch1_1, branch1_2 }, result);
+        }
+
+        [Fact]
+        public void WhenFindingChildrenOfLowerBranchByPath_ThenReturnNothing()
+        {
+            var trunk = CreateBranchTree("$/Project/Trunk");
+
+            var branch1 = CreateBranchTree("$/Project/Branch1", trunk);
+
+            IEnumerable<BranchTree> result = trunk.GetAllChildrenOfBranch("$/Project/Branch1");
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.Count());
+        }
     }
 }

--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -1,4 +1,5 @@
 * Support renamed tfs branches, baseless merge and automatic branch initialisation when encounter merge changeset(#480)
+* Being able to clone a Tfs subbranch with `--with-branches` option (#703)
 * Add `--force` to unshelve command (#636)
 * Add `--batch-size` to let the user specify the number of changesets fetched at the same time (for big history and big changesets) (#639)
 * Being able to clone TFS path "$/" (#662) 


### PR DESCRIPTION
We are now, not obliged to clone the trunk to use the `--with-branches` option!
That way the sub branch will be cloned (with all the branches merged into it)
 and all its children branches will be initialized after.

There is no more technical reasons that prevent cloning a sub branch...

Solve https://groups.google.com/forum/#!topic/git-tfs-dev/XndbEXRcx1M
