### PR TITLE
Update the repository description during the creation of the repository (everytime!)

### DIFF
--- a/GitTfs/Commands/Clone.cs
+++ b/GitTfs/Commands/Clone.cs
@@ -76,7 +76,6 @@ namespace Sep.Git.Tfs.Commands
                     catch (Exception)
                     {
                         retVal = init.Run(tfsUrl, tfsRepositoryPath, gitRepositoryPath);
-                        File.WriteAllText(@".git\description", tfsRepositoryPath + "\n" + HideUserCredentials(globals.CommandLineRun));
                     }
                 }
 
@@ -160,14 +159,6 @@ namespace Sep.Git.Tfs.Commands
                 }
             }
             return retVal;
-        }
-
-        public static string HideUserCredentials(string commandLineRun)
-        {
-            Regex rgx = new Regex("(--username|-u)[= ][^ ]+");
-            commandLineRun = rgx.Replace(commandLineRun, "--username=xxx");
-            rgx = new Regex("(--password|-p)[= ][^ ]+");
-            return rgx.Replace(commandLineRun, "--password=xxx");
         }
 
         private void VerifyTfsPathToClone(string tfsRepositoryPath)

--- a/GitTfs/Commands/Init.cs
+++ b/GitTfs/Commands/Init.cs
@@ -66,7 +66,24 @@ namespace Sep.Git.Tfs.Commands
                 Environment.CurrentDirectory = gitRepositoryPath;
                 globals.GitDir = ".";
             }
-            return Run(tfsUrl, tfsRepositoryPath);
+            var runResult = Run(tfsUrl, tfsRepositoryPath);
+            try
+            {
+                File.WriteAllText(@".git\description", tfsRepositoryPath + "\n" + HideUserCredentials(globals.CommandLineRun));
+            }
+            catch (Exception)
+            {
+                Trace.WriteLine("warning: Unable to update de repository description!");
+            }
+            return runResult;
+        }
+
+        public static string HideUserCredentials(string commandLineRun)
+        {
+            Regex rgx = new Regex("(--username|-u)[= ][^ ]+");
+            commandLineRun = rgx.Replace(commandLineRun, "--username=xxx");
+            rgx = new Regex("(--password|-p)[= ][^ ]+");
+            return rgx.Replace(commandLineRun, "--password=xxx");
         }
 
         private void InitSubdir(string repositoryPath)

--- a/GitTfsTest/Commands/CloneTest.cs
+++ b/GitTfsTest/Commands/CloneTest.cs
@@ -30,7 +30,7 @@ namespace Sep.Git.Tfs.Test.Commands
             "git tfs clone --username=xxx --password=xxx https://topsecret.com/tfs $/reallysupersecret")]
         public void ShouldEncodeUserCredentialsInTheCommandLine(string cmd, string output)
         {
-            Assert.Equal(output, Clone.HideUserCredentials(cmd));
+            Assert.Equal(output, Init.HideUserCredentials(cmd));
         }
     }
 }


### PR DESCRIPTION
...by moving the update in the init class.
Fix one case where the description was not updated