### PR TITLE
Avoid throwing an Exception for performance problem

### DIFF
--- a/GitTfs/Util/ChangeSieve.cs
+++ b/GitTfs/Util/ChangeSieve.cs
@@ -189,7 +189,12 @@ namespace Sep.Git.Tfs.Util
                     var history = item.VersionControlServer.QueryHistory(item.ServerItem, item.ChangesetId, 0,
                                                                      TfsRecursionType.None, null, 1, previousChangeset,
                                                                      1, true, false, false);
-                    var previousChange = history.First();
+                    var previousChange = history.FirstOrDefault();
+                    if(previousChange == null)
+                    {
+                        Trace.WriteLine(string.Format("No history found for item {0} changesetId {1}", item.ServerItem, item.ChangesetId));
+                        return null;
+                    }
                     oldItem = previousChange.Changes[0].Item;
                 }
                 catch


### PR DESCRIPTION
If this case happens for a changeset, their is in fact a lot of exceptions
thrown here, so it's better to manage it without throwing an exception
because it's much much slower :(