### PR TITLE
Mitigate crash with version supporting VS2015 for users of other versions

### DIFF
--- a/GitTfs/Commands/Info.cs
+++ b/GitTfs/Commands/Info.cs
@@ -54,6 +54,8 @@ namespace Sep.Git.Tfs.Commands
             _stdout.WriteLine(_versionProvider.GetVersionString());
             _stdout.WriteLine(" " + _versionProvider.GetPathToGitTfsExecutable());
 
+            _stdout.WriteLine(GitTfsConstants.MessageForceVersion);
+
             DescribeGitRepository();
         }
 

--- a/GitTfs/Commands/Version.cs
+++ b/GitTfs/Commands/Version.cs
@@ -34,6 +34,8 @@ namespace Sep.Git.Tfs.Commands
             stdout.WriteLine(versionProvider.GetVersionString());
             stdout.WriteLine(versionProvider.GetPathToGitTfsExecutable());
 
+            stdout.WriteLine(GitTfsConstants.MessageForceVersion);
+
             return GitTfsExitCodes.OK;
         }
 

--- a/GitTfs/Core/TfsInterop/TfsPlugin.cs
+++ b/GitTfs/Core/TfsInterop/TfsPlugin.cs
@@ -20,10 +20,10 @@ namespace Sep.Git.Tfs.Core.TfsInterop
                 return x.Try("GitTfs.Vs" + explicitVersion, "Sep.Git.Tfs.TfsPlugin") ??
                        x.Fail("Unable to load TFS version specified in GIT_TFS_CLIENT (" + explicitVersion + ")!");
             }
-            return x.Try("GitTfs.Vs2015", "Sep.Git.Tfs.TfsPlugin") ?? 
-                   x.Try("GitTfs.Vs2013", "Sep.Git.Tfs.TfsPlugin") ??
+            return x.Try("GitTfs.Vs2013", "Sep.Git.Tfs.TfsPlugin") ??
                    x.Try("GitTfs.Vs2012", "Sep.Git.Tfs.TfsPlugin") ??
                    x.Try("GitTfs.Vs2010", "Sep.Git.Tfs.TfsPlugin") ??
+                   x.Try("GitTfs.Vs2015", "Sep.Git.Tfs.TfsPlugin") ??
                    x.Fail();
         }
 

--- a/GitTfs/GitTfs.cs
+++ b/GitTfs/GitTfs.cs
@@ -60,6 +60,7 @@ namespace Sep.Git.Tfs
             else if(_globals.ShowVersion)
             {
                 _container.GetInstance<TextWriter>().WriteLine(_gitTfsVersionProvider.GetVersionString());
+                _container.GetInstance<TextWriter>().WriteLine(GitTfsConstants.MessageForceVersion);
                 return GitTfsExitCodes.OK;
             }
             else

--- a/GitTfs/GitTfsConstants.cs
+++ b/GitTfs/GitTfsConstants.cs
@@ -70,5 +70,9 @@ namespace Sep.Git.Tfs
 
         public const string BatchSize = GitTfsPrefix + ".batch-size";
         public static string InitialChangeset = GitTfsPrefix + ".initial-changeset";
+        public static string MessageForceVersion = Environment.NewLine
+            + "Note: If you want to force git-tfs to use another version of the tfs client library,"
+            + Environment.NewLine
+            + "set the environment variable `GIT_TFS_CLIENT` with the wished version (ie: '2013' for Visual Stusio 2013,...)";
     }
 }


### PR DESCRIPTION
Should let #893 happens less likely, the problem happening only for users with VS205 **AND** another older version of VisualStudio.

They will have to set the environment variable `GIT_TFS_CLIENT` to `2015` if they want to use the tfs client library of VS2015 instead of the ones of the other version.

Added also a message to inform users when using `git tfs version` command....