### PR TITLE
Added option for opt-out of TFS merge replicating

### DIFF
--- a/GitTfs/Commands/Init.cs
+++ b/GitTfs/Commands/Init.cs
@@ -138,6 +138,7 @@ namespace Sep.Git.Tfs.Commands
 
         private void GitTfsInit(string tfsUrl, string tfsRepositoryPath)
         {
+            globals.Repository.ReplicateTfsMerges = initOptions.ReplicateTfsMerges;
             globals.Repository.CreateTfsRemote(new RemoteInfo
             {
                 Id = globals.RemoteId,

--- a/GitTfs/Commands/InitOptions.cs
+++ b/GitTfs/Commands/InitOptions.cs
@@ -10,7 +10,11 @@ namespace Sep.Git.Tfs.Commands
     {
         private const string default_autocrlf = "false";
 
-        public InitOptions() { GitInitAutoCrlf = default_autocrlf; }
+        public InitOptions()
+        {
+            GitInitAutoCrlf = default_autocrlf;
+            ReplicateTfsMerges = true;
+        }
 
         public OptionSet OptionSet
         {
@@ -27,6 +31,7 @@ namespace Sep.Git.Tfs.Commands
                     { "ignorecase=", "Ignore case in file paths (default: system default)",
                         v => GitInitIgnoreCase = ValidateIgnoreCaseValue(v) },
                     {"bare", "Clone the TFS repository in a bare git repository", v => IsBare = v != null},
+                    {"m|replicateTfsMerges", "Mark TFS merge changesets as merge commits in git; default is true", v => ReplicateTfsMerges = v != null},
                     {"workspace=", "Set tfs workspace to a specific folder (a shorter path is better!)", v => WorkspacePath = v},
                 };
             }
@@ -55,5 +60,6 @@ namespace Sep.Git.Tfs.Commands
         public object GitInitShared { get; set; }
         public string GitInitAutoCrlf { get; set; }
         public string GitInitIgnoreCase { get; set; }
+        public bool ReplicateTfsMerges { get; set; }
     }
 }

--- a/GitTfs/Core/GitRepository.cs
+++ b/GitTfs/Core/GitRepository.cs
@@ -497,6 +497,16 @@ namespace Sep.Git.Tfs.Core
             }
         }
 
+        public bool ReplicateTfsMerges
+        {
+            get
+            {
+                string val = GetConfig("tfs.replicateTfsMerges");
+                return val == null || val == "1";
+            }
+            set { SetConfig("tfs.replicateTfsMerges", value ? "1" : "0"); }
+        }
+
         public void CopyBlob(string sha, string outputFile)
         {
             Blob blob; 

--- a/GitTfs/Core/GitTfsRemote.cs
+++ b/GitTfs/Core/GitTfsRemote.cs
@@ -342,7 +342,7 @@ namespace Sep.Git.Tfs.Core
                     if (lastChangesetIdToFetch > 0 && changeset.Summary.ChangesetId > lastChangesetIdToFetch)
                         return fetchResult;
                     string parentCommitSha = null;
-                    if (changeset.IsMergeChangeset && !ProcessMergeChangeset(changeset, stopOnFailMergeCommit, ref parentCommitSha))
+                    if (Repository.ReplicateTfsMerges && changeset.IsMergeChangeset && !ProcessMergeChangeset(changeset, stopOnFailMergeCommit, ref parentCommitSha))
                     {
                         fetchResult.IsSuccess = false;
                         return fetchResult;

--- a/GitTfs/Core/IGitRepository.cs
+++ b/GitTfs/Core/IGitRepository.cs
@@ -34,6 +34,7 @@ namespace Sep.Git.Tfs.Core
         IGitTreeBuilder GetTreeBuilder(string commit);
         IEnumerable<IGitChangedFile> GetChangedFiles(string from, string to);
         bool WorkingCopyHasUnstagedOrUncommitedChanges { get; }
+        bool ReplicateTfsMerges { get; set; }
         void CopyBlob(string sha, string outputFile);
         GitCommit GetCommit(string commitish);
         MergeResult Merge(string commitish);


### PR DESCRIPTION
Sometimes TFS guys do merge changesets apparently at random, while in git merge-commit has meaning that _all_ commits in the parent branches are merged. Thus preserving all of the merges sometimes do more harm than good. New setting is tfs.replicateTfsMerges and could be "0" or "1". This setting is turned on by default (i.e. if there's no such value in the git config file - it treats as "1") and is global (not tied to particular tfs remote/branch - mostly because on the per-tfs-remote basis it can do much confusion if configured differently in different places.

Also `init` command now has `-m+` or `--replicateTfsMerges+` option, that is true by default, but can be opted out like `-m-` or `--replicateTfsMerges-` (not sure it is the best syntax, but by the [NDesk.Options docs](http://www.ndesk.org/Options) it is the one used for bools).