### PR TITLE
replace irc with slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,8 @@ If you have questions or suggestions about how we could improve git-tfs you coul
 
 ## Community
 
-`#git-tfs` on FreeNode, and the [mailing list](https://groups.google.com/group/git-tfs-dev)
+Drop in and chat in [slack](https://gittfs.slack.com/). (For an invite, email `spraints at gmail.com`.)
+We also have a [mailing list](https://groups.google.com/group/git-tfs-dev).
 
 Thanks to [jetbrains](http://www.jetbrains.com/teamcity)
 ([teamcity](http://teamcity.codebetter.com/project.html?projectId=project256))


### PR DESCRIPTION
My irc thing is busted, so i haven't logged in in forever. slack looks like a pretty nice alternative, and has some kind of bridge to irc, not that anyone actually cares if it's in IRC.