### PR TITLE
Custom TFS check-in notes are not exported to commit message (#1004)

### DIFF
--- a/GitTfs.VsCommon/TfsHelper.Common.cs
+++ b/GitTfs.VsCommon/TfsHelper.Common.cs
@@ -568,21 +568,11 @@ namespace Sep.Git.Tfs.VsCommon
                         Url = Linking.GetArtifactUrl(wi.Uri.AbsoluteUri)
                     });
             }
-            foreach (var checkinNote in changeset.CheckinNote.Values)
-            {
-                switch (checkinNote.Name)
+            tfsChangeset.Summary.CheckinNotes = changeset.CheckinNote.Values.Select(note => new TfsCheckinNote
                 {
-                    case GitTfsConstants.CodeReviewer:
-                        tfsChangeset.Summary.CodeReviewer = checkinNote.Value;
-                        break;
-                    case GitTfsConstants.SecurityReviewer:
-                        tfsChangeset.Summary.SecurityReviewer = checkinNote.Value;
-                        break;
-                    case GitTfsConstants.PerformanceReviewer:
-                        tfsChangeset.Summary.PerformanceReviewer = checkinNote.Value;
-                        break;
-                }
-            }
+                    Name = note.Name,
+                    Value = note.Value
+                });
             tfsChangeset.Summary.PolicyOverrideComment = changeset.PolicyOverride.Comment;
             
             return tfsChangeset;

--- a/GitTfs/Core/GitTfsRemote.cs
+++ b/GitTfs/Core/GitTfsRemote.cs
@@ -470,12 +470,12 @@ namespace Sep.Git.Tfs.Core
                 }
 
                 if (!string.IsNullOrWhiteSpace(changeset.Summary.PolicyOverrideComment))
-                    log.Log += "\n" + GitTfsConstants.GitTfsPolicyOverrideCommentPrefix + changeset.Summary.PolicyOverrideComment;
+                    log.Log += "\n" + GitTfsConstants.GitTfsPolicyOverrideCommentPrefix + " " + changeset.Summary.PolicyOverrideComment;
 
                 foreach (var checkinNote in changeset.Summary.CheckinNotes)
                 {
                     if (!string.IsNullOrWhiteSpace(checkinNote.Name) && !string.IsNullOrWhiteSpace(checkinNote.Value))
-                        log.Log += "\n" + GitTfsConstants.GitTfsPrefix + "-" + CamelCaseToDelimitedStringConverter.Convert(checkinNote.Name, "-") + ":" + checkinNote.Value;
+                        log.Log += "\n" + GitTfsConstants.GitTfsPrefix + "-" + CamelCaseToDelimitedStringConverter.Convert(checkinNote.Name, "-") + ": " + checkinNote.Value;
                 }
             }
 
@@ -504,12 +504,12 @@ namespace Sep.Git.Tfs.Core
             }
 
             if (!string.IsNullOrWhiteSpace(changeset.Summary.PolicyOverrideComment))
-                metadatas.Append("\nPolicy Override Comment:" + changeset.Summary.PolicyOverrideComment);
+                metadatas.Append("\nPolicy Override Comment: " + changeset.Summary.PolicyOverrideComment);
 
             foreach (var checkinNote in changeset.Summary.CheckinNotes)
             {
                 if (!string.IsNullOrWhiteSpace(checkinNote.Name) && !string.IsNullOrWhiteSpace(checkinNote.Value))
-                    metadatas.Append("\n" + checkinNote.Name + ":" + checkinNote.Value);
+                    metadatas.Append("\n" + checkinNote.Name + ": " + checkinNote.Value);
             }
 
             if (!string.IsNullOrWhiteSpace(changeset.OmittedParentBranch))

--- a/GitTfs/Core/GitTfsRemote.cs
+++ b/GitTfs/Core/GitTfsRemote.cs
@@ -472,14 +472,11 @@ namespace Sep.Git.Tfs.Core
                 if (!string.IsNullOrWhiteSpace(changeset.Summary.PolicyOverrideComment))
                     log.Log += "\n" + GitTfsConstants.GitTfsPolicyOverrideCommentPrefix + changeset.Summary.PolicyOverrideComment;
 
-                if (!string.IsNullOrWhiteSpace(changeset.Summary.CodeReviewer))
-                    log.Log += "\n" + GitTfsConstants.GitTfsCodeReviewerPrefix + changeset.Summary.CodeReviewer;
-
-                if (!string.IsNullOrWhiteSpace(changeset.Summary.SecurityReviewer))
-                    log.Log += "\n" + GitTfsConstants.GitTfsSecurityReviewerPrefix + changeset.Summary.SecurityReviewer;
-
-                if (!string.IsNullOrWhiteSpace(changeset.Summary.PerformanceReviewer))
-                    log.Log += "\n" + GitTfsConstants.GitTfsPerformanceReviewerPrefix + changeset.Summary.PerformanceReviewer;
+                foreach (var checkinNote in changeset.Summary.CheckinNotes)
+                {
+                    if (!string.IsNullOrWhiteSpace(checkinNote.Name) && !string.IsNullOrWhiteSpace(checkinNote.Value))
+                        log.Log += "\n" + GitTfsConstants.GitTfsPrefix + "-" + CamelCaseToDelimitedStringConverter.Convert(checkinNote.Name, "-") + ":" + checkinNote.Value;
+                }
             }
 
             var commitSha = Commit(log);
@@ -509,14 +506,11 @@ namespace Sep.Git.Tfs.Core
             if (!string.IsNullOrWhiteSpace(changeset.Summary.PolicyOverrideComment))
                 metadatas.Append("\nPolicy Override Comment:" + changeset.Summary.PolicyOverrideComment);
 
-            if (!string.IsNullOrWhiteSpace(changeset.Summary.CodeReviewer))
-                metadatas.Append("\nCode Reviewer:" + changeset.Summary.CodeReviewer);
-
-            if (!string.IsNullOrWhiteSpace(changeset.Summary.SecurityReviewer))
-                metadatas.Append("\nSecurity Reviewer:" + changeset.Summary.SecurityReviewer);
-
-            if (!string.IsNullOrWhiteSpace(changeset.Summary.PerformanceReviewer))
-                metadatas.Append("\nPerformance Reviewer:" + changeset.Summary.PerformanceReviewer);
+            foreach (var checkinNote in changeset.Summary.CheckinNotes)
+            {
+                if (!string.IsNullOrWhiteSpace(checkinNote.Name) && !string.IsNullOrWhiteSpace(checkinNote.Value))
+                    metadatas.Append("\n" + checkinNote.Name + ":" + checkinNote.Value);
+            }
 
             if (!string.IsNullOrWhiteSpace(changeset.OmittedParentBranch))
                 metadatas.Append("\nOmitted parent branch: " + changeset.OmittedParentBranch);

--- a/GitTfs/Core/ITfsCheckinNote.cs
+++ b/GitTfs/Core/ITfsCheckinNote.cs
@@ -1,0 +1,8 @@
+﻿namespace Sep.Git.Tfs.Core
+{
+    public interface ITfsCheckinNote
+    {
+        string Name { get; set; }
+        string Value { get; set; }
+    }
+}

--- a/GitTfs/Core/TfsChangesetInfo.cs
+++ b/GitTfs/Core/TfsChangesetInfo.cs
@@ -10,15 +10,14 @@ namespace Sep.Git.Tfs.Core
         public string GitCommit { get; set; }
         public IEnumerable<ITfsWorkitem> Workitems { get; set; }
 
-        public string CodeReviewer { get; set; }
-        public string SecurityReviewer { get; set; }
-        public string PerformanceReviewer { get; set; }
+        public IEnumerable<ITfsCheckinNote> CheckinNotes { get; set; }
 
         public string PolicyOverrideComment { get; set; }
 
         public TfsChangesetInfo()
         {
             Workitems = Enumerable.Empty<ITfsWorkitem>();
+            CheckinNotes = Enumerable.Empty<ITfsCheckinNote>();
         }
     }
 }

--- a/GitTfs/Core/TfsCheckinNote.cs
+++ b/GitTfs/Core/TfsCheckinNote.cs
@@ -1,0 +1,8 @@
+﻿namespace Sep.Git.Tfs.Core
+{
+    public class TfsCheckinNote : ITfsCheckinNote
+    {
+        public string Name { get; set; }
+        public string Value { get; set; }
+    }
+}

--- a/GitTfs/GitTfs.csproj
+++ b/GitTfs/GitTfs.csproj
@@ -109,6 +109,7 @@
     <Compile Include="Core\GitTfsGatedCheckinException.cs" />
     <Compile Include="Core\GitTreeBuilder.cs" />
     <Compile Include="Core\IGitTreeBuilder.cs" />
+    <Compile Include="Core\ITfsCheckinNote.cs" />
     <Compile Include="Core\ITfsWorkitem.cs" />
     <Compile Include="Commands\Branch.cs" />
     <Compile Include="Core\BranchVisitors\BranchTreeContainsPathVisitor.cs" />
@@ -188,6 +189,7 @@
     <Compile Include="Core\TfsInterop\NullIdentity.cs" />
     <Compile Include="Core\TfsInterop\IChangeset.cs" />
     <Compile Include="Core\TfsTreeEntry.cs" />
+    <Compile Include="Core\TfsCheckinNote.cs" />
     <Compile Include="Core\TfsWorkitem.cs" />
     <Compile Include="Core\TfsWorkspace.cs" />
     <Compile Include="Core\TfsWriter.cs" />
@@ -197,6 +199,7 @@
     <Compile Include="Util\Bouncer.cs" />
     <Compile Include="Util\ChangeSieve.cs" />
     <Compile Include="Util\CheckinOptionsExtensions.cs" />
+    <Compile Include="Util\CamelCaseToDelimitedStringConverter.cs" />
     <Compile Include="Util\ConfigPropertyLoader.cs" />
     <Compile Include="Util\ExportMetadatasInitializer.cs" />
     <Compile Include="Util\PathResolver.cs" />

--- a/GitTfs/GitTfsConstants.cs
+++ b/GitTfs/GitTfsConstants.cs
@@ -14,9 +14,6 @@ namespace Sep.Git.Tfs
         public const string TfsRoot = "$/";
         public const string GitTfsPrefix = "git-tfs";
         public const string GitTfsWorkItemPrefix = GitTfsPrefix + "-work-item:";
-        public const string GitTfsCodeReviewerPrefix = GitTfsPrefix + "-code-reviewer:";
-        public const string GitTfsSecurityReviewerPrefix = GitTfsPrefix + "-security-reviewer:";
-        public const string GitTfsPerformanceReviewerPrefix = GitTfsPrefix + "-performance-reviewer:";
         public const string GitTfsPolicyOverrideCommentPrefix = GitTfsPrefix + "-force:";
        // e.g. git-tfs-id: [http://team:8080/]$/sandbox;C123
         public const string TfsCommitInfoFormat = "git-tfs-id: [{0}]{1};C{2}";
@@ -54,10 +51,6 @@ namespace Sep.Git.Tfs
         /// where {0} is the owning remote and {1} is the prefix
         /// </summary>
         public const string RemoteSubtreeFormat = "{0}_subtree/{1}";
-
-        public const string CodeReviewer = "Code Reviewer";
-        public const string SecurityReviewer = "Security Reviewer"; 
-        public const string PerformanceReviewer = "Performance Reviewer";
 
         public const string ExportMetadatasConfigKey = GitTfsPrefix + ".export-metadatas";
         public const string WorkspaceConfigKey = GitTfsPrefix + ".workspace-dir";

--- a/GitTfs/Util/CamelCaseToDelimitedStringConverter.cs
+++ b/GitTfs/Util/CamelCaseToDelimitedStringConverter.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Sep.Git.Tfs.Util
+{
+    public static class CamelCaseToDelimitedStringConverter
+    {
+        public static string Convert(string stringWithCamelCase, string delimiter)
+        {
+            var words = stringWithCamelCase
+                .Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)
+                .SelectMany(GetCaseDelimitedParts).Select(p => p.ToLowerInvariant());
+
+            return string.Join(delimiter, words);
+        }
+
+        private static IEnumerable<string> GetCaseDelimitedParts(string s)
+        {
+            var wordStartIndex = 0;
+            for (var index = 0; index < s.Length; index++)
+            {
+                if (IsFirstCharacterOfNewWord(s, index, wordStartIndex))
+                {
+                    yield return s.Substring(wordStartIndex, index - wordStartIndex).ToLowerInvariant();
+                    wordStartIndex = index;
+                }
+            }
+
+            yield return s.Substring(wordStartIndex).ToLowerInvariant();
+        }
+
+        private static bool IsFirstCharacterOfNewWord(string s, int index, int wordStartIndex)
+        {
+            if (index == 0)
+                return false;
+
+            return char.IsUpper(s[index]) && !char.IsUpper(s[index - 1]) ||
+                   char.IsUpper(s[index]) && char.IsUpper(s[index - 1]) && wordStartIndex == index - 2 ||
+                   char.IsUpper(s[index]) && char.IsUpper(s[index - 1]) && s.Length >= index + 2 && !char.IsUpper(s[index + 1]);
+        }
+    }
+}

--- a/GitTfsTest/GitTfsTest.csproj
+++ b/GitTfsTest/GitTfsTest.csproj
@@ -119,6 +119,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestHelpers\ExtensionMethods.cs" />
     <Compile Include="Util\AuthorsFileUnitTest.cs" />
+    <Compile Include="Util\CamelCaseToDelimitedStringConverterTests.cs" />
     <Compile Include="Util\CommitSpecificCheckinOptionsFactoryTests.cs" />
     <Compile Include="Util\GitTfsCommandRunnerTests.cs" />
     <Compile Include="Util\BouncerTest.cs" />

--- a/GitTfsTest/Util/CamelCaseToDelimitedStringConverterTests.cs
+++ b/GitTfsTest/Util/CamelCaseToDelimitedStringConverterTests.cs
@@ -1,0 +1,28 @@
+﻿namespace Sep.Git.Tfs.Test.Util
+{
+    using Sep.Git.Tfs.Util;
+    using Xunit;
+    using Xunit.Extensions;
+
+    public class CamelCaseToDelimitedStringConverterTests
+    {
+        [Theory]
+        [InlineData("Code Reviewer", "-", "code-reviewer")]
+        [InlineData(" Code Reviewer", "-", "code-reviewer")]
+        [InlineData("Code Reviewer ", "-", "code-reviewer")]
+        [InlineData(" Code Reviewer ", "-", "code-reviewer")]
+        [InlineData("Code  Reviewer", "-", "code-reviewer")]
+        [InlineData("CodeReviewer", "-", "code-reviewer")]
+        [InlineData("Jira Issue ID", "-", "jira-issue-id")]
+        [InlineData("Jira Issue Id", "-", "jira-issue-id")]
+        [InlineData("Some IPAddress", "-", "some-ip-address")]
+        [InlineData("SomeIPAddress", "-", "some-ip-address")]
+        [InlineData("JustAName", "-", "just-a-name")]
+        [InlineData("AnOtherDelimiter", "#", "an#other#delimiter")]
+        public void ReturnsExpectedValue(string stringWithCamelCase, string delimiter, string expected)
+        {
+            var actual = CamelCaseToDelimitedStringConverter.Convert(stringWithCamelCase, delimiter);
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -1,0 +1,1 @@
+* Custom TFS check-in notes are not exported to commit message (#1004, @EdwinEngelen)


### PR DESCRIPTION
The changes have been tested against VS2015.