### PR TITLE
[do not merge] testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,3 +190,4 @@ Thanks to [jetbrains](http://www.jetbrains.com/teamcity)
 ([teamcity](http://teamcity.codebetter.com/project.html?projectId=project256))
 for providing CI!
 bump
+bump

--- a/README.md
+++ b/README.md
@@ -189,3 +189,4 @@ We also have a [mailing list](https://groups.google.com/group/git-tfs-dev).
 Thanks to [jetbrains](http://www.jetbrains.com/teamcity)
 ([teamcity](http://teamcity.codebetter.com/project.html?projectId=project256))
 for providing CI!
+bump

--- a/README.md
+++ b/README.md
@@ -191,3 +191,4 @@ Thanks to [jetbrains](http://www.jetbrains.com/teamcity)
 for providing CI!
 bump
 bump
+bump

--- a/README.md
+++ b/README.md
@@ -192,3 +192,4 @@ for providing CI!
 bump
 bump
 bump
+bump


### PR DESCRIPTION
I turned on [oauth application policies](https://help.github.com/articles/about-third-party-application-restrictions/) for the git-tfs org today, and want to ensure that CI is still hooked up and can report status.

* [x] teamcity
* [ ] appveyor

Are there any other hooks or apps that should be able to access the git-tfs org?

cc @pmiossec 