### PR TITLE
Always display the git errors to help git-tfs users

### DIFF
--- a/GitTfs/Core/GitRepository.cs
+++ b/GitTfs/Core/GitRepository.cs
@@ -70,7 +70,7 @@ namespace Sep.Git.Tfs.Core
         public string WorkingCopyPath { get; set; }
         public string WorkingCopySubdir { get; set; }
 
-        protected override Process Start(string[] command, Action<ProcessStartInfo> initialize)
+        protected override GitProcess Start(string[] command, Action<ProcessStartInfo> initialize)
         {
             return base.Start(command, initialize.And(SetUpPaths));
         }

--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -1,1 +1,2 @@
-* Improve vrify command (check all remote option, add exit code, add ignore path case mismatch option) (#853, @pmiossec)
+* Improve verify command (check all remote option, add exit code, add ignore path case mismatch option) (#853, @pmiossec)
+* Always display the git errors messages to help git-tfs users (#820, @spraint & @pmiossec)


### PR DESCRIPTION
See problem describe here: https://mgrowan.wordpress.com/2015/05/06/git-tfs-pull-command-exited-with-error-code-128/

Introduce HideGitErrorMessage() because there is one call
where the error is "expected" in some cases (when the repository doesn't exist)