### PR TITLE
refacto: use 'int' to handle changeset Ids

### DIFF
--- a/GitTfs.VsCommon/TfsHelper.Common.cs
+++ b/GitTfs.VsCommon/TfsHelper.Common.cs
@@ -168,7 +168,7 @@ namespace Sep.Git.Tfs.VsCommon
             }
         }
 
-        public IEnumerable<ITfsChangeset> GetChangesets(string path, long startVersion, IGitTfsRemote remote, long lastVersion = -1, bool byLots = false)
+        public IEnumerable<ITfsChangeset> GetChangesets(string path, int startVersion, IGitTfsRemote remote, int lastVersion = -1, bool byLots = false)
         {
             if (Is2008OrOlder)
             {
@@ -177,9 +177,9 @@ namespace Sep.Git.Tfs.VsCommon
                 yield break;
             }
 
-            var start = (int)startVersion;
+            var start = startVersion;
             Changeset[] changesets;
-            var lastChangeset = lastVersion == -1 ? VersionSpec.Latest : new ChangesetVersionSpec((int)lastVersion);
+            var lastChangeset = lastVersion == -1 ? VersionSpec.Latest : new ChangesetVersionSpec(lastVersion);
             do
             {
                 var startChangeset = new ChangesetVersionSpec(start);
@@ -199,10 +199,10 @@ namespace Sep.Git.Tfs.VsCommon
             } while (!byLots && changesets.Length == BatchCount);
         }
 
-        public IEnumerable<ITfsChangeset> GetChangesetsForTfs2008(string path, long startVersion, IGitTfsRemote remote)
+        public IEnumerable<ITfsChangeset> GetChangesetsForTfs2008(string path, int startVersion, IGitTfsRemote remote)
         {
             var changesets = VersionControl.QueryHistory(path, VersionSpec.Latest, 0, RecursionType.Full,
-                                                                        null, new ChangesetVersionSpec((int) startVersion), VersionSpec.Latest, int.MaxValue,
+                                                                        null, new ChangesetVersionSpec(startVersion), VersionSpec.Latest, int.MaxValue,
                                                                         true, true, true)
                                                           .Cast<Changeset>().OrderBy(changeset => changeset.ChangesetId).ToArray();
             // don't take the enumerator produced by a foreach statement or a yield statement, as there are references
@@ -214,9 +214,9 @@ namespace Sep.Git.Tfs.VsCommon
             }
         }
 
-        public virtual int FindMergeChangesetParent(string path, long targetChangeset, GitTfsRemote remote)
+        public virtual int FindMergeChangesetParent(string path, int targetChangeset, GitTfsRemote remote)
         {
-            var targetVersion = new ChangesetVersionSpec((int)targetChangeset);
+            var targetVersion = new ChangesetVersionSpec(targetChangeset);
             var searchTo = targetVersion;
             var mergeInfo = VersionControl.QueryMerges(null, null, path, targetVersion, null, searchTo, RecursionType.Full);
             if (mergeInfo.Length == 0) return -1;
@@ -693,7 +693,7 @@ namespace Sep.Git.Tfs.VsCommon
             return "git-tfs-" + Guid.NewGuid();
         }
 
-        public long ShowCheckinDialog(IWorkspace workspace, IPendingChange[] pendingChanges, IEnumerable<IWorkItemCheckedInfo> checkedInfos, string checkinComment)
+        public int ShowCheckinDialog(IWorkspace workspace, IPendingChange[] pendingChanges, IEnumerable<IWorkItemCheckedInfo> checkedInfos, string checkinComment)
         {
             return ShowCheckinDialog(_bridge.Unwrap<Workspace>(workspace),
                                      pendingChanges.Select(p => _bridge.Unwrap<PendingChange>(p)).ToArray(),
@@ -701,7 +701,7 @@ namespace Sep.Git.Tfs.VsCommon
                                      checkinComment);
         }
 
-        private long ShowCheckinDialog(Workspace workspace, PendingChange[] pendingChanges,
+        private int ShowCheckinDialog(Workspace workspace, PendingChange[] pendingChanges,
             WorkItemCheckedInfo[] checkedInfos, string checkinComment)
         {
             using (var parentForm = new ParentForm())
@@ -1311,7 +1311,7 @@ namespace Sep.Git.Tfs.VsCommon
             return null;
         }
 
-        public long QueueGatedCheckinBuild(Uri buildDefinitionUri, string buildDefinitionName, string shelvesetName, string checkInTicket)
+        public int QueueGatedCheckinBuild(Uri buildDefinitionUri, string buildDefinitionName, string shelvesetName, string checkInTicket)
         {
             var buildServer = (IBuildServer)_server.GetService(typeof(IBuildServer));
  

--- a/GitTfs.VsFake/TfsHelper.VsFake.cs
+++ b/GitTfs.VsFake/TfsHelper.VsFake.cs
@@ -49,7 +49,7 @@ namespace Sep.Git.Tfs.VsFake
 
         public bool CanShowCheckinDialog { get { return false; } }
 
-        public long ShowCheckinDialog(IWorkspace workspace, IPendingChange[] pendingChanges, IEnumerable<IWorkItemCheckedInfo> checkedInfos, string checkinComment)
+        public int ShowCheckinDialog(IWorkspace workspace, IPendingChange[] pendingChanges, IEnumerable<IWorkItemCheckedInfo> checkedInfos, string checkinComment)
         {
             throw new NotImplementedException();
         }
@@ -75,7 +75,7 @@ namespace Sep.Git.Tfs.VsFake
             return _script.Changesets.LastOrDefault().Id;
         }
 
-        public IEnumerable<ITfsChangeset> GetChangesets(string path, long startVersion, IGitTfsRemote remote, long lastVersion = -1, bool byLots = false)
+        public IEnumerable<ITfsChangeset> GetChangesets(string path, int startVersion, IGitTfsRemote remote, int lastVersion = -1, bool byLots = false)
         {
             if (!_script.Changesets.Any(c => c.IsBranchChangeset) && _script.Changesets.Any(c => c.IsMergeChangeset))
                 return _script.Changesets.Where(x => x.Id >= startVersion).Select(x => BuildTfsChangeset(x, remote));
@@ -85,7 +85,7 @@ namespace Sep.Git.Tfs.VsFake
                 .Select(x => BuildTfsChangeset(x, remote));
         }
 
-        public int FindMergeChangesetParent(string path, long firstChangeset, GitTfsRemote remote)
+        public int FindMergeChangesetParent(string path, int firstChangeset, GitTfsRemote remote)
         {
             var firstChangesetOfBranch = _script.Changesets.FirstOrDefault(c => c.IsMergeChangeset && c.MergeChangesetDatas.MergeIntoBranch == path && c.MergeChangesetDatas.BeforeMergeChangesetId < firstChangeset);
             if (firstChangesetOfBranch != null)
@@ -518,7 +518,7 @@ namespace Sep.Git.Tfs.VsFake
             throw new NotImplementedException();
         }
 
-        public long QueueGatedCheckinBuild(Uri value, string buildDefinitionName, string shelvesetName, string checkInTicket)
+        public int QueueGatedCheckinBuild(Uri value, string buildDefinitionName, string shelvesetName, string checkInTicket)
         {
             throw new NotImplementedException();
         }

--- a/GitTfs/Commands/Branch.cs
+++ b/GitTfs/Commands/Branch.cs
@@ -206,7 +206,7 @@ namespace Sep.Git.Tfs.Commands
             }
             var remote = commit.Remote;
             Trace.WriteLine("Creating branch in TFS...");
-            remote.Tfs.CreateBranch(remote.TfsRepositoryPath, tfsPath, (int)commit.ChangesetId, Comment ?? "Creation branch " + tfsPath);
+            remote.Tfs.CreateBranch(remote.TfsRepositoryPath, tfsPath, commit.ChangesetId, Comment ?? "Creation branch " + tfsPath);
             Trace.WriteLine("Init branch in local repository...");
             initBranch.DontCreateGitBranch = true;
             var returnCode = initBranch.Run(tfsPath, gitBranchNameExpected);

--- a/GitTfs/Commands/Checkin.cs
+++ b/GitTfs/Commands/Checkin.cs
@@ -15,7 +15,7 @@ namespace Sep.Git.Tfs.Commands
         {
         }
 
-        protected override long DoCheckin(TfsChangesetInfo changeset, string refToCheckin)
+        protected override int DoCheckin(TfsChangesetInfo changeset, string refToCheckin)
         {
             return changeset.Remote.Checkin(refToCheckin, changeset, _checkinOptions);
         }

--- a/GitTfs/Commands/CheckinBase.cs
+++ b/GitTfs/Commands/CheckinBase.cs
@@ -59,6 +59,6 @@ namespace Sep.Git.Tfs.Commands
             return GitTfsExitCodes.OK;
         }
 
-        protected abstract long DoCheckin(TfsChangesetInfo changeset, string refToCheckin);
+        protected abstract int DoCheckin(TfsChangesetInfo changeset, string refToCheckin);
     }
 }

--- a/GitTfs/Commands/CheckinTool.cs
+++ b/GitTfs/Commands/CheckinTool.cs
@@ -14,7 +14,7 @@ namespace Sep.Git.Tfs.Commands
         {
         }
 
-        protected override long DoCheckin(TfsChangesetInfo changeset, string refToCheckin)
+        protected override int DoCheckin(TfsChangesetInfo changeset, string refToCheckin)
         {
             if (!changeset.Remote.Tfs.CanShowCheckinDialog)
                 throw new GitTfsException(

--- a/GitTfs/Commands/Checkout.cs
+++ b/GitTfs/Commands/Checkout.cs
@@ -40,8 +40,8 @@ namespace Sep.Git.Tfs.Commands
 
         public int Run(string id)
         {
-            long changesetId;
-            if(!long.TryParse(id, out changesetId))
+            int changesetId;
+            if(!int.TryParse(id, out changesetId))
                 throw new GitTfsException("error: wrong format for changeset id...");
             var sha = _globals.Repository.FindCommitHashByChangesetId(changesetId);
             if (string.IsNullOrEmpty(sha))

--- a/GitTfs/Commands/InitBranch.cs
+++ b/GitTfs/Commands/InitBranch.cs
@@ -188,7 +188,7 @@ namespace Sep.Git.Tfs.Commands
         {
             public string TfsRepositoryPath { get; set; }
             public string GitBranchNameExpected { get; set; }
-            public long RootChangesetId { get; set; }
+            public int RootChangesetId { get; set; }
         }
 
         [DebuggerDisplay("{TfsRepositoryPath} C{RootChangesetId}")]
@@ -197,7 +197,7 @@ namespace Sep.Git.Tfs.Commands
             public string TfsRepositoryPath { get; set; }
             public IGitTfsRemote TfsRemote { get; set; }
             public bool IsEntirelyFetched { get; set; }
-            public long RootChangesetId { get; set; }
+            public int RootChangesetId { get; set; }
             public IList<RootBranch> CreationBranchData { get; set; }
             public Exception Error { get; set; }
         }

--- a/GitTfs/Commands/Rcheckin.cs
+++ b/GitTfs/Commands/Rcheckin.cs
@@ -122,7 +122,7 @@ namespace Sep.Git.Tfs.Commands
         {
             var tfsRemote = parentChangeset.Remote;
             string currentParent = parentChangeset.Remote.MaxCommitHash;
-            long newChangesetId = 0;
+            int newChangesetId = 0;
 
             foreach (var commit in commitsToCheckin)
             {

--- a/GitTfs/Commands/Subtree.cs
+++ b/GitTfs/Commands/Subtree.cs
@@ -149,7 +149,7 @@ namespace Sep.Git.Tfs.Commands
             {
                 var p = Prefix.Replace(" ", "\\ ");
 
-                long latest = Math.Max(owner.MaxChangesetId, remote.MaxChangesetId);
+                int latest = Math.Max(owner.MaxChangesetId, remote.MaxChangesetId);
                 string msg = string.Format(GitTfsConstants.TfsCommitInfoFormat, owner.TfsUrl, owner.TfsRepositoryPath, latest);
                 msg = string.Format(@"Add '{0}/' from commit '{1}'
 

--- a/GitTfs/ConfigProperties.cs
+++ b/GitTfs/ConfigProperties.cs
@@ -25,7 +25,7 @@ namespace Sep.Git.Tfs
             get { return _loader.Get(GitTfsConstants.BatchSize, 100); }
         }
 
-        public long? InitialChangeset
+        public int? InitialChangeset
         {
             set
             {
@@ -33,7 +33,7 @@ namespace Sep.Git.Tfs
             }
             get
             {
-                long? initialChangeset = _loader.Get<long>(GitTfsConstants.InitialChangeset, -1);
+                int? initialChangeset = _loader.Get<int>(GitTfsConstants.InitialChangeset, -1);
                 return initialChangeset == -1 ? null : initialChangeset;
             }
         }

--- a/GitTfs/Core/Bootstrapper.cs
+++ b/GitTfs/Core/Bootstrapper.cs
@@ -37,7 +37,7 @@ namespace Sep.Git.Tfs.Core
                 remote = changeset.Remote;
                 if (changeset.Remote.MaxChangesetId < changeset.ChangesetId)
                 {
-                    long oldChangeset = changeset.Remote.MaxChangesetId;
+                    int oldChangeset = changeset.Remote.MaxChangesetId;
                     _globals.Repository.MoveTfsRefForwardIfNeeded(changeset.Remote);
                     _stdout.WriteLine("-> existing remote {0} (updated from changeset {1})", changeset.Remote.Id, oldChangeset);
                 }

--- a/GitTfs/Core/DerivedGitTfsRemote.cs
+++ b/GitTfs/Core/DerivedGitTfsRemote.cs
@@ -150,7 +150,7 @@ namespace Sep.Git.Tfs.Core
             set { throw DerivedRemoteException; }
         }
 
-        public long MaxChangesetId
+        public int MaxChangesetId
         {
             get { throw DerivedRemoteException; }
             set { throw DerivedRemoteException; }
@@ -195,7 +195,7 @@ namespace Sep.Git.Tfs.Core
             throw DerivedRemoteException;
         }
 
-        public IGitTfsRemote InitBranch(RemoteOptions remoteOptions, string tfsRepositoryPath, long shaRootChangesetId, bool fetchParentBranch, string gitBranchNameExpected = null, IRenameResult renameResult = null)
+        public IGitTfsRemote InitBranch(RemoteOptions remoteOptions, string tfsRepositoryPath, int shaRootChangesetId, bool fetchParentBranch, string gitBranchNameExpected = null, IRenameResult renameResult = null)
         {
             throw new NotImplementedException();
         }
@@ -210,7 +210,7 @@ namespace Sep.Git.Tfs.Core
             throw DerivedRemoteException;
         }
 
-        public IFetchResult FetchWithMerge(long mergeChangesetId, bool stopOnFailMergeCommit = false, IRenameResult renameResult = null, params string[] parentCommitsHashes)
+        public IFetchResult FetchWithMerge(int mergeChangesetId, bool stopOnFailMergeCommit = false, IRenameResult renameResult = null, params string[] parentCommitsHashes)
         {
             throw DerivedRemoteException;
         }
@@ -240,17 +240,17 @@ namespace Sep.Git.Tfs.Core
             throw DerivedRemoteException;
         }
 
-        public long CheckinTool(string head, TfsChangesetInfo parentChangeset)
+        public int CheckinTool(string head, TfsChangesetInfo parentChangeset)
         {
             throw DerivedRemoteException;
         }
 
-        public long Checkin(string treeish, TfsChangesetInfo parentChangeset, CheckinOptions options, string sourceTfsPath = null)
+        public int Checkin(string treeish, TfsChangesetInfo parentChangeset, CheckinOptions options, string sourceTfsPath = null)
         {
             throw DerivedRemoteException;
         }
 
-        public long Checkin(string head, string parent, TfsChangesetInfo parentChangeset, CheckinOptions options, string sourceTfsPath = null)
+        public int Checkin(string head, string parent, TfsChangesetInfo parentChangeset, CheckinOptions options, string sourceTfsPath = null)
         {
             throw DerivedRemoteException;
         }
@@ -265,12 +265,12 @@ namespace Sep.Git.Tfs.Core
             throw DerivedRemoteException;
         }
 
-        public ITfsChangeset GetChangeset(long changesetId)
+        public ITfsChangeset GetChangeset(int changesetId)
         {
             throw DerivedRemoteException;
         }
 
-        public void UpdateTfsHead(string commitHash, long changesetId)
+        public void UpdateTfsHead(string commitHash, int changesetId)
         {
             throw DerivedRemoteException;
         }

--- a/GitTfs/Core/GitRepository.cs
+++ b/GitTfs/Core/GitRepository.cs
@@ -282,7 +282,7 @@ namespace Sep.Git.Tfs.Core
 
         public void MoveTfsRefForwardIfNeeded(IGitTfsRemote remote, string @ref)
         {
-            long currentMaxChangesetId = remote.MaxChangesetId;
+            int currentMaxChangesetId = remote.MaxChangesetId;
             var untrackedTfsChangesets = from cs in GetLastParentTfsCommits(@ref)
                                          where cs.Remote.Id == remote.Id && cs.ChangesetId > currentMaxChangesetId
                                          orderby cs.ChangesetId
@@ -349,7 +349,7 @@ namespace Sep.Git.Tfs.Core
             Trace.WriteLine("Commits visited count:" + alreadyVisitedCommits.Count);
         }
 
-        public TfsChangesetInfo GetTfsChangesetById(string remoteRef, long changesetId)
+        public TfsChangesetInfo GetTfsChangesetById(string remoteRef, int changesetId)
         {
             var commit = FindCommitByChangesetId(changesetId, remoteRef);
             if (commit == null)
@@ -549,10 +549,10 @@ namespace Sep.Git.Tfs.Core
             return reference != null;
         }
 
-        private readonly Dictionary<long, string> changesetsCache = new Dictionary<long, string>();
+        private readonly Dictionary<int, string> changesetsCache = new Dictionary<int, string>();
         private bool cacheIsFull = false;
 
-        public string FindCommitHashByChangesetId(long changesetId)
+        public string FindCommitHashByChangesetId(int changesetId)
         {
             var commit = FindCommitByChangesetId(changesetId);
             if (commit == null)
@@ -563,12 +563,12 @@ namespace Sep.Git.Tfs.Core
 
         private static readonly Regex tfsIdRegex = new Regex("^git-tfs-id: .*;C([0-9]+)\r?$", RegexOptions.Multiline | RegexOptions.Compiled | RegexOptions.RightToLeft);
 
-        public static bool TryParseChangesetId(string commitMessage, out long changesetId)
+        public static bool TryParseChangesetId(string commitMessage, out int changesetId)
         {
             var match = tfsIdRegex.Match(commitMessage);
             if (match.Success)
             {
-                changesetId = long.Parse(match.Groups[1].Value);
+                changesetId = int.Parse(match.Groups[1].Value);
                 return true;
             }
 
@@ -576,7 +576,7 @@ namespace Sep.Git.Tfs.Core
             return false;
         }
 
-        private Commit FindCommitByChangesetId(long changesetId, string remoteRef = null)
+        private Commit FindCommitByChangesetId(int changesetId, string remoteRef = null)
         {
             Trace.WriteLine("Looking for changeset " + changesetId + " in git repository...");
 
@@ -602,7 +602,7 @@ namespace Sep.Git.Tfs.Core
             Commit commit = null;
             foreach (var c in commitsFromRemoteBranches)
             {
-                long id;
+                int id;
                 if (TryParseChangesetId(c.Message, out id))
                 {
                     changesetsCache[id] = c.Sha;

--- a/GitTfs/Core/IGitRepository.cs
+++ b/GitTfs/Core/IGitRepository.cs
@@ -24,7 +24,7 @@ namespace Sep.Git.Tfs.Core
         void MoveTfsRefForwardIfNeeded(IGitTfsRemote remote);
         void MoveTfsRefForwardIfNeeded(IGitTfsRemote remote, string @ref);
         IEnumerable<TfsChangesetInfo> GetLastParentTfsCommits(string head);
-        TfsChangesetInfo GetTfsChangesetById(string remoteRef, long changesetId);
+        TfsChangesetInfo GetTfsChangesetById(string remoteRef, int changesetId);
         TfsChangesetInfo GetTfsCommit(GitCommit commit);
         TfsChangesetInfo GetTfsCommit(string sha);
         TfsChangesetInfo GetCurrentTfsCommit();
@@ -42,7 +42,7 @@ namespace Sep.Git.Tfs.Core
         string AssertValidBranchName(string gitBranchName);
         bool CreateBranch(string gitBranchName, string target);
         Branch RenameBranch(string oldName, string newName);
-        string FindCommitHashByChangesetId(long changesetId);
+        string FindCommitHashByChangesetId(int changesetId);
         void CreateTag(string name, string sha, string comment, string Owner, string emailOwner, System.DateTime creationDate);
         void CreateNote(string sha, string content, string owner, string emailOwner, DateTime creationDate);
         void MoveRemote(string oldRemoteName, string newRemoteName);

--- a/GitTfs/Core/IGitTfsRemote.cs
+++ b/GitTfs/Core/IGitTfsRemote.cs
@@ -9,7 +9,7 @@ namespace Sep.Git.Tfs.Core
     public interface IFetchResult : IRenameResult
     {
         bool IsSuccess { get; set; }
-        long LastFetchedChangesetId { get; set; }
+        int LastFetchedChangesetId { get; set; }
         int NewChangesetCount { get; set; }
         string ParentBranchTfsPath { get; set; }
     }
@@ -39,7 +39,7 @@ namespace Sep.Git.Tfs.Core
         string TfsPassword { get; set; }
         IGitRepository Repository { get; set; }
         ITfsHelper Tfs { get; set; }
-        long MaxChangesetId { get; set; }
+        int MaxChangesetId { get; set; }
         string MaxCommitHash { get; set; }
         string RemoteRef { get; }
         bool IsSubtree { get; }
@@ -49,33 +49,33 @@ namespace Sep.Git.Tfs.Core
         bool ExportMetadatas { get; set; }
         Dictionary<string, string> ExportWorkitemsMapping { get; set; }
         bool ShouldSkip(string path);
-        IGitTfsRemote InitBranch(RemoteOptions remoteOptions, string tfsRepositoryPath, long rootChangesetId = -1, bool fetchParentBranch = false, string gitBranchNameExpected = null, IRenameResult renameResult = null);
+        IGitTfsRemote InitBranch(RemoteOptions remoteOptions, string tfsRepositoryPath, int rootChangesetId = -1, bool fetchParentBranch = false, string gitBranchNameExpected = null, IRenameResult renameResult = null);
         string GetPathInGitRepo(string tfsPath);
         IFetchResult Fetch(bool stopOnFailMergeCommit = false, int lastChangesetIdToFetch = -1, IRenameResult renameResult = null);
-        IFetchResult FetchWithMerge(long mergeChangesetId, bool stopOnFailMergeCommit = false, IRenameResult renameResult = null, params string[] parentCommitsHashes);
+        IFetchResult FetchWithMerge(int mergeChangesetId, bool stopOnFailMergeCommit = false, IRenameResult renameResult = null, params string[] parentCommitsHashes);
         void QuickFetch();
         void QuickFetch(int changesetId);
         void Unshelve(string shelvesetOwner, string shelvesetName, string destinationBranch, Action<Exception> ignorableErrorHandler, bool force);
         void Shelve(string shelvesetName, string treeish, TfsChangesetInfo parentChangeset, bool evaluateCheckinPolicies);
         bool HasShelveset(string shelvesetName);
-        long CheckinTool(string head, TfsChangesetInfo parentChangeset);
-        long Checkin(string treeish, TfsChangesetInfo parentChangeset, CheckinOptions options, string sourceTfsPath = null);
+        int CheckinTool(string head, TfsChangesetInfo parentChangeset);
+        int Checkin(string treeish, TfsChangesetInfo parentChangeset, CheckinOptions options, string sourceTfsPath = null);
 
         /// <summary>
         /// Checks in to TFS set of changes from git repository between given commits (parent..head) onto given TFS changeset. Returns ID of the new changeset.
         /// </summary>
-        long Checkin(string head, string parent, TfsChangesetInfo parentChangeset, CheckinOptions options, string sourceTfsPath = null);
+        int Checkin(string head, string parent, TfsChangesetInfo parentChangeset, CheckinOptions options, string sourceTfsPath = null);
         void CleanupWorkspace();
         void CleanupWorkspaceDirectory();
-        ITfsChangeset GetChangeset(long changesetId);
-        void UpdateTfsHead(string commitHash, long changesetId);
+        ITfsChangeset GetChangeset(int changesetId);
+        void UpdateTfsHead(string commitHash, int changesetId);
         void EnsureTfsAuthenticated();
         bool MatchesUrlAndRepositoryPath(string tfsUrl, string tfsRepositoryPath);
     }
 
     public static class IGitTfsRemoteExt
     {
-        public static IFetchResult FetchWithMerge(this IGitTfsRemote remote, long mergeChangesetId, bool stopOnFailMergeCommit = false, params string[] parentCommitsHashes)
+        public static IFetchResult FetchWithMerge(this IGitTfsRemote remote, int mergeChangesetId, bool stopOnFailMergeCommit = false, params string[] parentCommitsHashes)
         {
             return remote.FetchWithMerge(mergeChangesetId, stopOnFailMergeCommit, null, parentCommitsHashes);
         }

--- a/GitTfs/Core/ITfsWorkspace.cs
+++ b/GitTfs/Core/ITfsWorkspace.cs
@@ -29,7 +29,7 @@ namespace Sep.Git.Tfs.Core
         /// <summary>
         /// Evaluates check-in policies and checks in all pending changes.
         /// </summary>
-        long Checkin(CheckinOptions checkinOptions);
+        int Checkin(CheckinOptions checkinOptions);
         /// <summary>
         /// Populates the workspace with a snapshot, as of the given changeset.
         /// </summary>
@@ -48,7 +48,7 @@ namespace Sep.Git.Tfs.Core
         /// </summary>
         string GetLocalItemForServerItem(string serverItem);
 
-        long CheckinTool(Func<string> generateCheckinComment);
+        int CheckinTool(Func<string> generateCheckinComment);
         void Merge(string sourceTfsPath, string tfsRepositoryPath);
 
         /// <summary>

--- a/GitTfs/Core/LogEntry.cs
+++ b/GitTfs/Core/LogEntry.cs
@@ -22,7 +22,7 @@ namespace Sep.Git.Tfs.Core
         public Tree Tree { get; set; }
         public IList<string> CommitParents { get; private set; }
 
-        public long ChangesetId { get; set; }
+        public int ChangesetId { get; set; }
         public IGitTfsRemote Remote { get; set; }
     }
 }

--- a/GitTfs/Core/TfsChangesetInfo.cs
+++ b/GitTfs/Core/TfsChangesetInfo.cs
@@ -6,7 +6,7 @@ namespace Sep.Git.Tfs.Core
     public class TfsChangesetInfo
     {
         public IGitTfsRemote Remote { get; set; }
-        public long ChangesetId { get; set; }
+        public int ChangesetId { get; set; }
         public string GitCommit { get; set; }
         public IEnumerable<ITfsWorkitem> Workitems { get; set; }
 

--- a/GitTfs/Core/TfsInterop/ITfsHelper.cs
+++ b/GitTfs/Core/TfsInterop/ITfsHelper.cs
@@ -10,7 +10,7 @@ namespace Sep.Git.Tfs.Core.TfsInterop
         string Url { get; set; }
         string Username { get; set; }
         string Password { get; set; }
-        IEnumerable<ITfsChangeset> GetChangesets(string path, long startVersion, IGitTfsRemote remote, long lastVersion = -1, bool byLots = false);
+        IEnumerable<ITfsChangeset> GetChangesets(string path, int startVersion, IGitTfsRemote remote, int lastVersion = -1, bool byLots = false);
         void WithWorkspace(string directory, IGitTfsRemote remote, TfsChangesetInfo versionToFetch, Action<ITfsWorkspace> action);
         IShelveset CreateShelveset(IWorkspace workspace, string shelvesetName);
         IEnumerable<IWorkItemCheckinInfo> GetWorkItemInfos(IEnumerable<string> workItems, TfsWorkItemCheckinAction checkinAction);
@@ -25,7 +25,7 @@ namespace Sep.Git.Tfs.Core.TfsInterop
         ITfsChangeset GetShelvesetData(IGitTfsRemote remote, string shelvesetOwner, string shelvesetName);
         int ListShelvesets(ShelveList shelveList, IGitTfsRemote remote);
         bool CanShowCheckinDialog { get; }
-        long ShowCheckinDialog(IWorkspace workspace, IPendingChange[] pendingChanges, IEnumerable<IWorkItemCheckedInfo> checkedInfos, string checkinComment);
+        int ShowCheckinDialog(IWorkspace workspace, IPendingChange[] pendingChanges, IEnumerable<IWorkItemCheckedInfo> checkedInfos, string checkinComment);
         void CleanupWorkspaces(string workingDirectory);
         IList<RootBranch> GetRootChangesetForBranch(string tfsPathBranchToCreate, int lastChangesetIdToCheck = -1, string tfsPathParentBranch = null);
         IEnumerable<TfsLabel> GetLabels(string tfsPathBranch, string nameFilter = null);
@@ -36,7 +36,7 @@ namespace Sep.Git.Tfs.Core.TfsInterop
         void CreateBranch(string sourcePath, string targetPath, int changesetId, string comment = null);
         void CreateTfsRootBranch(string projectName, string mainBranch, string gitRepositoryPath, bool createTeamProjectFolder);
         bool IsExistingInTfs(string path);
-        int FindMergeChangesetParent(string path, long firstChangeset, GitTfsRemote remote);
+        int FindMergeChangesetParent(string path, int firstChangeset, GitTfsRemote remote);
         /// <summary>
         /// Creates and maps a workspace for the given remote with the given local -> server directory mappings, at the given Tfs version,
         /// and then performs the action.
@@ -47,6 +47,6 @@ namespace Sep.Git.Tfs.Core.TfsInterop
         /// <param name="versionToFetch">The TFS version to fetch from the server</param>
         /// <param name="action">The action to perform</param>
         void WithWorkspace(string localDirectory, IGitTfsRemote remote, IEnumerable<Tuple<string, string>> mappings, TfsChangesetInfo versionToFetch, Action<ITfsWorkspace> action);
-        long QueueGatedCheckinBuild(Uri value, string buildDefinitionName, string shelvesetName, string checkInTicket);
+        int QueueGatedCheckinBuild(Uri value, string buildDefinitionName, string shelvesetName, string checkInTicket);
     }
 }

--- a/GitTfs/Core/TfsWorkspace.cs
+++ b/GitTfs/Core/TfsWorkspace.cs
@@ -53,7 +53,7 @@ namespace Sep.Git.Tfs.Core
             _workspace.Shelve(shelveset, pendingChanges, _checkinOptions.Force ? TfsShelvingOptions.Replace : TfsShelvingOptions.None);
         }
 
-        public long CheckinTool(Func<string> generateCheckinComment)
+        public int CheckinTool(Func<string> generateCheckinComment)
         {
             var pendingChanges = _workspace.GetPendingChanges();
 
@@ -75,7 +75,7 @@ namespace Sep.Git.Tfs.Core
             _workspace.Merge(sourceTfsPath, tfsRepositoryPath);
         }
 
-        public long Checkin(CheckinOptions options)
+        public int Checkin(CheckinOptions options)
         {
             if (options == null) options = _checkinOptions;
 
@@ -130,7 +130,7 @@ namespace Sep.Git.Tfs.Core
             }
         }
 
-        private long LaunchGatedCheckinBuild(ReadOnlyCollection<KeyValuePair<string, Uri>> affectedBuildDefinitions, string shelvesetName, string checkInTicket)
+        private int LaunchGatedCheckinBuild(ReadOnlyCollection<KeyValuePair<string, Uri>> affectedBuildDefinitions, string shelvesetName, string checkInTicket)
         {
             _stdout.WriteLine("Due to a gated check-in, a shelveset '" + shelvesetName + "' containing your changes has been created and need to be built before it can be committed.");
             KeyValuePair<string, Uri> buildDefinition;
@@ -217,7 +217,7 @@ namespace Sep.Git.Tfs.Core
 
         private void GetFromTfs(string path)
         {
-            _workspace.ForceGetFile(_workspace.GetServerItemForLocalItem(path), (int)_contextVersion.ChangesetId);
+            _workspace.ForceGetFile(_workspace.GetServerItemForLocalItem(path), _contextVersion.ChangesetId);
         }
 
         public void Get(int changesetId)

--- a/GitTfsTest/Commands/InitBranchTest.cs
+++ b/GitTfsTest/Commands/InitBranchTest.cs
@@ -66,7 +66,7 @@ namespace Sep.Git.Tfs.Test.Commands
             remote.Tfs.Stub(t => t.GetRootChangesetForBranch("$/MyProject/MyBranch")).Return(new List<RootBranch>() { new RootBranch(2010, "$/MyProject/MyBranch") });
             var mockRemote = MockRepository.GenerateStub<IGitTfsRemote>();
             mockRemote.Stub(r => r.Fetch(Arg<bool>.Is.Anything, Arg<int>.Is.Anything, Arg<IRenameResult>.Is.Anything)).Return(new GitTfsRemote.FetchResult() { IsSuccess = true });
-            remote.Stub(t => t.InitBranch(Arg<RemoteOptions>.Is.Anything, Arg<string>.Is.Anything, Arg<long>.Is.Anything, Arg<bool>.Is.Anything, Arg<string>.Is.Anything, Arg<IRenameResult>.Is.Anything)).Return(mockRemote);
+            remote.Stub(t => t.InitBranch(Arg<RemoteOptions>.Is.Anything, Arg<string>.Is.Anything, Arg<int>.Is.Anything, Arg<bool>.Is.Anything, Arg<string>.Is.Anything, Arg<IRenameResult>.Is.Anything)).Return(mockRemote);
 
             gitRepository.Expect(x => x.ReadTfsRemote("default")).Return(remote).Repeat.Once();
             gitRepository.Expect(x => x.ReadAllTfsRemotes()).Return(new List<IGitTfsRemote> { remote }).Repeat.Once();
@@ -92,7 +92,7 @@ namespace Sep.Git.Tfs.Test.Commands
             remote.Tfs = mocks.Get<ITfsHelper>();
             var mockRemote = MockRepository.GenerateStub<IGitTfsRemote>();
             mockRemote.Stub(r => r.Fetch(Arg<bool>.Is.Anything, Arg<int>.Is.Anything, Arg<IRenameResult>.Is.Anything)).Return(new GitTfsRemote.FetchResult() { IsSuccess = true });
-            remote.Stub(t => t.InitBranch(Arg<RemoteOptions>.Is.Anything, Arg<string>.Is.Anything, Arg<long>.Is.Anything, Arg<bool>.Is.Anything, Arg<string>.Is.Anything, Arg<IRenameResult>.Is.Anything)).Return(mockRemote);
+            remote.Stub(t => t.InitBranch(Arg<RemoteOptions>.Is.Anything, Arg<string>.Is.Anything, Arg<int>.Is.Anything, Arg<bool>.Is.Anything, Arg<string>.Is.Anything, Arg<IRenameResult>.Is.Anything)).Return(mockRemote);
             remote.Tfs.Stub(t => t.GetRootChangesetForBranch("$/MyProject/MyBranch")).Return(new List<RootBranch>() { new RootBranch(2010, "$/MyProject/MyBranch") });
 
             IGitTfsRemote existingBranchRemote = MockRepository.GenerateStub<IGitTfsRemote>();
@@ -168,7 +168,7 @@ namespace Sep.Git.Tfs.Test.Commands
             remote.Tfs = mocks.Get<ITfsHelper>();
             var mockRemote = MockRepository.GenerateStub<IGitTfsRemote>();
             mockRemote.Stub(r => r.Fetch(Arg<bool>.Is.Anything, Arg<int>.Is.Anything, Arg<IRenameResult>.Is.Anything)).Return(new GitTfsRemote.FetchResult() { IsSuccess = true });
-            remote.Stub(t => t.InitBranch(Arg<RemoteOptions>.Is.Anything, Arg<string>.Is.Anything, Arg<long>.Is.Anything, Arg<bool>.Is.Anything, Arg<string>.Is.Anything, Arg<IRenameResult>.Is.Anything)).Return(mockRemote);
+            remote.Stub(t => t.InitBranch(Arg<RemoteOptions>.Is.Anything, Arg<string>.Is.Anything, Arg<int>.Is.Anything, Arg<bool>.Is.Anything, Arg<string>.Is.Anything, Arg<IRenameResult>.Is.Anything)).Return(mockRemote);
             remote.Tfs.Stub(t => t.GetRootChangesetForBranch("$/MyProject/MyBranch", -1, remote.TfsRepositoryPath)).Return(new List<RootBranch>() { new RootBranch(2008, "$/MyProject/MyBranch") });
 
             mocks.ClassUnderTest.ParentBranch = remote.TfsRepositoryPath;

--- a/GitTfsTest/Core/CommitParserTests.cs
+++ b/GitTfsTest/Core/CommitParserTests.cs
@@ -16,7 +16,7 @@ namespace Sep.Git.Tfs.Test.Core
             {
                 return new[] {
                     new object[] { "git-tfs-id: foo;C123", true, 123 },
-                    new object[] { "git-tfs-id: handle more than Int32;C" + uint.MaxValue, true, uint.MaxValue },
+                    new object[] { "git-tfs-id: handle more than Int32;C" + int.MaxValue, true, int.MaxValue },
                     new object[] { "foo-tfs-id: bar;C123", false, 0 },
                     new object[] { "\ngit-tfs-id: foo;C234\n", true, 234 },
                     new object[] { "\r\ngit-tfs-id: foo;C345\r\n", true, 345 },
@@ -32,9 +32,9 @@ namespace Sep.Git.Tfs.Test.Core
 
         [Theory]
         [PropertyData("Cases")]
-        public void Run(string message, bool expectParsed, long expectId)
+        public void Run(string message, bool expectParsed, int expectId)
         {
-            long id;
+            int id;
             bool parsed = GitRepository.TryParseChangesetId(message, out id);
             Assert.Equal(expectParsed, parsed);
             if (parsed)


### PR DESCRIPTION
instead of 'long' to match what is done in the tfs api