### PR TITLE
Chocolatey: Remove dependency to the deprecated git package

### DIFF
--- a/ChocolateyTemplates/gittfs.nuspec
+++ b/ChocolateyTemplates/gittfs.nuspec
@@ -16,7 +16,7 @@ ${ReleaseNotesContents}
     <licenseUrl>https://github.com/git-tfs/git-tfs/blob/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <dependencies>
-      <dependency id="msysgit" />
+      <dependency id="git" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
Use https://chocolatey.org/packages/git
instead of https://chocolatey.org/packages/msysgit