### PR TITLE
bugfix

### DIFF
--- a/GitTfs/Core/GitTfsRemote.cs
+++ b/GitTfs/Core/GitTfsRemote.cs
@@ -443,16 +443,10 @@ namespace Sep.Git.Tfs.Core
         {
             if (ExportMetadatas)
             {
-                if (changeset.Summary.Workitems.Any())
-                {
-                    log.Log += "\nwork-items: " + string.Join(", ", changeset.Summary.Workitems.Select(wi => "#" + wi.Id)); ;
-                }
-
-                if (ExportWorkitemsMapping.Count != 0)
-                {
-                    foreach (var mapping in ExportWorkitemsMapping)
-                    {
-                        log.Log = log.Log.Replace("#" + mapping.Key, "#" + mapping.Value);
+                if (changeset.Summary.Workitems.Any()) {
+                    var workItemIds = TranslateWorkItems(changeset.Summary.Workitems.Select(wi => wi.Id.ToString()));
+                    if (workItemIds != null) {
+                        log.Log += "\nwork-items: " + string.Join(", ", workItemIds.Select(s => "#" + s));
                     }
                 }
 
@@ -511,6 +505,25 @@ namespace Sep.Git.Tfs.Core
             if (metadatas.Length != 0)
                 Repository.CreateNote(commitSha, metadatas.ToString(), log.AuthorName, log.AuthorEmail, log.Date);
             return commitSha;
+        }
+
+        private IEnumerable<string> TranslateWorkItems(IEnumerable<string> workItemsOriginal) {
+            if (ExportWorkitemsMapping.Count != 0) {
+                List<string> workItemsTranslated = new List<string>();
+                if (workItemsOriginal != null) {
+                    foreach (var oldWorkItemId in workItemsOriginal) {
+                        string translatedWorkItemId = null;
+                        if (oldWorkItemId != null && !ExportWorkitemsMapping.TryGetValue(oldWorkItemId, out translatedWorkItemId)) {
+                            translatedWorkItemId = oldWorkItemId;
+                        }
+                        if (translatedWorkItemId != null) {
+                            workItemsTranslated.Add(translatedWorkItemId);
+                        }
+                    }
+                }
+                workItemsOriginal = workItemsTranslated;
+            }
+            return workItemsOriginal;
         }
 
         private string FindRootRemoteAndFetch(int parentChangesetId)


### PR DESCRIPTION
- workitems could be translated to a new Id and then this new Id could be translated again and again
- furthermore only initial substring of "#" + Id.ToString() could be translated in the case that Id.ToString() had different lengths