### PR TITLE
When a ref name is already used, find a strategy to give another one

### DIFF
--- a/GitTfs/Core/GitRepository.cs
+++ b/GitTfs/Core/GitRepository.cs
@@ -61,6 +61,11 @@ namespace Sep.Git.Tfs.Core
             return "refs/heads/" + branchName;
         }
 
+        public static string ShortToTfsRemoteName(string branchName)
+        {
+            return "refs/remotes/tfs/" + branchName;
+        }
+
         public string GitDir { get; set; }
         public string WorkingCopyPath { get; set; }
         public string WorkingCopySubdir { get; set; }
@@ -508,7 +513,26 @@ namespace Sep.Git.Tfs.Core
         {
             if (!Reference.IsValidName(ShortToLocalName(gitBranchName)))
                 throw new GitTfsException("The name specified for the new git branch is not allowed. Choose another one!");
+            while (IsRefNameUsed(gitBranchName))
+            {
+                gitBranchName = "_" + gitBranchName;
+            }
             return gitBranchName;
+        }
+
+        private bool IsRefNameUsed(string gitBranchName)
+        {
+            var parts = gitBranchName.Split('/');
+            var refName = parts.First();
+            for (int i = 1; i <= parts.Length; i++)
+            {
+                if (HasRef(ShortToLocalName(refName)) || HasRef(ShortToTfsRemoteName(refName)))
+                    return true;
+                if (i < parts.Length)
+                    refName += '/' + parts[i];
+            }
+            
+            return false;
         }
 
         public bool CreateBranch(string gitBranchName, string target)


### PR DESCRIPTION
An example of the case happening when cloning an existing tfs repository
was a branch created in "$/project/dev/my_branch" when in the past was
existing or still exists a branch with the path "$/project/dev_my_branch"
(the 2 refs will have the same git name).

The solution here is to add a `_` at the beginning of the expected ref name
until we found a ref name which is not used.