### PR TITLE
Don't stop the release build if uploading the archive to github.com fails

### DIFF
--- a/Release.proj
+++ b/Release.proj
@@ -155,7 +155,7 @@
 
   <!-- Internal: Create a release on github.com -->
   <Target Name="ReleaseOnGitHub" DependsOnTargets="VersionRequired; AuthTokenRequired; MSBuildCommunityTasks">
-    <CreateRelease Condition="'$(DryRun)' == 'False'" Repository="$(GitHubOwner)/$(GitHubRepository)" TagName="v$(Version)" Files="@(ArchiveFile)" OauthToken="$(GitHubAuthToken)" ReleaseNotesFile="$(ReleaseNotes)" />
+    <CreateRelease Condition="'$(DryRun)' == 'False'" Repository="$(GitHubOwner)/$(GitHubRepository)" TagName="v$(Version)" Files="@(ArchiveFile)" OauthToken="$(GitHubAuthToken)" ReleaseNotesFile="$(ReleaseNotes)" ContinueOnError="ErrorAndContinue" />
     <Message Condition="'$(DryRun)' != 'False'" Text="(would create release on github.com)" />
   </Target>
 

--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -1,0 +1,1 @@
+* Other fixes (#886)


### PR DESCRIPTION
This fails pretty much every time I try it. I end up manually uploading the archive and digging through the msbuild file to figure out what still needs to be done to finish the build.

This change doesn't make the release upload any more reliable, but it should let the rest of the release steps finish, while still reporting the error. I'll just have to notice the error and manually upload the zip file.