### PR TITLE
Handle interaction between -m and commit message. Fix problem with gi…

### DIFF
--- a/GitTfs/Core/TfsWorkspace.cs
+++ b/GitTfs/Core/TfsWorkspace.cs
@@ -41,7 +41,7 @@ namespace Sep.Git.Tfs.Core
                 throw new GitTfsException("Nothing to shelve!");
 
             var shelveset = _tfsHelper.CreateShelveset(_workspace, shelvesetName);
-            shelveset.Comment = string.IsNullOrWhiteSpace(_checkinOptions.CheckinComment) && !_checkinOptions.NoGenerateCheckinComment ? generateCheckinComment() : _checkinOptions.CheckinComment;
+            shelveset.Comment = string.IsNullOrWhiteSpace(checkinOptions.CheckinComment) && !checkinOptions.NoGenerateCheckinComment ? generateCheckinComment() : checkinOptions.CheckinComment;
             shelveset.WorkItemInfo = GetWorkItemInfos(checkinOptions).ToArray();
             if (evaluateCheckinPolicies)
             {

--- a/GitTfs/Util/CheckinOptionsFactory.cs
+++ b/GitTfs/Util/CheckinOptionsFactory.cs
@@ -54,9 +54,15 @@ namespace Sep.Git.Tfs.Util
         {
             var customCheckinOptions = sourceCheckinOptions.Clone(this.globals);
 
+            // Use commit message comment in call to ProcessWorkItemCommands
             customCheckinOptions.CheckinComment = commitMessage;
-
             customCheckinOptions.ProcessWorkItemCommands(writer, false);
+
+            // This means a -m was provided. Override the shelveset comment with the -m value.
+            if (!string.IsNullOrWhiteSpace(sourceCheckinOptions.CheckinComment))
+            {
+                customCheckinOptions.CheckinComment = sourceCheckinOptions.CheckinComment;
+            }
 
             return customCheckinOptions;
         }


### PR DESCRIPTION
Thanks a lot for the pull request you are going to do!
Please verify that you validate these points:

- [ ] indentation is made with 4 spaces
- [ ] your pull request contains only changes intended (no refactoring, line return added, ... that could make code review harder. Make another one if you think it is needed...)
- [ ] run and verify that existing tests pass and add some new units tests, if needed.
- [ ] update the documentation, if needed.
- [ ] update the [release notes file](../tree/master/doc/release-notes/NEXT.md)
…t-tfs-work-item:# not being removed.

Change to BuildShelveSetSpecificCheckinOptions means work items are never scraped from the -m, but the -m is still used as a comment after. Using checkinOptions rather than _checkinOptions fixes the removal problem.