### PR TITLE
Fix for issue #771: Fixed incorrect call to VersionControlServer.QueryMerges().

### DIFF
--- a/GitTfs.VsCommon/TfsHelper.Common.cs
+++ b/GitTfs.VsCommon/TfsHelper.Common.cs
@@ -220,7 +220,8 @@ namespace Sep.Git.Tfs.VsCommon
         public virtual int FindMergeChangesetParent(string path, long targetChangeset, GitTfsRemote remote)
         {
             var targetVersion = new ChangesetVersionSpec((int)targetChangeset);
-            var mergeInfo = VersionControl.QueryMerges(null, null, path, targetVersion, targetVersion, targetVersion, RecursionType.Full);
+            var searchTo = targetVersion;
+            var mergeInfo = VersionControl.QueryMerges(null, null, path, targetVersion, null, searchTo, RecursionType.Full);
             if (mergeInfo.Length == 0) return -1;
             return mergeInfo.Max(x => x.SourceVersion);
         }

--- a/GitTfs.VsCommon/TfsHelper.Common.cs
+++ b/GitTfs.VsCommon/TfsHelper.Common.cs
@@ -41,6 +41,7 @@ namespace Sep.Git.Tfs.VsCommon
                 _resolverInstalled = true;
             }
         }
+        
         [SetterProperty]
         public Janitor Janitor { get; set; }
 


### PR DESCRIPTION
Fix for #771. I added an extra variable (searchTo) because it makes intent much clearer.

Fixed incorrect call to VersionControlServer.QueryMerges(). Now searches for merges from the beginning of time instead of from the current version. See MSDN API documents for more details: https://msdn.microsoft.com/en-us/library/bb138969.aspx