### PR TITLE
when URIs contain spaces or special characters, TFS escape them while ge...

### DIFF
--- a/GitTfs.VsCommon/TfsHelper.Common.cs
+++ b/GitTfs.VsCommon/TfsHelper.Common.cs
@@ -73,7 +73,8 @@ namespace Sep.Git.Tfs.VsCommon
                 {
                     // maybe it is not an Uri but instance name
                     var servers = RegisteredTfsConnections.GetConfigurationServers();
-                    var registered = servers.FirstOrDefault(s => String.Compare(s.Name, Url, StringComparison.OrdinalIgnoreCase) == 0);
+                    var registered = servers.FirstOrDefault(s => ((String.Compare(s.Name, Url, StringComparison.OrdinalIgnoreCase) == 0) ||
+                                                                  (String.Compare(s.Name, Uri.EscapeDataString(Url), StringComparison.OrdinalIgnoreCase) == 0)));
                     if (registered == null)
                         throw new GitTfsException("Given tfs name is not correct URI and not found as a registered TFS instance");
                     uri = registered.Uri;


### PR DESCRIPTION
when URIs contain spaces or special characters, TFS escape them while generating URI. For an help to end user HelperBase can check for escaped chars

For example in my environment my collection was named : "GSX Products" and URI generated by TFS was "GSX%20Products".