### PR TITLE
Initialize a branch when not finding the root commit in the repository

### DIFF
--- a/GitTfs/Commands/Fetch.cs
+++ b/GitTfs/Commands/Fetch.cs
@@ -187,6 +187,8 @@ namespace Sep.Git.Tfs.Commands
             {
                 if (InitialChangeset.HasValue)
                 {
+                    properties.InitialChangeset = InitialChangeset.Value;
+                    properties.PersistAllOverrides();
                     remote.QuickFetch(InitialChangeset.Value);
                     remote.Fetch(stopOnFailMergeCommit);
                 }

--- a/GitTfs/Commands/QuickFetch.cs
+++ b/GitTfs/Commands/QuickFetch.cs
@@ -16,9 +16,11 @@ namespace Sep.Git.Tfs.Commands
     //  2. Load the correct set of extant casing.
     public class QuickFetch : Fetch
     {
+        private ConfigProperties _properties;
         public QuickFetch(Globals globals, ConfigProperties properties, TextWriter stdout, RemoteOptions remoteOptions, AuthorsFile authors)
             : base(globals, properties, stdout, remoteOptions, authors, null)
         {
+            _properties = properties;
         }
 
         protected override void DoFetch(IGitTfsRemote remote, bool stopOnFailMergeCommit)
@@ -27,6 +29,8 @@ namespace Sep.Git.Tfs.Commands
                 remote.QuickFetch(InitialChangeset.Value);
             else
                 remote.QuickFetch();
+            _properties.InitialChangeset = remote.MaxChangesetId;
+            _properties.PersistAllOverrides();
         }
     }
 }

--- a/GitTfs/ConfigProperties.cs
+++ b/GitTfs/ConfigProperties.cs
@@ -27,8 +27,15 @@ namespace Sep.Git.Tfs
 
         public long? InitialChangeset
         {
-            set { _loader.Override(GitTfsConstants.InitialChangeset, value); }
-            get { return _loader.Get<long?>(GitTfsConstants.InitialChangeset, null); }
+            set
+            {
+                _loader.Override(GitTfsConstants.InitialChangeset, value ?? -1);
+            }
+            get
+            {
+                long? initialChangeset = _loader.Get<long>(GitTfsConstants.InitialChangeset, -1);
+                return initialChangeset == -1 ? null : initialChangeset;
+            }
         }
 
     }

--- a/GitTfs/ConfigProperties.cs
+++ b/GitTfs/ConfigProperties.cs
@@ -24,5 +24,12 @@ namespace Sep.Git.Tfs
             set { _loader.Override(GitTfsConstants.BatchSize, value); }
             get { return _loader.Get(GitTfsConstants.BatchSize, 100); }
         }
+
+        public long? InitialChangeset
+        {
+            set { _loader.Override(GitTfsConstants.InitialChangeset, value); }
+            get { return _loader.Get<long?>(GitTfsConstants.InitialChangeset, null); }
+        }
+
     }
 }

--- a/GitTfs/Core/GitTfsRemote.cs
+++ b/GitTfs/Core/GitTfsRemote.cs
@@ -619,8 +619,9 @@ namespace Sep.Git.Tfs.Core
                 remote = InitBranch(this.remoteOptions, tfsBranch.Path, rootChangesetId, true);
                 if (remote == null)
                 {
-                    stdout.WriteLine("error: root commit not found corresponding to changeset " + rootChangesetId);
-                    return null;
+                    stdout.WriteLine("warning: root commit not found corresponding to changeset " + rootChangesetId);
+                    stdout.WriteLine("=> continuing anyway by creating a branch without parent...");
+                    return InitTfsBranch(this.remoteOptions, tfsBranch.Path);
                 }
 
                 if (branch.IsRenamedBranch)

--- a/GitTfs/GitTfsConstants.cs
+++ b/GitTfs/GitTfsConstants.cs
@@ -69,5 +69,6 @@ namespace Sep.Git.Tfs
         public const string IgnoreNotInitBranches = GitTfsPrefix + ".ignore-not-init-branches";
 
         public const string BatchSize = GitTfsPrefix + ".batch-size";
+        public static string InitialChangeset = GitTfsPrefix + ".initial-changeset";
     }
 }

--- a/GitTfsTest/Core/GlobalsTests.cs
+++ b/GitTfsTest/Core/GlobalsTests.cs
@@ -34,7 +34,7 @@ namespace Sep.Git.Tfs.Test.Core
                            new TfsChangesetInfo()
                                {
                                    ChangesetId = 34,
-                                   Remote = new GitTfsRemote(new RemoteInfo() {Id = "myRemote"}, gitRepoMock, new RemoteOptions(), globals, mocker.Get<ITfsHelper>(), new StringWriter())
+                                   Remote = new GitTfsRemote(new RemoteInfo() {Id = "myRemote"}, gitRepoMock, new RemoteOptions(), globals, mocker.Get<ITfsHelper>(), new StringWriter(), new ConfigProperties(null))
                                }
                        });
             Assert.Equal("myRemote", globals.RemoteId);
@@ -52,12 +52,12 @@ namespace Sep.Git.Tfs.Test.Core
                            new TfsChangesetInfo()
                                {
                                    ChangesetId = 34,
-                                   Remote = new GitTfsRemote(new RemoteInfo() {Id = "mainRemote"}, gitRepoMock, new RemoteOptions(), globals, mocker.Get<ITfsHelper>(), new StringWriter())
+                                   Remote = new GitTfsRemote(new RemoteInfo() {Id = "mainRemote"}, gitRepoMock, new RemoteOptions(), globals, mocker.Get<ITfsHelper>(), new StringWriter(), new ConfigProperties(null))
                                },
                                new TfsChangesetInfo()
                                {
                                    ChangesetId = 34,
-                                   Remote = new GitTfsRemote(new RemoteInfo() {Id = "myRemote"}, gitRepoMock, new RemoteOptions(), globals, mocker.Get<ITfsHelper>(), new StringWriter())
+                                   Remote = new GitTfsRemote(new RemoteInfo() {Id = "myRemote"}, gitRepoMock, new RemoteOptions(), globals, mocker.Get<ITfsHelper>(), new StringWriter(), new ConfigProperties(null))
                                },
                        });
             Assert.Equal("mainRemote", globals.RemoteId);
@@ -85,7 +85,7 @@ namespace Sep.Git.Tfs.Test.Core
             globals.Repository.Stub(r => r.GetLastParentTfsCommits("HEAD"))
                    .Return(new List<TfsChangesetInfo>());
             globals.Repository.Stub(r => r.ReadAllTfsRemotes())
-                   .Return(new List<GitTfsRemote>() { new GitTfsRemote(new RemoteInfo() { Id = "default" }, gitRepoMock, new RemoteOptions(), globals, mocker.Get<ITfsHelper>(), new StringWriter()) });
+                   .Return(new List<GitTfsRemote>() { new GitTfsRemote(new RemoteInfo() { Id = "default" }, gitRepoMock, new RemoteOptions(), globals, mocker.Get<ITfsHelper>(), new StringWriter(), new ConfigProperties(null)) });
             Assert.Equal("default", globals.RemoteId);
         }
 
@@ -98,7 +98,7 @@ namespace Sep.Git.Tfs.Test.Core
             globals.Repository.Stub(r => r.GetLastParentTfsCommits("HEAD"))
                    .Return(new List<TfsChangesetInfo>());
             globals.Repository.Stub(r => r.ReadAllTfsRemotes())
-                   .Return(new List<GitTfsRemote>() { new GitTfsRemote(new RemoteInfo() { Id = "myRemote" }, gitRepoMock, new RemoteOptions(), globals, mocker.Get<ITfsHelper>(), new StringWriter()) });
+                   .Return(new List<GitTfsRemote>() { new GitTfsRemote(new RemoteInfo() { Id = "myRemote" }, gitRepoMock, new RemoteOptions(), globals, mocker.Get<ITfsHelper>(), new StringWriter(), new ConfigProperties(null)) });
             Assert.Throws(typeof(GitTfsException), () => globals.RemoteId);
         }
 
@@ -113,8 +113,8 @@ namespace Sep.Git.Tfs.Test.Core
             globals.Repository.Stub(r => r.ReadAllTfsRemotes())
                    .Return(new List<GitTfsRemote>()
                        {
-                           new GitTfsRemote(new RemoteInfo() { Id = "myRemote" }, gitRepoMock, new RemoteOptions(), globals, mocker.Get<ITfsHelper>(), new StringWriter()),
-                           new GitTfsRemote(new RemoteInfo() { Id = "myRemote2" }, gitRepoMock, new RemoteOptions(), globals, mocker.Get<ITfsHelper>(), new StringWriter())
+                           new GitTfsRemote(new RemoteInfo() { Id = "myRemote" }, gitRepoMock, new RemoteOptions(), globals, mocker.Get<ITfsHelper>(), new StringWriter(), new ConfigProperties(null)),
+                           new GitTfsRemote(new RemoteInfo() { Id = "myRemote2" }, gitRepoMock, new RemoteOptions(), globals, mocker.Get<ITfsHelper>(), new StringWriter(), new ConfigProperties(null))
                        });
             Assert.Throws(typeof(GitTfsException), () => globals.RemoteId);
         }

--- a/doc/commands/clone.md
+++ b/doc/commands/clone.md
@@ -34,6 +34,7 @@ a TFS source tree and fetch all the changesets
 								 Path to Work-items mapping export file
 		  --ignore-branches      Ignore fetching merged branches when encounter merge changesets
 		  --batch-size=VALUE          Size of a the batch of tfs changesets fetched (-1 for all in one batch)
+      -c, --changeset=VALUE      The changeset to clone from (must be a number)
 		  --with-branches        init all the TFS branches during the clone
 		  --resumable            if an error occurred, try to continue when you restart clone
 								 with same parameters
@@ -44,6 +45,18 @@ To clone all of `$/Project1` from your TFS 2010 server `tfs`
 into a new directory `Project1`, do this:
 
     git tfs clone http://tfs:8080/tfs/DefaultCollection $/Project1
+
+### Clone from a specific changeset
+
+To clone from a specific changeset in the history of `$/Project1` from your TFS server `tfs`
+into a new directory `Project1`, do this:
+
+    git tfs clone http://tfs:8080/tfs/DefaultCollection $/Project1 -c=126
+
+where `126` is the id of the changeset to clone.
+
+This command will get all the history from this specific changeset.
+It could be especially useful when you have a huge history and also when the entire history could not be clone due to not supported tfs specificities!
 
 ### Clone only the trunk (with dependency branches)
 

--- a/doc/commands/quick-clone.md
+++ b/doc/commands/quick-clone.md
@@ -1,6 +1,6 @@
 ## Summary
 
-The quick-clone command creates a new git repository, initialized from the last change-set in a TFS source tree, ignoring the full history. 
+The quick-clone command creates a new git repository, initialized from the last changeset (or a specific changeset in history) in a TFS source tree, ignoring the full history. 
 Useful for making code changes or additions where past history isn't relevant.
 
 ## Synopsis

--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -1,4 +1,5 @@
 * Add Vs2015 (and TFS2015) support (#760, @pmiossec)
+* Initialize a branch when not finding the root commit in the repository (#789, @pmiossec)
 * Manage the case where files are added when renaming a tfs branch (#718, @pmiossec)
 * Being able to clone from a specific changeset (#784, @pmiossec)
 * Rcheckin with libgit2sharp (#605, @pmiossec)


### PR DESCRIPTION
This PR permit:
- to initialize branches where the root changeset is not found in the git repository
- prevent fetching changeset before the initially cloned changeset when cloning from a specific changeset (using `quick-clone` or  #784 )

Should fix #787 and help a lot in cloning very messy TFS repository where some branches has been definitively deleted (and perhaps other cases)