### PR TITLE
Feature/fix changesets comments policy error

### DIFF
--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -3,3 +3,4 @@
 * Eliminated multiple IEnumerable enumerations causing excessive TFS communication (#936 @ogvolkov)
 * Fix -m argument for shelve command, which was being ignored (#912)
 * Fix env var usage (#967)
+* Update TFS Client libraries to NuGet package version 14.95.3 (#959)

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -2,8 +2,8 @@ source https://www.nuget.org/api/v2/
 
 nuget NuGet.CommandLine
 nuget LibGit2Sharp 0.21.0.176
-nuget Microsoft.TeamFoundationServer.Client 14.89.0 framework: >= net45
-nuget Microsoft.TeamFoundationServer.ExtendedClient 14.89.0 framework: >= net45
+nuget Microsoft.TeamFoundationServer.Client 14.95.3 framework: >= net45
+nuget Microsoft.TeamFoundationServer.ExtendedClient 14.95.3 framework: >= net45
 nuget WixSharp 1.0.22.3 framework: >= net40
 nuget xunit 1.9.2 framework: >= net40
 nuget xunit.extensions 1.9.2 framework: >= net40


### PR DESCRIPTION
Update the `Microsoft.TeamFoundationServer.*Client` references from `14.89.0` to `14.95.3`. The justification is that when we were on a TFS 2012 server, the current references worked. However, at the organization I work at, we recently migrated to TFS 2013. After migration, we got one of the following errors:

>ERROR] Policy: Internal error in Changeset Comments Policy. Error loading the Changeset Comments Policy polilture=neutral, PublicKeyToken=b03f5f7f11d50a3a' is not registered.). Installation instructions:
>No changes checked in.

and

>[ERROR] Policy: Internal error in Changeset Comments Policy. Error loading the Changeset Comments Policy policy (The policy assembly 'Microsoft.TeamFoundation.PowerTools.CheckinPolicies.ChangesetComments, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' is not registered.). Installation instructions:
>No changes checked in.

This fixes the issue reported as issue #959 by @JoachimC.