### PR TITLE
Support repositories which have the character ']' in their name

### DIFF
--- a/GitTfs/GitTfsConstants.cs
+++ b/GitTfs/GitTfsConstants.cs
@@ -25,7 +25,7 @@ namespace Sep.Git.Tfs
                           GitTfsPrefix +
                           "-id:\\s+" +
                           "\\[(?<url>.+)\\]" +
-                          "(?<repository>.+)?;" +
+                          "(?<repository>\\$.+)?;" +
                           "C(?<changeset>\\d+)" +
                           "\\s*$", RegexOptions.Multiline|RegexOptions.Compiled);
         // e.g. git-tfs-work-item: 24 associate

--- a/GitTfsTest/Core/GitTfsConstantsTest.cs
+++ b/GitTfsTest/Core/GitTfsConstantsTest.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace Sep.Git.Tfs.Test.Core
+{
+    public class GitTfsConstantsTest
+    {
+        [Fact]
+        public void TestTfsCommitInfoRegex_WhenTheRepositoryContainsSquareBrackets_ThenWeGetTheCorrectValues()
+        {
+            string url = "http://tfsserver:8080/tfs/MainProjectCollection";
+            string repository = "$/Server/Branches/V1.1/Features/v1.1 [Bugs]/ShopServer";
+            string changesetId = "177712";
+
+            string gitTfsMetaInfo = "git-tfs-id: [" + url + "]" + repository + ";C" + changesetId;
+
+            var match = GitTfsConstants.TfsCommitInfoRegex.Match(gitTfsMetaInfo);
+
+            Assert.Equal(url, match.Groups["url"].Value);
+            Assert.Equal(repository, match.Groups["repository"].Value);
+            Assert.Equal(changesetId, match.Groups["changeset"].Value);
+        }
+
+    }
+}

--- a/GitTfsTest/GitTfsTest.csproj
+++ b/GitTfsTest/GitTfsTest.csproj
@@ -102,6 +102,7 @@
     <Compile Include="Core\ChangeSieveTests.cs" />
     <Compile Include="Core\CommitParserTests.cs" />
     <Compile Include="Core\ConfigPropertyLoaderTests.cs" />
+    <Compile Include="Core\GitTfsConstantsTest.cs" />
     <Compile Include="Core\GlobalsTests.cs" />
     <Compile Include="Core\DirectoryTidierTests.cs" />
     <Compile Include="Core\GitTfsRemoteTests.cs" />


### PR DESCRIPTION
I changed the regex to support repositories that have the character ']' in their name.

For example, the regex before the change break the following string incorrectly:

input:

git-tfs-id: [`http://tfsserver:8080/tfs/MainProjectCollection`]`$/Server/Branches/V1.1/Features/v1.1 [Bugs]/ShopServer`;`C177712`

incorrect output:

url:            `http://tfsserver:8080/tfs/MainProjectCollection]$/Server/Branches/V1.1/Features/v1.1 [Bugs`
repository: `/ShopServer`
changeset: `177712`

output after the regex change:

url:           	`http://tfsserver:8080/tfs/MainProjectCollection`
repository		`$/Server/Branches/V1.1/Features/v1.1 [Bugs]/ShopServer`
changeset	`177712`
