### PR TITLE
Fix changesets returned by TfsHelperFake

### DIFF
--- a/GitTfs.VsFake/TfsHelper.VsFake.cs
+++ b/GitTfs.VsFake/TfsHelper.VsFake.cs
@@ -77,8 +77,9 @@ namespace Sep.Git.Tfs.VsFake
         {
             if (!_script.Changesets.Any(c => c.IsBranchChangeset) && _script.Changesets.Any(c => c.IsMergeChangeset))
                 return _script.Changesets.Where(x => x.Id >= startVersion).Select(x => BuildTfsChangeset(x, remote));
+            var branchPath = path + "/";
             return _script.Changesets
-                .Where(x => x.Id >= startVersion && x.Changes.Any(c => c.RepositoryPath.ToLower().IndexOf(path.ToLower()) == 0 || path.ToLower().IndexOf(c.RepositoryPath.ToLower()) == 0))
+                .Where(x => x.Id >= startVersion && x.Changes.Any(c => c.RepositoryPath.IndexOf(branchPath, StringComparison.CurrentCultureIgnoreCase) == 0 || branchPath.IndexOf(c.RepositoryPath, StringComparison.CurrentCultureIgnoreCase) == 0))
                 .Select(x => BuildTfsChangeset(x, remote));
         }
 


### PR DESCRIPTION
when one branch name is contained in the name of one other