### PR TITLE
Fix bare repository fetching

### DIFF
--- a/GitTfs/Commands/Fetch.cs
+++ b/GitTfs/Commands/Fetch.cs
@@ -125,13 +125,13 @@ namespace Sep.Git.Tfs.Commands
         protected virtual void DoFetch(IGitTfsRemote remote, bool stopOnFailMergeCommit)
         {
             var bareBranch = string.IsNullOrEmpty(BareBranch) ? remote.Id : BareBranch;
-            if (remote.Repository.IsBare)
+            if (!ForceFetch &&
+                remote.Repository.IsBare &&
+                remote.Repository.HasRef(GitRepository.ShortToLocalName(bareBranch)) &&
+                remote.MaxCommitHash != remote.Repository.GetCommit(bareBranch).Sha)
             {
-                if (!remote.Repository.HasRef(GitRepository.ShortToLocalName(bareBranch)))
-                    throw new GitTfsException("error : the specified git branch doesn't exist...");
-                if (!ForceFetch && remote.MaxCommitHash != remote.Repository.GetCommit(bareBranch).Sha)
-                    throw new GitTfsException("error : fetch is not allowed when there is ahead commits!",
-                        new [] {"Remove ahead commits and retry", "use the --force option (ahead commits will be lost!)"});
+                throw new GitTfsException("error : fetch is not allowed when there is ahead commits!",
+                    new[] {"Remove ahead commits and retry", "use the --force option (ahead commits will be lost!)"});
             }
 
             // It is possible that we have outdated refs/remotes/tfs/<id>.

--- a/GitTfs/Commands/Fetch.cs
+++ b/GitTfs/Commands/Fetch.cs
@@ -124,15 +124,14 @@ namespace Sep.Git.Tfs.Commands
 
         protected virtual void DoFetch(IGitTfsRemote remote, bool stopOnFailMergeCommit)
         {
+            var bareBranch = string.IsNullOrEmpty(BareBranch) ? remote.Id : BareBranch;
             if (remote.Repository.IsBare)
             {
-                if(string.IsNullOrEmpty(BareBranch))
-                    throw new GitTfsException("error : specify a git branch to fetch on...");
-                if (!remote.Repository.HasRef(GitRepository.ShortToLocalName(BareBranch)))
+                if (!remote.Repository.HasRef(GitRepository.ShortToLocalName(bareBranch)))
                     throw new GitTfsException("error : the specified git branch doesn't exist...");
-                if (!ForceFetch && remote.MaxCommitHash != remote.Repository.GetCommit(BareBranch).Sha)
+                if (!ForceFetch && remote.MaxCommitHash != remote.Repository.GetCommit(bareBranch).Sha)
                     throw new GitTfsException("error : fetch is not allowed when there is ahead commits!",
-                        new List<string>() {"Remove ahead commits and retry", "use the --force option (ahead commits will be lost!)"});
+                        new [] {"Remove ahead commits and retry", "use the --force option (ahead commits will be lost!)"});
             }
 
             // It is possible that we have outdated refs/remotes/tfs/<id>.
@@ -202,7 +201,7 @@ namespace Sep.Git.Tfs.Commands
                 remote.CleanupWorkspaceDirectory();
 
                 if (remote.Repository.IsBare)
-                    remote.Repository.UpdateRef(GitRepository.ShortToLocalName(BareBranch), remote.MaxCommitHash);
+                    remote.Repository.UpdateRef(GitRepository.ShortToLocalName(bareBranch), remote.MaxCommitHash);
             }
         }
 

--- a/GitTfs/Core/GitRepository.cs
+++ b/GitTfs/Core/GitRepository.cs
@@ -272,8 +272,13 @@ namespace Sep.Git.Tfs.Core
 
         public void MoveTfsRefForwardIfNeeded(IGitTfsRemote remote)
         {
+            MoveTfsRefForwardIfNeeded(remote, "HEAD");
+        }
+
+        public void MoveTfsRefForwardIfNeeded(IGitTfsRemote remote, string @ref)
+        {
             long currentMaxChangesetId = remote.MaxChangesetId;
-            var untrackedTfsChangesets = from cs in GetLastParentTfsCommits("HEAD")
+            var untrackedTfsChangesets = from cs in GetLastParentTfsCommits(@ref)
                                          where cs.Remote.Id == remote.Id && cs.ChangesetId > currentMaxChangesetId
                                          orderby cs.ChangesetId
                                          select cs;

--- a/GitTfs/Core/IGitRepository.cs
+++ b/GitTfs/Core/IGitRepository.cs
@@ -22,6 +22,7 @@ namespace Sep.Git.Tfs.Core
         GitCommit Commit(LogEntry logEntry);
         void UpdateRef(string gitRefName, string commitSha, string message = null);
         void MoveTfsRefForwardIfNeeded(IGitTfsRemote remote);
+        void MoveTfsRefForwardIfNeeded(IGitTfsRemote remote, string @ref);
         IEnumerable<TfsChangesetInfo> GetLastParentTfsCommits(string head);
         TfsChangesetInfo GetTfsChangesetById(string remoteRef, long changesetId);
         TfsChangesetInfo GetTfsCommit(GitCommit commit);

--- a/GitTfs/Core/TfsWorkspace.cs
+++ b/GitTfs/Core/TfsWorkspace.cs
@@ -26,7 +26,7 @@ namespace Sep.Git.Tfs.Core
             _contextVersion = contextVersion;
             _checkinOptions = checkinOptions;
             _tfsHelper = tfsHelper;
-            _localDirectory = localDirectory;
+            _localDirectory = remote.Repository.IsBare ? Path.GetFullPath(localDirectory) : localDirectory;
             _stdout = stdout;
 
             this.Remote = remote;

--- a/GitTfsTest/Core/TfsWorkspaceTests.cs
+++ b/GitTfsTest/Core/TfsWorkspaceTests.cs
@@ -19,6 +19,7 @@ namespace Sep.Git.Tfs.Test.Core
             TextWriter writer = new StringWriter();
             TfsChangesetInfo contextVersion = MockRepository.GenerateStub<TfsChangesetInfo>();
             IGitTfsRemote remote = MockRepository.GenerateStub<IGitTfsRemote>();
+            remote.Repository = MockRepository.GenerateStub<IGitRepository>();
             CheckinOptions checkinOptions = new CheckinOptions();
             ITfsHelper tfsHelper = MockRepository.GenerateStub<ITfsHelper>();
             CheckinPolicyEvaluator policyEvaluator = new CheckinPolicyEvaluator();
@@ -43,6 +44,7 @@ namespace Sep.Git.Tfs.Test.Core
             TextWriter writer = new StringWriter();
             TfsChangesetInfo contextVersion = MockRepository.GenerateStub<TfsChangesetInfo>();
             IGitTfsRemote remote = MockRepository.GenerateStub<IGitTfsRemote>();
+            remote.Repository = MockRepository.GenerateStub<IGitRepository>();
             CheckinOptions checkinOptions = new CheckinOptions();
             ITfsHelper tfsHelper = MockRepository.GenerateStub<ITfsHelper>();
             CheckinPolicyEvaluator policyEvaluator = new CheckinPolicyEvaluator();
@@ -92,6 +94,7 @@ namespace Sep.Git.Tfs.Test.Core
             TextWriter writer = new StringWriter();
             TfsChangesetInfo contextVersion = MockRepository.GenerateStub<TfsChangesetInfo>();
             IGitTfsRemote remote = MockRepository.GenerateStub<IGitTfsRemote>();
+            remote.Repository = MockRepository.GenerateStub<IGitRepository>();
             CheckinOptions checkinOptions = new CheckinOptions();
             ITfsHelper tfsHelper = MockRepository.GenerateStub<ITfsHelper>();
             CheckinPolicyEvaluator policyEvaluator = new CheckinPolicyEvaluator();
@@ -143,6 +146,7 @@ namespace Sep.Git.Tfs.Test.Core
             TextWriter writer = new StringWriter();
             TfsChangesetInfo contextVersion = MockRepository.GenerateStub<TfsChangesetInfo>();
             IGitTfsRemote remote = MockRepository.GenerateStub<IGitTfsRemote>();
+            remote.Repository = MockRepository.GenerateStub<IGitRepository>();
             CheckinOptions checkinOptions = new CheckinOptions();
             ITfsHelper tfsHelper = MockRepository.GenerateStub<ITfsHelper>();
             CheckinPolicyEvaluator policyEvaluator = new CheckinPolicyEvaluator();
@@ -196,6 +200,7 @@ namespace Sep.Git.Tfs.Test.Core
             TextWriter writer = new StringWriter();
             TfsChangesetInfo contextVersion = MockRepository.GenerateStub<TfsChangesetInfo>();
             IGitTfsRemote remote = MockRepository.GenerateStub<IGitTfsRemote>();
+            remote.Repository = MockRepository.GenerateStub<IGitRepository>();
             CheckinOptions checkinOptions = new CheckinOptions();
             ITfsHelper tfsHelper = MockRepository.GenerateStub<ITfsHelper>();
             CheckinPolicyEvaluator policyEvaluator = new CheckinPolicyEvaluator();


### PR DESCRIPTION
Pull request summary

- Default `--bare-branch` to remote.Id, closes #744
- Do not throw exception if we are in a bare repository and we do not have target head, closes #704
- Update heads when we are fetching dependent remote, closes #743
- Make sure that workspace's local directory is a full path when work with bare repositories, re-fixes #285 