### PR TITLE
Copy collection before iterating since it can be modified

### DIFF
--- a/GitTfs/Commands/Fetch.cs
+++ b/GitTfs/Commands/Fetch.cs
@@ -104,7 +104,8 @@ namespace Sep.Git.Tfs.Commands
             if (!FetchAll && IgnoreBranches)
                 globals.Repository.SetConfig(GitTfsConstants.IgnoreBranches, true.ToString());
 
-            foreach (var remote in GetRemotesToFetch(args))
+            var remotesToFetch = GetRemotesToFetch(args).ToList();
+            foreach (var remote in remotesToFetch)
             {
                 FetchRemote(stopOnFailMergeCommit, remote);
             }


### PR DESCRIPTION
Sometimes I get exception about enumeration being modified.
There is at least one other place with the same problem that I haven't tracked down yet.