### PR TITLE
[WIP] Fixed #873 clone with renamed or recreated branches leads to infinite loop

### DIFF
--- a/GitTfsTest/Integration/CloneTests.cs
+++ b/GitTfsTest/Integration/CloneTests.cs
@@ -60,6 +60,20 @@ namespace Sep.Git.Tfs.Test.Integration
         }
 
         [FactExceptOnUnix]
+        public void CloneWithRecreatedBranches()
+        {
+            h.SetupFake(r =>
+            {
+                r.Changeset(1, "Create Team Project", DateTime.Now).Change(TfsChangeType.Add, TfsItemType.Folder, "$/MyProject");
+                r.Changeset(2, "Create trunk", DateTime.Now).Change(TfsChangeType.Add, TfsItemType.Folder, "$/MyProject/Trunk");
+                r.BranchChangeset(3, "Create branch", DateTime.Now, "$/MyProject/Trunk", "$/MyProject/Branch", 2);
+                r.Changeset(4, "Delete branch", DateTime.Now).Change(TfsChangeType.Delete, TfsItemType.Folder, "$/MyProject/Branch");
+                r.BranchChangeset(5, "Create branch", DateTime.Now, "$/MyProject/Trunk", "$/MyProject/Branch", 4);
+            });
+            h.Run("clone", "--branches=all", h.TfsUrl, "$/MyProject/Trunk");
+        }
+
+        [FactExceptOnUnix]
         public void CloneProjectWithInternationalCharactersInFileNamesAndFolderNames()
         {
             h.SetupFake(r =>


### PR DESCRIPTION
Trying to fix #873 clone with renamed or recreated branches leads to infinite loop

The new test fails with: `System.ArgumentException : An item with the same key has already been added.`

Any ideas?
