### PR TITLE
Added two checkin options: ignore-missing-files and add-missing-files.

### DIFF
--- a/GitTfs/Commands/CheckinOptions.cs
+++ b/GitTfs/Commands/CheckinOptions.cs
@@ -36,6 +36,10 @@ namespace Sep.Git.Tfs.Commands
                     { "no-gate", "Disables gated checkin.",
                         v => { OverrideGatedCheckIn = true; } },
                     { "author=", "TFS User ID to check in on behalf of", var => AuthorTfsUserId = var },
+                    { "ignore-missing-files", "When applying an edit operation, ignores items that were expected to already be in TFS but were not found. Missing files indicates bad synchronization at some point. Use this option with care.",
+                        v => IgnoreMissingItems = v != null },
+                    { "add-missing-files", "When applying an edit operation, add items that were expected to already be in TFS but were not found. Missing files indicates bad synchronization at some point. Use this option with care. This option is ignored if ignore-missing-files option is used.",
+                        v => AddMissingItems = v != null },
                 };
             }
         }
@@ -57,6 +61,8 @@ namespace Sep.Git.Tfs.Commands
 
         public string AuthorTfsUserId { get; set; }
         public Regex WorkItemAssociateRegex { get; set; }
+        public bool IgnoreMissingItems { get; set; }
+        public bool AddMissingItems { get; set; }
 
     }
 }

--- a/GitTfs/Core/TfsWorkspace.cs
+++ b/GitTfs/Core/TfsWorkspace.cs
@@ -153,8 +153,7 @@ namespace Sep.Git.Tfs.Core
                 {
                     _stdout.WriteLine("Warning: One item should have been edited, but actually edited " + edited + ". Ignoring item.");
                 }
-                else
-                if (edited == 0 && _checkinOptions.AddMissingItems)
+                else if (edited == 0 && _checkinOptions.AddMissingItems)
                 {
                     _stdout.WriteLine("Warning: One item should have been edited, but was not found. Adding the file instead.");
                     Add(path);

--- a/GitTfs/Core/TfsWorkspace.cs
+++ b/GitTfs/Core/TfsWorkspace.cs
@@ -143,11 +143,27 @@ namespace Sep.Git.Tfs.Core
 
         public void Edit(string path)
         {
-            path = GetLocalPath(path);
-            _stdout.WriteLine(" edit " + path);
-            GetFromTfs(path);
-            var edited = _workspace.PendEdit(path);
-            if (edited != 1) throw new Exception("One item should have been edited, but actually edited " + edited + " items.");
+            var localPath = GetLocalPath(path);
+            _stdout.WriteLine(" edit " + localPath);
+            GetFromTfs(localPath);
+            var edited = _workspace.PendEdit(localPath);
+            if (edited != 1)
+            {
+                if (_checkinOptions.IgnoreMissingItems)
+                {
+                    _stdout.WriteLine("Warning: One item should have been edited, but actually edited " + edited + ". Ignoring item.");
+                }
+                else
+                if (edited == 0 && _checkinOptions.AddMissingItems)
+                {
+                    _stdout.WriteLine("Warning: One item should have been edited, but was not found. Adding the file instead.");
+                    Add(path);
+                }
+                else
+                {
+                    throw new Exception("One item should have been edited, but actually edited " + edited + " items.");
+                }
+            }
         }
 
         public void Delete(string path)


### PR DESCRIPTION
Added two checkin options: ignore-missing-files and add-missing-files.
This allows the user to repair lost files that were lost at some point in the synchronization history. 
Adding files that were supposed to be existing in TFS is of course a problem, but this is an observed problem and in some cases this may be an acceptable patch.