### PR TITLE
up-to option, .skip-changesets and error/fail on bad checkout from TFS

### DIFF
--- a/GitTfs.VsCommon/TfsHelper.Common.cs
+++ b/GitTfs.VsCommon/TfsHelper.Common.cs
@@ -170,6 +170,27 @@ namespace Sep.Git.Tfs.VsCommon
             }
         }
 
+        public SortedSet<long> ChangeSetNumbersToIgnore()
+        {
+            SortedSet<long> result = new SortedSet<long>();
+
+            var toIgnore = properties.SkipChangeSets;
+            if (toIgnore != null && toIgnore.Length > 0)
+            {
+                var parts = toIgnore.Split(',');
+                foreach (var part in parts)
+                {
+                    int changeSetNum;
+                    if (int.TryParse(part, out changeSetNum))
+                    {
+                        result.Add(changeSetNum);
+                    }
+                }
+            }
+
+            return result;
+        }
+
         public IEnumerable<ITfsChangeset> GetChangesets(string path, long startVersion, IGitTfsRemote remote, long lastVersion = -1, bool byLots = false)
         {
             if (Is2008OrOlder)

--- a/GitTfs.VsFake/TfsHelper.VsFake.cs
+++ b/GitTfs.VsFake/TfsHelper.VsFake.cs
@@ -63,6 +63,11 @@ namespace Sep.Git.Tfs.VsFake
 
         #region read changesets
 
+        public SortedSet<long> ChangeSetNumbersToIgnore()
+        {
+            return new SortedSet<long>();
+        }
+
         public ITfsChangeset GetLatestChangeset(IGitTfsRemote remote)
         {
             return _script.Changesets.LastOrDefault().Try(x => BuildTfsChangeset(x, remote));

--- a/GitTfs/Commands/Fetch.cs
+++ b/GitTfs/Commands/Fetch.cs
@@ -31,6 +31,7 @@ namespace Sep.Git.Tfs.Commands
             this.remoteOptions = remoteOptions;
             this.authors = authors;
             this.labels = labels;
+            this.upToChangeSet = -1;
         }
 
         bool FetchAll { get; set; }
@@ -51,6 +52,17 @@ namespace Sep.Git.Tfs.Commands
                 properties.BatchSize = batchSize;
             }
         }
+        public string UpToChangeSetOption
+        {
+            set
+            {
+                int tmp;
+                if (!int.TryParse(value, out tmp))
+                    throw new GitTfsException("error: up-to parameter should be an integer.");
+                upToChangeSet = tmp;
+            }
+        }
+        int upToChangeSet { get; set; }
 
         public virtual OptionSet OptionSet
         {
@@ -76,6 +88,8 @@ namespace Sep.Git.Tfs.Commands
                         v => IgnoreBranches = v != null },
                     { "batch-size=", "Size of a the batch of tfs changesets fetched (-1 for all in one batch)",
                         v => BatchSizeOption = v },
+                    { "t|up-to=", "up-to changeset # (optional, -1 for up to maximum, must be a number, not prefixed with C)", 
+                        v => UpToChangeSetOption = v }
                 }.Merge(remoteOptions.OptionSet);
             }
         }
@@ -181,8 +195,7 @@ namespace Sep.Git.Tfs.Commands
 
             try
             {
-                remote.Fetch(stopOnFailMergeCommit);
-
+                remote.Fetch(upToChangeSet, stopOnFailMergeCommit);
             }
             finally
             {

--- a/GitTfs/Commands/InitBranch.cs
+++ b/GitTfs/Commands/InitBranch.cs
@@ -397,7 +397,7 @@ namespace Sep.Git.Tfs.Commands
             try
             {
                 Trace.WriteLine("Try fetching changesets...");
-                var fetchResult = tfsRemote.Fetch(stopOnFailMergeCommit);
+                var fetchResult = tfsRemote.Fetch(-1, stopOnFailMergeCommit);
                 Trace.WriteLine("Changesets fetched!");
 
                 if (fetchResult.IsSuccess && createBranch && tfsRemote.Id != GitTfsConstants.DefaultRepositoryId)

--- a/GitTfs/ConfigProperties.cs
+++ b/GitTfs/ConfigProperties.cs
@@ -24,5 +24,10 @@ namespace Sep.Git.Tfs
             set { _loader.Override(GitTfsConstants.BatchSize, value); }
             get { return _loader.Get(GitTfsConstants.BatchSize, 100); }
         }
+
+        public string SkipChangeSets
+        {
+            get { return _loader.Get(GitTfsConstants.SkipChangeSets, ""); }
+        }
     }
 }

--- a/GitTfs/Core/DerivedGitTfsRemote.cs
+++ b/GitTfs/Core/DerivedGitTfsRemote.cs
@@ -205,7 +205,7 @@ namespace Sep.Git.Tfs.Core
             throw DerivedRemoteException;
         }
 
-        public IFetchResult Fetch(bool stopOnFailMergeCommit = false)
+        public IFetchResult Fetch(int lastChangesetIdToFetch = -1, bool stopOnFailMergeCommit = false)
         {
             throw DerivedRemoteException;
         }

--- a/GitTfs/Core/IGitTfsRemote.cs
+++ b/GitTfs/Core/IGitTfsRemote.cs
@@ -46,7 +46,7 @@ namespace Sep.Git.Tfs.Core
         bool ShouldSkip(string path);
         IGitTfsRemote InitBranch(RemoteOptions remoteOptions, string tfsRepositoryPath, long rootChangesetId = -1, bool fetchParentBranch = false, string gitBranchNameExpected = null);
         string GetPathInGitRepo(string tfsPath);
-        IFetchResult Fetch(bool stopOnFailMergeCommit = false);
+        IFetchResult Fetch(int lastChangesetIdToFetch = -1, bool stopOnFailMergeCommit = false);
         IFetchResult FetchWithMerge(long mergeChangesetId, bool stopOnFailMergeCommit = false, params string[] parentCommitsHashes);
         void QuickFetch();
         void QuickFetch(int changesetId);

--- a/GitTfs/Core/TfsChangeset.cs
+++ b/GitTfs/Core/TfsChangeset.cs
@@ -66,7 +66,8 @@ namespace Sep.Git.Tfs.Core
             }
             else
             {
-                _stdout.WriteLine("Cannot checkout file '{0}' from TFS. Skip it", change.GitPath);
+                _stdout.WriteLine("Cannot checkout file '{0}' from TFS.", change.GitPath);
+                throw new GitTfsException("error: failed to checkout file '{0}' from TFS !");
             }
         }
 

--- a/GitTfs/Core/TfsInterop/ITfsHelper.cs
+++ b/GitTfs/Core/TfsInterop/ITfsHelper.cs
@@ -10,6 +10,7 @@ namespace Sep.Git.Tfs.Core.TfsInterop
         string Url { get; set; }
         string Username { get; set; }
         string Password { get; set; }
+        SortedSet<long> ChangeSetNumbersToIgnore();
         IEnumerable<ITfsChangeset> GetChangesets(string path, long startVersion, IGitTfsRemote remote, long lastVersion = -1, bool byLots = false);
         void WithWorkspace(string directory, IGitTfsRemote remote, TfsChangesetInfo versionToFetch, Action<ITfsWorkspace> action);
         IShelveset CreateShelveset(IWorkspace workspace, string shelvesetName);

--- a/GitTfs/GitTfs.csproj
+++ b/GitTfs/GitTfs.csproj
@@ -51,6 +51,7 @@
     <CodeAnalysisIgnoreBuiltInRuleSets>true</CodeAnalysisIgnoreBuiltInRuleSets>
     <CodeAnalysisIgnoreBuiltInRules>true</CodeAnalysisIgnoreBuiltInRules>
     <CodeAnalysisFailOnMissingRules>false</CodeAnalysisFailOnMissingRules>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <OutputPath>bin\Release\</OutputPath>
@@ -64,6 +65,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisIgnoreBuiltInRuleSets>true</CodeAnalysisIgnoreBuiltInRuleSets>
     <CodeAnalysisIgnoreBuiltInRules>true</CodeAnalysisIgnoreBuiltInRules>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -261,7 +263,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\lib\libgit2sharp\LibGit2Sharp\LibGit2Sharp.csproj">
-      <Project>{EE6ED99F-CB12-4683-B055-D28FC7357A34}</Project>
+      <Project>{ee6ed99f-cb12-4683-b055-d28fc7357a34}</Project>
       <Name>LibGit2Sharp</Name>
     </ProjectReference>
   </ItemGroup>

--- a/GitTfs/GitTfsConstants.cs
+++ b/GitTfs/GitTfsConstants.cs
@@ -69,5 +69,7 @@ namespace Sep.Git.Tfs
         public const string IgnoreNotInitBranches = GitTfsPrefix + ".ignore-not-init-branches";
 
         public const string BatchSize = GitTfsPrefix + ".batch-size";
+
+        public const string SkipChangeSets = GitTfsPrefix + ".skip-changesets";
     }
 }


### PR DESCRIPTION
I am currently am migrating a large TFS repository to GIT (resulting .git is ~13 GB) and as part of this work I made some modifications to git-tfs:

* added up-to option to fetch command:
e.g.
git tfs pull -t 10

This will pull only up to changeset C10.
Note: This allows to get changes in chunks. So these pulls can be reviewed, etc.


* added .skip-changesets to git-tfs configuration (comma delimited list of changeset numbers to skip over)

git config --add git-tfs.skip-changesets "45079,45080"

any further fetch/pull/clone etc. will skip over changeset C45079 and C45080.

I needed this, as we had some bad changesets, where a manager had renamed the complete root path and then undoing this change. This was done in SourceSafe, which then later got ported to TFS. This migration turned this change into two changesets. The first one deleting the complete source tree and the 2nd one re-adding it all. Having this pointless change in the history meant that any "annotate/blame" would stop at that changeset.


* added exception to TfsChangeset.Update if the expected files cannot be found (because of bad pull from TFS)

The connection to TFS can go down at times (temorarily) and cause a bad checkout. This then resulted in the original git-tfs skipping those files it couldn't find in the checkout folder. I have modified this to report and error and stop the import at this point, so the user can intervene.

