### PR TITLE
Use index notation to change GIT_PAGER

### DIFF
--- a/GitTfs/Core/GitHelpers.cs
+++ b/GitTfs/Core/GitHelpers.cs
@@ -241,7 +241,7 @@ namespace Sep.Git.Tfs.Core
             startInfo.SetArguments(command);
             startInfo.CreateNoWindow = true;
             startInfo.UseShellExecute = false;
-            startInfo.EnvironmentVariables.Add("GIT_PAGER", "cat");
+            startInfo.EnvironmentVariables["GIT_PAGER"] = "cat";
             RedirectStderr(startInfo);
             initialize(startInfo);
             Trace.WriteLine("Starting process: " + startInfo.FileName + " " + startInfo.Arguments, "git command");


### PR DESCRIPTION
This should make it either add the variable if it's not present, or
modify an existing one if it is -- avoiding an error in that case.

Fixes issue #958.

(I'd add some test, but that goes beyond both a "quick fix" and my knowledge of C#...)
