### PR TITLE
Update web site in release.proj

### DIFF
--- a/Release.proj
+++ b/Release.proj
@@ -145,11 +145,12 @@
 
   <!-- Internal: Update the "download" button on git-tfs.com -->
   <Target Name="UpdateWebSite" DependsOnTargets="VersionRequired; ClonePagesRepository">
-    <Exec WorkingDirectory="$(WebSiteDir)" Command="git checkout master" />
+    <Exec WorkingDirectory="$(WebSiteDir)" Command="git fetch" />
+    <Exec WorkingDirectory="$(WebSiteDir)" Command="git checkout -B v$(Version) origin/master" />
     <WriteLinesToFile File="$(WebSiteDir)/$(DownloadButton)" Lines="&lt;a href=%22$(DownloadUrl)%22 class=%22download-button%22&gt;Download v$(Version)&lt;/a&gt;" Overwrite="true" Encoding="ASCII"/>
     <!-- If the previous attempt was aborted, we might have already updated the button and this commit will be empty. -->
     <Exec WorkingDirectory="$(WebSiteDir)" Command="git commit -m %22v$(Version)%22 $(DownloadButton)" IgnoreExitCode="true" />
-    <Exec WorkingDirectory="$(WebSiteDir)" Command="git push $(WebSiteRepository) master" />
+    <Exec WorkingDirectory="$(WebSiteDir)" Command="git push $(WebSiteRepository) HEAD:refs/heads/master" />
   </Target>
 
   <!-- Internal. -->


### PR DESCRIPTION
Follow-up to #766. The one thing that didn't work was updating [the download button on the website](https://git-tfs.com/). The old code worked fine if `releases\git-tfs.github.com` wasn't cloned yet, but it failed if it needed to be fetched instead.