### PR TITLE
Vsts missing author fix

### DIFF
--- a/GitTfs.VsCommon/TfsHelper.Vs2012Base.cs
+++ b/GitTfs.VsCommon/TfsHelper.Vs2012Base.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using Microsoft.TeamFoundation.Client;
 using Microsoft.TeamFoundation.Framework.Client;
 using Microsoft.TeamFoundation.Framework.Common;
-using Microsoft.TeamFoundation.Server;
 using Microsoft.TeamFoundation.VersionControl.Client;
 using StructureMap;
 using Sep.Git.Tfs.Core.TfsInterop;
@@ -42,19 +41,22 @@ namespace Sep.Git.Tfs.VsCommon
             return build != null ? build : queuedBuild.Build;
         }
 
-#pragma warning disable 618
-        private IGroupSecurityService GroupSecurityService
+        private IIdentityManagementService IdentityManagementService
         {
-            get { return GetService<IGroupSecurityService>(); }
+            get { return GetService<IIdentityManagementService>(); }
         }
 
         public override IIdentity GetIdentity(string username)
         {
-            return _bridge.Wrap<WrapperForIdentity, Identity>(Retry.Do(() => GroupSecurityService.ReadIdentity(SearchFactor.AccountName, username, QueryMembership.None)));
+            var identities = new Guid[] { new Guid(username) };
+            var teamFoundationIdentities = Retry.Do(() => IdentityManagementService.ReadIdentities(identities, MembershipQuery.None));
+            var teamFoundationIdentity = teamFoundationIdentities.First();
+            return _bridge.Wrap<WrapperForIdentity, TeamFoundationIdentity>(teamFoundationIdentity);
         }
 
         protected override TfsTeamProjectCollection GetTfsCredential(Uri uri)
         {
+#pragma warning disable 618
             return HasCredentials ?
                 new TfsTeamProjectCollection(uri, GetCredential(), new UICredentialsProvider()) :
                 new TfsTeamProjectCollection(uri, new UICredentialsProvider());

--- a/GitTfs.VsCommon/Wrappers.cs
+++ b/GitTfs.VsCommon/Wrappers.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using Microsoft.TeamFoundation.Framework.Client;
 using Microsoft.TeamFoundation.Server;
 using Microsoft.TeamFoundation.VersionControl.Client;
 using Sep.Git.Tfs.Core;
@@ -190,11 +191,11 @@ namespace Sep.Git.Tfs.VsCommon
         }
     }
 
-    public class WrapperForIdentity : WrapperFor<Identity>, IIdentity
+    public class WrapperForIdentity : WrapperFor<TeamFoundationIdentity>, IIdentity
     {
-        private readonly Identity _identity;
+        private readonly TeamFoundationIdentity _identity;
 
-        public WrapperForIdentity(Identity identity) : base(identity)
+        public WrapperForIdentity(TeamFoundationIdentity identity) : base(identity)
         {
             Debug.Assert(identity != null, "wrapped property must not be null.");
             _identity = identity;
@@ -202,7 +203,7 @@ namespace Sep.Git.Tfs.VsCommon
 
         public string MailAddress
         {
-            get { return _identity.MailAddress; }
+            get { return _identity.UniqueName; } // when tested with VSTS this seems to be the property that email lives in
         }
 
         public string DisplayName

--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -1,3 +1,4 @@
 * Rcheckin should respect --no-merge option (#928 @ivan-danilov)
 * Revert "Also build the installer in CI" (#925, #922)
 * Eliminated multiple IEnumerable enumerations causing excessive TFS communication (#936 @ogvolkov)
+* Fix reading author from VSTS #934


### PR DESCRIPTION
Thanks a lot for the pull request you are going to do!
Please verify that you validate these points:
- [x] indentation is made with 4 spaces
- [x] your pull request contains only changes intended (no refactoring, line return added, ... that could make code review harder. Make another one if you think it is needed...)
- [x] run and verify that existing tests pass and add some new units tests, if needed.
- [ ] update the documentation, if needed.
- [x] update the [release notes file](../tree/master/doc/release-notes/NEXT.md)

---

Something changed on Visual Studio Team Services that meant the old
deprecated API we were using no longer returned the name/email we need,
resulting in commit authors being the raw user guid. This change
finishes off the change to the new API that was started previously and
gets it producing the display name and email address again.
- Read identity from GUID using new API.
- Update wrapper to use new TFS identity class.
- Map returned data based on what looked right when debugging.

Effectively reverts and finishes off the original change: "Revert
TeamFoundationIdentity because it changes the identity received" -
2b8eaecd993b1112b38da019d7664215b8ad8e49.

refs:
- https://social.msdn.microsoft.com/Forums/vstudio/en-US/c0fea096-92d5-4466-832c-43db0a4e65ae/how-to-retrive-user-alias-by-user-guid?forum=tfsgeneral
- https://msdn.microsoft.com/en-us/library/ff731923%28v=vs.120%29.aspx - IIdentityManagementService.ReadIdentities()

Fixes #934
