### PR TITLE
Only get full tree if candidates for removal exist

### DIFF
--- a/GitTfs/Core/DirectoryTidier.cs
+++ b/GitTfs/Core/DirectoryTidier.cs
@@ -7,26 +7,49 @@ namespace Sep.Git.Tfs.Core
 {
     public class DirectoryTidier : ITfsWorkspaceModifier, IDisposable
     {
-        ITfsWorkspaceModifier _workspace;
-        List<string> _filesInTfs;
-        List<string> _filesRemovedFromTfs;
-        bool _disposed;
-
-        public DirectoryTidier(ITfsWorkspaceModifier workspace, IEnumerable<TfsTreeEntry> initialTfsTree)
+        enum FileOperation
         {
-            _workspace = workspace;
-            _filesInTfs = initialTfsTree.Where(entry => entry.Item.ItemType == TfsItemType.File).Select(entry => entry.FullName.ToLowerInvariant()).ToList();
-            _filesRemovedFromTfs = new List<string>();
+            Add,
+            Remove,
+            RenameFrom,
+            RenameTo,
+            Edit,
+            EditAndRenameFrom,
         }
 
+        ITfsWorkspaceModifier _workspace;
+        Func<IEnumerable<TfsTreeEntry>> _getInitialTfsTree;
+        List<string> _filesInTfs;
+        Dictionary<string, FileOperation> _fileOperations;
+        bool _disposed;
+
+        public DirectoryTidier(ITfsWorkspaceModifier workspace, Func<IEnumerable<TfsTreeEntry>> getInitialTfsTree)
+        {
+            _workspace = workspace;
+            _getInitialTfsTree = getInitialTfsTree;
+            _fileOperations = new Dictionary<string, FileOperation>(StringComparer.InvariantCultureIgnoreCase);
+        }
 
         public void Dispose()
         {
             if (_disposed)
                 return;
             _disposed = true;
+
+            var candidateDirectories = CalculateCandidateDirectories();
+            if (!candidateDirectories.Any())
+                return;
+
+            _filesInTfs = _getInitialTfsTree().Where(entry => entry.Item.ItemType == TfsItemType.File).Select(entry => entry.FullName.ToLowerInvariant()).ToList();
+
+            foreach (var fileAndOperation in _fileOperations)
+            {
+                if (fileAndOperation.Value == FileOperation.Remove)
+                    _filesInTfs.Remove(fileAndOperation.Key.ToLowerInvariant());
+            }
+
             var deletedDirs = new List<string>();
-            foreach (var dir in _filesRemovedFromTfs.Select(f => GetDirectoryName(f)).OrderBy(d => d, StringComparer.InvariantCultureIgnoreCase))
+            foreach (var dir in candidateDirectories.OrderBy(d => d, StringComparer.InvariantCultureIgnoreCase))
             {
                 DeleteEmptyDir(dir, deletedDirs);
             }
@@ -67,7 +90,6 @@ namespace Sep.Git.Tfs.Core
             return _filesInTfs.Any(file => file.StartsWith(dirName));
         }
 
-
         string ITfsWorkspaceModifier.GetLocalPath(string path)
         {
             return _workspace.GetLocalPath(path);
@@ -76,33 +98,60 @@ namespace Sep.Git.Tfs.Core
         void ITfsWorkspaceModifier.Add(string path)
         {
             _workspace.Add(path);
-            _filesInTfs.Add(path.ToLowerInvariant());
+            _fileOperations.Add(path, FileOperation.Add);
         }
 
         void ITfsWorkspaceModifier.Edit(string path)
         {
             _workspace.Edit(path);
+            _fileOperations.Add(path, FileOperation.Edit);
         }
 
         void ITfsWorkspaceModifier.Delete(string path)
         {
             _workspace.Delete(path);
-            _filesRemovedFromTfs.Add(path);
-            _filesInTfs.Remove(path.ToLowerInvariant());
+            _fileOperations.Add(path, FileOperation.Remove);
         }
 
         void ITfsWorkspaceModifier.Rename(string pathFrom, string pathTo, string score)
         {
             _workspace.Rename(pathFrom, pathTo, score);
-            /*
-            // Even though this may have been removed from a directory, we'll
-            // make it look like it wasn't, because TFS doesn't allow these
-            // directories to be removed.
-            // See https://github.com/git-tfs/git-tfs/issues/313
-            _filesRemovedFromTfs.Add(pathFrom);
-            _filesInTfs.Remove(pathFrom.ToLowerInvariant());
-            */
-            _filesInTfs.Add(pathTo.ToLowerInvariant());
+
+            FileOperation pathFromOperation;
+            if (_fileOperations.TryGetValue(pathFrom, out pathFromOperation) &&
+                pathFromOperation == FileOperation.Edit)
+            {
+                _fileOperations[pathFrom] = FileOperation.EditAndRenameFrom;
+            }
+            else
+            {
+                _fileOperations.Add(pathFrom, FileOperation.RenameFrom);
+            }
+            _fileOperations.Add(pathTo, FileOperation.RenameTo);
+        }
+
+        IEnumerable<string> CalculateCandidateDirectories()
+        {
+            var directoriesWithRemovedFiles = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
+            var directoriesBlockedForRemoval = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
+
+            foreach (var fileAndOperation in _fileOperations)
+            {
+                var directory = GetDirectoryName(fileAndOperation.Key);
+                switch (fileAndOperation.Value)
+                {
+                    case FileOperation.Remove:
+                        directoriesWithRemovedFiles.Add(directory);
+                        break;
+                    default:
+                        directoriesBlockedForRemoval.Add(directory);
+                        break;
+                }
+            }
+
+            directoriesBlockedForRemoval.Add(null);
+            directoriesWithRemovedFiles.ExceptWith(directoriesBlockedForRemoval);
+            return directoriesWithRemovedFiles;
         }
     }
 }

--- a/GitTfs/Core/GitTfsRemote.cs
+++ b/GitTfs/Core/GitTfsRemote.cs
@@ -877,7 +877,7 @@ namespace Sep.Git.Tfs.Core
 
         private void PendChangesToWorkspace(string head, string parent, ITfsWorkspaceModifier workspace)
         {
-            using (var tidyWorkspace = new DirectoryTidier(workspace, GetLatestChangeset().GetFullTree()))
+            using (var tidyWorkspace = new DirectoryTidier(workspace, () => GetLatestChangeset().GetFullTree()))
             {
                 foreach (var change in Repository.GetChangedFiles(parent, head))
                 {


### PR DESCRIPTION
Getting the initial TFS tree to determine which empty folders can be
deleted can be slow. The directory tidier will now process the changes
first to determine if there are possible candidates for removal, then get
the initial TFS tree to verify if needed.