### PR TITLE
Prevent failure while cloning if a user no longer exists in Active Direc...

### DIFF
--- a/GitTfs/Core/TfsChangeset.cs
+++ b/GitTfs/Core/TfsChangeset.cs
@@ -156,7 +156,14 @@ namespace Sep.Git.Tfs.Core
 
         private LogEntry MakeNewLogEntry(IChangeset changesetToLog, IGitTfsRemote remote = null)
         {
-            var identity = _tfs.GetIdentity(changesetToLog.Committer);
+            IIdentity identity = null;
+            try
+            {
+                identity = _tfs.GetIdentity(changesetToLog.Committer);
+            }
+            catch
+            {
+            } 
             var name = changesetToLog.Committer;
             var email = changesetToLog.Committer;
             if (_authors != null && _authors.Authors.ContainsKey(changesetToLog.Committer))


### PR DESCRIPTION
This is a fix for issue #738 (related to #735).
Apparently if an Active Directory user has been deleted then The TFS API ReadIdentity throws a SoapException. This fix simply wraps the call to GetIdentity in a try/catch to prevent the cloning from terminating.