### PR TITLE
Eliminated multiple IEnumerable enumerations causing excessive TFS communication

### DIFF
--- a/GitTfs/Core/GitTfsRemote.cs
+++ b/GitTfs/Core/GitTfsRemote.cs
@@ -328,16 +328,18 @@ namespace Sep.Git.Tfs.Core
             // TFS 2010 doesn't like when we ask for history past its last changeset.
             if (MaxChangesetId >= latestChangesetId)
                 return fetchResult;
-            IEnumerable<ITfsChangeset> fetchedChangesets;
+                        
+            bool fetchRetrievedChangesets;
             do
             {
-                fetchedChangesets = FetchChangesets(true, lastChangesetIdToFetch);
-                if(!fetchedChangesets.Any())
-                    return fetchResult;
-
+                var fetchedChangesets = FetchChangesets(true, lastChangesetIdToFetch);
+                
                 var objects = BuildEntryDictionary();
+                fetchRetrievedChangesets = false;
                 foreach (var changeset in fetchedChangesets)
                 {
+                    fetchRetrievedChangesets = true;
+
                     fetchResult.NewChangesetCount++;
                     if (lastChangesetIdToFetch > 0 && changeset.Summary.ChangesetId > lastChangesetIdToFetch)
                         return fetchResult;
@@ -378,7 +380,7 @@ namespace Sep.Git.Tfs.Core
                     }
                     DoGcIfNeeded();
                 }
-            } while (fetchedChangesets.Any() && latestChangesetId > fetchResult.LastFetchedChangesetId);
+            } while (fetchRetrievedChangesets && latestChangesetId > fetchResult.LastFetchedChangesetId);
             return fetchResult;
         }
 


### PR DESCRIPTION
GitTfsRemote.FetchWithMerge performs a multiple enumeration of fetchedChangesets enumerable (via Any/foreach/Any once again), which causes TfsHelperBase.GetChangesets to query TFS via VersionControl.QueryHistory several times instead of one.

The code after fix might shave off some seconds during pull, and is generally more lean with regard to network communication.

I do not know how important it is to keep TfsHelperBase.GetChangesets lazy, so I avoided the simplest fix of materializing FetchChangesets result using ToList.