### PR TITLE
Add retry for MappingConflictException

### DIFF
--- a/GitTfs.VsCommon/Retry.cs
+++ b/GitTfs.VsCommon/Retry.cs
@@ -36,17 +36,17 @@ namespace Sep.Git.Tfs.VsCommon
                 {
                     return action();
                 }
-                catch (Microsoft.TeamFoundation.TeamFoundationServiceUnavailableException ex)
-                {
-                    exceptions.Add(ex);
-                    Thread.Sleep(retryInterval);
-                }
-                catch (Microsoft.TeamFoundation.Framework.Client.DatabaseOperationTimeoutException ex)
+                catch (Microsoft.TeamFoundation.TeamFoundationServerException ex)
                 {
                     exceptions.Add(ex);
                     Thread.Sleep(retryInterval);
                 }
                 catch (System.Net.WebException ex)
+                {
+                    exceptions.Add(ex);
+                    Thread.Sleep(retryInterval);
+                }
+                catch (GitTfsException ex) // allows continue of catch (MappingConflictException e) throw as innerexception
                 {
                     exceptions.Add(ex);
                     Thread.Sleep(retryInterval);

--- a/GitTfs.VsCommon/TfsHelper.Common.cs
+++ b/GitTfs.VsCommon/TfsHelper.Common.cs
@@ -618,8 +618,7 @@ namespace Sep.Git.Tfs.VsCommon
             if (!_workspaces.TryGetValue(remote.Id, out workspace))
             {
                 Trace.WriteLine("Setting up a TFS workspace with subtrees at " + localDirectory);
-                var folders = mappings.Select(x => new WorkingFolder(x.Item1, Path.Combine(localDirectory, x.Item2))).ToArray();
-                _workspaces.Add(remote.Id, workspace = Retry.Do(() => GetWorkspace(folders)));
+                _workspaces.Add(remote.Id, workspace = Retry.Do(() => GetWorkspace(mappings.Select(x => new WorkingFolder(x.Item1, Path.Combine(localDirectory, x.Item2))).ToArray())));
                 Janitor.CleanThisUpWhenWeClose(() => TryToDeleteWorkspace(workspace));
             }
             var tfsWorkspace = _container.With("localDirectory").EqualTo(localDirectory)

--- a/GitTfs.VsCommon/TfsHelper.Common.cs
+++ b/GitTfs.VsCommon/TfsHelper.Common.cs
@@ -618,7 +618,12 @@ namespace Sep.Git.Tfs.VsCommon
             if (!_workspaces.TryGetValue(remote.Id, out workspace))
             {
                 Trace.WriteLine("Setting up a TFS workspace with subtrees at " + localDirectory);
-                _workspaces.Add(remote.Id, workspace = Retry.Do(() => GetWorkspace(mappings.Select(x => new WorkingFolder(x.Item1, Path.Combine(localDirectory, x.Item2))).ToArray())));
+                var mappingsAsList = mappings as ICollection<Tuple<string, string>> ?? mappings.ToList();
+                _workspaces.Add(remote.Id, workspace = Retry.Do(() =>
+                {
+                    var workingFolders = mappingsAsList.Select(x => new WorkingFolder(x.Item1, Path.Combine(localDirectory, x.Item2)));
+                    return GetWorkspace(workingFolders.ToArray());
+                }));
                 Janitor.CleanThisUpWhenWeClose(() => TryToDeleteWorkspace(workspace));
             }
             var tfsWorkspace = _container.With("localDirectory").EqualTo(localDirectory)


### PR DESCRIPTION
 * Fixes Issue #570
 * Hacky catch of GitTfsException to retry on MappingConflictException
 * Catch more general TeamFoundationServerException
 * Additionally guards creating workspaces in a retry block