### PR TITLE
Added AppVeyor yaml configuration (for windows ci build)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,16 @@
+version: 1.0.{build}
+os: Windows Server 2012 R2
+configuration: Debug
+platform: Any CPU
+clone_folder: c:\gittfs
+init: []
+install:
+- git submodule init
+- git submodule update
+- cinst vs2010sdk -y
+- cinst tfs2010objectmodel -y
+build:
+  project: gittfs.sln
+  verbosity: minimal
+test:
+  assemblies: '**\*Test*.dll'


### PR DESCRIPTION
I've tried to make a Windows CI configuration for git-tfs on AppVeyor.com (only opensource CI hosting on Windows i knew about)

This makes it possible to use a Windows CI build instead (or in addition if you like) to the current TravisCi mono CI.

This runs on Windows servers, and uses chocolatey to install the required vs-sdk and TFS objectmodel.
This means that this runs the whole gittfs.sln and not just the CI.proj which seems to only build part of the solution, as the TFS dll's isn't available on linux/mono (as far as i understand?)

You can see an example of a build on my fork appveyor build page (https://ci.appveyor.com/project/TheoAndersen/git-tfs)

This could be a stepping stone to trying out tests actually using git and the tfs api's - but as is got pointed out in issue https://github.com/git-tfs/git-tfs/issues/763 (which i totally agree on) - it would need to be reliable and not too slow.

What do you guys think?