### PR TITLE
Add an exit code to the verify command

### DIFF
--- a/GitTfs/GitTfsExitCodes.cs
+++ b/GitTfs/GitTfsExitCodes.cs
@@ -25,5 +25,10 @@ namespace Sep.Git.Tfs
         public const int InvalidArguments = 2;
         public const int ForceRequired = 3;
         public const int ExceptionThrown = Byte.MaxValue - 1;
+
+        //Verify
+        public const int VerifyPathCaseMismatch = 100;
+        public const int VerifyFileMissing = 101;
+        public const int VerifyContentMismatch = 102;
     }
 }

--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -1,0 +1,1 @@
+* Improve vrify command (check all remote option, add exit code, add ignore path case mismatch option) (#853, @pmiossec)


### PR DESCRIPTION
The command now exit with a code != 0
when differences are found...

* Case mismatch : 100 //Could be normal on ntfs that is case insensitive
* Files missing: 101 //Could be normal if some files are ignored during clone/ fetch with regex
* Content mismatch: 102 //Absolutely not normal :(