### PR TITLE
#875 - Gated check-in in batch could possibly give a build failed

### DIFF
--- a/GitTfs.VsCommon/TfsHelper.Common.cs
+++ b/GitTfs.VsCommon/TfsHelper.Common.cs
@@ -1331,15 +1331,22 @@ namespace Sep.Git.Tfs.VsCommon
                 queuedBuild.Refresh(QueryOptions.Definitions);
             } while (queuedBuild.Build == null || !queuedBuild.Build.BuildFinished);
             _stdout.WriteLine(string.Empty);
-            if (queuedBuild.Build.Status == BuildStatus.Succeeded)
+
+            var build = GetSpecificBuildFromQueuedBuild(queuedBuild, shelvesetName);
+            if (build.Status == BuildStatus.Succeeded)
             {
-                _stdout.WriteLine("Build success! Your changes have been checked in.");
+                _stdout.WriteLine("Build was successful! Your changes have been checked in.");
                 return VersionControl.GetLatestChangesetId();
             }
             else
             {
-                throw new GitTfsException("the build of the gated check-in has failed! Your changes has not been checked-in!");
+                throw new GitTfsException("The gated check-in has failed! Your changeset is rejected!");
             }
+        }
+
+        protected virtual IBuildDetail GetSpecificBuildFromQueuedBuild(IQueuedBuild queuedBuild, string shelvesetName)
+        {
+            return queuedBuild.Build;
         }
     }
 

--- a/GitTfs.VsCommon/TfsHelper.Vs2012Base.cs
+++ b/GitTfs.VsCommon/TfsHelper.Vs2012Base.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using Microsoft.TeamFoundation.Client;
 using Microsoft.TeamFoundation.Framework.Client;
 using Microsoft.TeamFoundation.Framework.Common;
@@ -7,6 +8,7 @@ using Microsoft.TeamFoundation.Server;
 using Microsoft.TeamFoundation.VersionControl.Client;
 using StructureMap;
 using Sep.Git.Tfs.Core.TfsInterop;
+using Microsoft.TeamFoundation.Build.Client;
 
 namespace Sep.Git.Tfs.VsCommon
 {
@@ -32,6 +34,12 @@ namespace Sep.Git.Tfs.VsCommon
                     ?? TryGetUserRegString(@"Software\Microsoft\WDExpress\" + TfsVersionString + "_Config", "InstallDir");
             }
             return vsInstallDir;
+        }
+
+        protected override IBuildDetail GetSpecificBuildFromQueuedBuild(IQueuedBuild queuedBuild, string shelvesetName)
+        {
+            var build = queuedBuild.Builds.FirstOrDefault(b => b.ShelvesetName == shelvesetName);
+            return build != null ? build : queuedBuild.Build;
         }
 
 #pragma warning disable 618


### PR DESCRIPTION
When multiple shelvesets are validated in a batch, it possible that some shelveset didn't pass. The overall build status is Partially Succeeded. To find out if the requested build has been rejected or not, lookup this build in the request builds collection and check the status.