### PR TITLE
Add a "dry run" mode to the release process

### DIFF
--- a/Release.proj
+++ b/Release.proj
@@ -140,7 +140,6 @@
 
   <!-- Internal: Called by Release to create the zip. -->
   <Target Name="Package" DependsOnTargets="VersionRequired; MSBuildCommunityTasks; DefineReleaseFiles">
-    <Message Text="@(ReleaseFiles)" />
     <Zip Files="@(ReleaseFiles)" ZipFileName="$(Archive)" WorkingDirectory="$(BuildDir)" />
   </Target>
 

--- a/Release.proj
+++ b/Release.proj
@@ -114,7 +114,7 @@
   </Target>
 
   <!-- Internal. -->
-  <Target Name="UpdateVersionInReadme" DependsOnTargets="VersionRequired">
+  <Target Name="UpdateVersionInReadme" DependsOnTargets="VersionRequired; MSBuildCommunityTasks">
     <FileUpdate Files="README.md" Regex="The most recent version is __.*__\." ReplacementText="The most recent version is __$(Version)__." />
   </Target>
 

--- a/Release.proj
+++ b/Release.proj
@@ -34,6 +34,8 @@
     <WebSiteDir>$(PackagedDir)/git-tfs.github.com</WebSiteDir>
     <DownloadButton>_includes/download_button.html</DownloadButton>
     <WebSiteRepository>https://github.com/$(GitHubOwner)/git-tfs.github.com.git</WebSiteRepository>
+
+    <DryRun Condition="'$(DryRun)' == ''">True</DryRun>
   </PropertyGroup>
 
   <!-- Internal. -->
@@ -129,8 +131,8 @@
   <!-- Internal: Called by Release to push the release tag to github.com -->
   <Target Name="PushSource" DependsOnTargets="VersionRequired">
     <!-- Do these separately so that the push to master blocks the push of the tag. -->
-    <Exec Command="git push $(OriginUrl) HEAD:refs/heads/master" />
-    <Exec Command="git push $(OriginUrl) v$(Version)" />
+    <Exec Condition="'$(DryRun)' == 'False'" Command="git push $(OriginUrl) HEAD:refs/heads/master" />
+    <Exec Condition="'$(DryRun)' == 'False'" Command="git push $(OriginUrl) v$(Version)" />
   </Target>
 
   <!-- Internal: Called by Release to create the zip. -->
@@ -140,7 +142,7 @@
 
   <!-- Internal: Create a release on github.com -->
   <Target Name="ReleaseOnGitHub" DependsOnTargets="VersionRequired; AuthTokenRequired; MSBuildCommunityTasks">
-    <CreateRelease Repository="$(GitHubOwner)/$(GitHubRepository)" TagName="v$(Version)" Files="@(ArchiveFile)" OauthToken="$(GitHubAuthToken)" ReleaseNotesFile="$(ReleaseNotes)" />
+    <CreateRelease Condition="'$(DryRun)' == 'False'" Repository="$(GitHubOwner)/$(GitHubRepository)" TagName="v$(Version)" Files="@(ArchiveFile)" OauthToken="$(GitHubAuthToken)" ReleaseNotesFile="$(ReleaseNotes)" />
   </Target>
 
   <!-- Internal: Update the "download" button on git-tfs.com -->
@@ -150,7 +152,7 @@
     <WriteLinesToFile File="$(WebSiteDir)/$(DownloadButton)" Lines="&lt;a href=%22$(DownloadUrl)%22 class=%22download-button%22&gt;Download v$(Version)&lt;/a&gt;" Overwrite="true" Encoding="ASCII"/>
     <!-- If the previous attempt was aborted, we might have already updated the button and this commit will be empty. -->
     <Exec WorkingDirectory="$(WebSiteDir)" Command="git commit -m %22v$(Version)%22 $(DownloadButton)" IgnoreExitCode="true" />
-    <Exec WorkingDirectory="$(WebSiteDir)" Command="git push $(WebSiteRepository) HEAD:refs/heads/master" />
+    <Exec Condition="'$(DryRun)' == 'False'" WorkingDirectory="$(WebSiteDir)" Command="git push $(WebSiteRepository) HEAD:refs/heads/master" />
   </Target>
 
   <!-- Internal. -->
@@ -230,6 +232,6 @@
 
   <!-- Internal. -->
   <Target Name="PushChocolateyPackage" DependsOnTargets="BuildChocolateyPackage">
-    <Exec Command="cpush $(ChocolateyNupkg)" />
+    <Exec Condition="'$(DryRun)' == 'False'" Command="cpush $(ChocolateyNupkg)" />
   </Target>
 </Project>

--- a/Release.proj
+++ b/Release.proj
@@ -133,6 +133,7 @@
     <!-- Do these separately so that the push to master blocks the push of the tag. -->
     <Exec Condition="'$(DryRun)' == 'False'" Command="git push $(OriginUrl) HEAD:refs/heads/master" />
     <Exec Condition="'$(DryRun)' == 'False'" Command="git push $(OriginUrl) v$(Version)" />
+    <Message Condition="'$(DryRun)' != 'False'" Text="(would push to github.com)" />
   </Target>
 
   <!-- Internal: Called by Release to create the zip. -->
@@ -143,6 +144,7 @@
   <!-- Internal: Create a release on github.com -->
   <Target Name="ReleaseOnGitHub" DependsOnTargets="VersionRequired; AuthTokenRequired; MSBuildCommunityTasks">
     <CreateRelease Condition="'$(DryRun)' == 'False'" Repository="$(GitHubOwner)/$(GitHubRepository)" TagName="v$(Version)" Files="@(ArchiveFile)" OauthToken="$(GitHubAuthToken)" ReleaseNotesFile="$(ReleaseNotes)" />
+    <Message Condition="'$(DryRun)' != 'False'" Text="(would create release on github.com)" />
   </Target>
 
   <!-- Internal: Update the "download" button on git-tfs.com -->
@@ -153,6 +155,7 @@
     <!-- If the previous attempt was aborted, we might have already updated the button and this commit will be empty. -->
     <Exec WorkingDirectory="$(WebSiteDir)" Command="git commit -m %22v$(Version)%22 $(DownloadButton)" IgnoreExitCode="true" />
     <Exec Condition="'$(DryRun)' == 'False'" WorkingDirectory="$(WebSiteDir)" Command="git push $(WebSiteRepository) HEAD:refs/heads/master" />
+    <Message Condition="'$(DryRun)' != 'False'" Text="(would push pages site to github.com)" />
   </Target>
 
   <!-- Internal. -->
@@ -233,5 +236,6 @@
   <!-- Internal. -->
   <Target Name="PushChocolateyPackage" DependsOnTargets="BuildChocolateyPackage">
     <Exec Condition="'$(DryRun)' == 'False'" Command="cpush $(ChocolateyNupkg)" />
+    <Message Condition="'$(DryRun)' != 'False'" Text="(would push chocolatey package)" />
   </Target>
 </Project>

--- a/Release.proj
+++ b/Release.proj
@@ -52,15 +52,17 @@
   </Target>
 
   <!-- The contents of the zip. -->
-  <ItemGroup>
-    <ReleaseFiles Include="$(SolutionDir)\README.md" />
-    <ReleaseFiles Include="$(SolutionDir)\LICENSE" />
-    <ReleaseFiles Include="$(SolutionDir)\NOTICE" />
-    <ReleaseFiles Include="$(BuildDir)\git-tfs.exe" />
-    <ReleaseFiles Include="$(BuildDir)\*.config" />
-    <ReleaseFiles Include="$(BuildDir)\*.dll" Exclude="$(BuildDir)\Microsoft.*.dll" />
-    <ReleaseFiles Include="$(BuildDir)\NativeBinaries\**\*.dll" />
-  </ItemGroup>
+  <Target Name="DefineReleaseFiles">
+    <ItemGroup>
+      <ReleaseFiles Include="$(SolutionDir)\README.md" />
+      <ReleaseFiles Include="$(SolutionDir)\LICENSE" />
+      <ReleaseFiles Include="$(SolutionDir)\NOTICE" />
+      <ReleaseFiles Include="$(BuildDir)\git-tfs.exe" />
+      <ReleaseFiles Include="$(BuildDir)\*.config" />
+      <ReleaseFiles Include="$(BuildDir)\*.dll" Exclude="$(BuildDir)\Microsoft.*.dll" />
+      <ReleaseFiles Include="$(BuildDir)\NativeBinaries\**\*.dll" />
+    </ItemGroup>
+  </Target>
 
   <!-- The zip. -->
   <ItemGroup>
@@ -137,7 +139,8 @@
   </Target>
 
   <!-- Internal: Called by Release to create the zip. -->
-  <Target Name="Package" DependsOnTargets="VersionRequired; MSBuildCommunityTasks">
+  <Target Name="Package" DependsOnTargets="VersionRequired; MSBuildCommunityTasks; DefineReleaseFiles">
+    <Message Text="@(ReleaseFiles)" />
     <Zip Files="@(ReleaseFiles)" ZipFileName="$(Archive)" WorkingDirectory="$(BuildDir)" />
   </Target>
 

--- a/Releasing.md
+++ b/Releasing.md
@@ -13,8 +13,14 @@ Normally, you should do this:
 
 2. Set the auth.targets file with with your OAuth token (see auth.targets.example)
 
-3. Build the release and include the version (e.g. X.Y.Z) and the name of a changelog file (optional).
+3. Do a dry run of the release. Include the version (e.g. X.Y.Z) and the name of a changelog file (optional).
 
 ```
 > msbuild Release.proj /t:Release /p:Version=X.Y.Z
+```
+
+4. Build the release. Include the version (e.g. X.Y.Z) and the name of a changelog file (optional).
+
+```
+> msbuild Release.proj /t:Release /p:Version=X.Y.Z;DryRun=False
 ```

--- a/Releasing.md
+++ b/Releasing.md
@@ -11,15 +11,21 @@ Normally, you should do this:
 > git status
 ```
 
-2. Set the auth.targets file with with your OAuth token (see auth.targets.example)
+2. Restore submodules
 
-3. Do a dry run of the release. Include the version (e.g. X.Y.Z) and the name of a changelog file (optional).
+```
+> git submodule update --init --recursive
+```
+
+3. Set the auth.targets file with with your OAuth token (see auth.targets.example)
+
+4. Do a dry run of the release. Include the version (e.g. X.Y.Z) and the name of a changelog file (optional).
 
 ```
 > msbuild Release.proj /t:Release /p:Version=X.Y.Z
 ```
 
-4. Build the release. Include the version (e.g. X.Y.Z) and the name of a changelog file (optional).
+5. Build the release. Include the version (e.g. X.Y.Z) and the name of a changelog file (optional).
 
 ```
 > msbuild Release.proj /t:Release /p:Version=X.Y.Z;DryRun=False


### PR DESCRIPTION
"Dry run" means that all non-local changes are not run. This includes tagging on github.com, creating the release on the github project, updating the website, and pushing to chocolatey. "Dry run" is the new default mode in `Release.proj`.

Once this is merged to master, I'll merge it with #757 and make sure that everything's looking good there.

cc @pmiossec @allansson