### PR TITLE
Rcheckin should respect --no-merge option

### DIFF
--- a/GitTfs/Commands/Rcheckin.cs
+++ b/GitTfs/Commands/Rcheckin.cs
@@ -129,7 +129,9 @@ namespace Sep.Git.Tfs.Commands
                 var message = BuildCommitMessage(commit, !_checkinOptions.NoGenerateCheckinComment, currentParent);
                 string target = commit.Sha;
                 var parents = commit.Parents.Where(c => c.Sha != currentParent).ToArray();
-                string tfsRepositoryPathOfMergedBranch = FindTfsRepositoryPathOfMergedBranch(tfsRemote, parents, target);
+                string tfsRepositoryPathOfMergedBranch = _checkinOptions.NoMerge
+                                                             ? null
+                                                             : FindTfsRepositoryPathOfMergedBranch(tfsRemote, parents, target);
 
                 var commitSpecificCheckinOptions = _checkinOptionsFactory.BuildCommitSpecificCheckinOptions(_checkinOptions, message, commit, _authors);
 


### PR DESCRIPTION
I found that `--no-merge` was used just to format output string, but made no difference with TFS doing. And as I actually needed the option I had to fix it.

I'm not sure though it is the only place that requires changes, but I haven't found others.