### PR TITLE
Logs the "TFS 2010 doesn't like..." comment

### DIFF
--- a/GitTfs/Core/GitTfsRemote.cs
+++ b/GitTfs/Core/GitTfsRemote.cs
@@ -325,9 +325,12 @@ namespace Sep.Git.Tfs.Core
             var latestChangesetId = GetLatestChangesetId();
             if (lastChangesetIdToFetch != -1)
                 latestChangesetId = Math.Min(latestChangesetId, lastChangesetIdToFetch);
-            // TFS 2010 doesn't like when we ask for history past its last changeset.
+
             if (MaxChangesetId >= latestChangesetId)
+            {
+                Trace.WriteLine("TFS 2010 doesn't like when we ask for history past its last changeset.");
                 return fetchResult;
+            }
                         
             bool fetchRetrievedChangesets;
             do


### PR DESCRIPTION
Lost quite some time figuring out why git-tfs wasn't working. After some debugging I ended up on this line. Would be useful to have this appear in the console instead of having it as a comment in code.