### PR TITLE
Cleaning renaming

### DIFF
--- a/GitTfs.Setup/GitTfs.Setup.csproj
+++ b/GitTfs.Setup/GitTfs.Setup.csproj
@@ -39,6 +39,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -48,6 +49,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/GitTfs.Setup/GitTfs.Setup.csproj
+++ b/GitTfs.Setup/GitTfs.Setup.csproj
@@ -101,7 +101,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5')">
       <PropertyGroup>
         <__paket__WixSharp_targets>WixSharp</__paket__WixSharp_targets>
       </PropertyGroup>
@@ -117,7 +117,7 @@
   <UsingTask AssemblyFile="packages\WixSharp.1.0.22.3\build\SetEnvVar.dll" TaskName="SetEnvVar" />
   <Import Project="..\.paket\paket.targets" />
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5')">
       <ItemGroup>
         <Reference Include="Microsoft.Deployment.WindowsInstaller">
           <HintPath>..\packages\WixSharp\lib\Microsoft.Deployment.WindowsInstaller.dll</HintPath>

--- a/GitTfs.Setup/Program.cs
+++ b/GitTfs.Setup/Program.cs
@@ -2,7 +2,6 @@
 using System.Diagnostics;
 using WixSharp;
 using System.IO;
-using File = WixSharp.File;
 
 namespace GitTfs.Setup
 {

--- a/GitTfs.Vs2010/GitTfs.Vs2010.csproj
+++ b/GitTfs.Vs2010/GitTfs.Vs2010.csproj
@@ -45,6 +45,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <OutputPath>bin\Release\</OutputPath>
@@ -56,6 +57,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/GitTfs.Vs2012/GitTfs.Vs2012.csproj
+++ b/GitTfs.Vs2012/GitTfs.Vs2012.csproj
@@ -25,6 +25,7 @@
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -34,6 +35,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.TeamFoundation, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />

--- a/GitTfs.Vs2013/GitTfs.Vs2013.csproj
+++ b/GitTfs.Vs2013/GitTfs.Vs2013.csproj
@@ -27,6 +27,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <Prefer32Bit>false</Prefer32Bit>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -37,6 +38,7 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.TeamFoundation.Build.Client, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />

--- a/GitTfs.Vs2013/TfsHelper.Vs2013.cs
+++ b/GitTfs.Vs2013/TfsHelper.Vs2013.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using Sep.Git.Tfs.VsCommon;
 using StructureMap;
 

--- a/GitTfs.Vs2015/GitTfs.Vs2015.csproj
+++ b/GitTfs.Vs2015/GitTfs.Vs2015.csproj
@@ -98,6 +98,13 @@
     <None Include="paket.references" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5')">
+      <PropertyGroup>
+        <__paket__Microsoft_TeamFoundationServer_ExtendedClient_targets>Microsoft.TeamFoundationServer.ExtendedClient</__paket__Microsoft_TeamFoundationServer_ExtendedClient_targets>
+      </PropertyGroup>
+    </When>
+  </Choose>
   <PropertyGroup>
     <PostBuildEvent>xcopy /y /I "$(TargetDir)*.dll" "$(SolutionDir)GitTfs\$(OutDir)$(ProjectName)" /EXCLUDE:$(SolutionDir)files_to_ignore_during_post_build_copy.txt</PostBuildEvent>
   </PropertyGroup>
@@ -110,7 +117,7 @@
   -->
   <Import Project="..\.paket\paket.targets" />
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.5'">
       <ItemGroup>
         <Reference Include="System.Net.Http.Formatting">
           <HintPath>..\packages\Microsoft.AspNet.WebApi.Client\lib\net45\System.Net.Http.Formatting.dll</HintPath>
@@ -121,7 +128,7 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.5'">
       <ItemGroup>
         <Reference Include="System.Web.Http">
           <HintPath>..\packages\Microsoft.AspNet.WebApi.Core\lib\net45\System.Web.Http.dll</HintPath>
@@ -132,20 +139,7 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1')" />
-  </Choose>
-  <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1')" />
-  </Choose>
-  <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1')">
-      <PropertyGroup>
-        <__paket__Microsoft_TeamFoundationServer_ExtendedClient_targets>Microsoft.TeamFoundationServer.ExtendedClient</__paket__Microsoft_TeamFoundationServer_ExtendedClient_targets>
-      </PropertyGroup>
-    </When>
-  </Choose>
-  <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.5'">
       <ItemGroup>
         <Reference Include="Microsoft.TeamFoundation.Build.Client">
           <HintPath>..\packages\Microsoft.TeamFoundationServer.ExtendedClient\lib\net45\Microsoft.TeamFoundation.Build.Client.dll</HintPath>
@@ -181,7 +175,7 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.5'">
       <ItemGroup>
         <Reference Include="Microsoft.TeamFoundation.Common">
           <HintPath>..\packages\Microsoft.VisualStudio.Services.Client\lib\net45\Microsoft.TeamFoundation.Common.dll</HintPath>
@@ -202,7 +196,7 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.5'">
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Services.Client">
           <HintPath>..\packages\Microsoft.VisualStudio.Services.InteractiveClient\lib\net45\Microsoft.VisualStudio.Services.Client.dll</HintPath>
@@ -213,10 +207,16 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1')" />
-  </Choose>
-  <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.0'">
+      <ItemGroup>
+        <Reference Include="Newtonsoft.Json">
+          <HintPath>..\packages\Newtonsoft.Json\lib\net40\Newtonsoft.Json.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.5'">
       <ItemGroup>
         <Reference Include="Newtonsoft.Json">
           <HintPath>..\packages\Newtonsoft.Json\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -225,12 +225,6 @@
         </Reference>
       </ItemGroup>
     </When>
-  </Choose>
-  <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1')" />
-  </Choose>
-  <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1')" />
   </Choose>
   <Import Project="..\packages\Microsoft.TeamFoundationServer.ExtendedClient\build\$(__paket__Microsoft_TeamFoundationServer_ExtendedClient_targets).targets" Condition="Exists('..\packages\Microsoft.TeamFoundationServer.ExtendedClient\build\$(__paket__Microsoft_TeamFoundationServer_ExtendedClient_targets).targets')" Label="Paket" />
 </Project>

--- a/GitTfs.Vs2015/GitTfs.Vs2015.csproj
+++ b/GitTfs.Vs2015/GitTfs.Vs2015.csproj
@@ -28,6 +28,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <Prefer32Bit>false</Prefer32Bit>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -38,6 +39,7 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="StructureMap">

--- a/GitTfs.VsCommon/TfsHelper.Common.cs
+++ b/GitTfs.VsCommon/TfsHelper.Common.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -598,7 +598,7 @@ namespace Sep.Git.Tfs.VsCommon
             return result != null && result.Length > 0;
         }
 
-        private Dictionary<string, Workspace> _workspaces = new Dictionary<string, Workspace>();
+        private readonly Dictionary<string, Workspace> _workspaces = new Dictionary<string, Workspace>();
 
         public void WithWorkspace(string localDirectory, IGitTfsRemote remote, IEnumerable<Tuple<string, string>> mappings, TfsChangesetInfo versionToFetch, Action<ITfsWorkspace> action)
         {

--- a/GitTfs.VsCommon/TfsHelper.Common.cs
+++ b/GitTfs.VsCommon/TfsHelper.Common.cs
@@ -57,7 +57,7 @@ namespace Sep.Git.Tfs.VsCommon
 
         public bool HasCredentials
         {
-            get { return !String.IsNullOrEmpty(Username); }
+            get { return !string.IsNullOrEmpty(Username); }
         }
 
         public void EnsureAuthenticated()
@@ -73,8 +73,8 @@ namespace Sep.Git.Tfs.VsCommon
                 {
                     // maybe it is not an Uri but instance name
                     var servers = RegisteredTfsConnections.GetConfigurationServers();
-                    var registered = servers.FirstOrDefault(s => ((String.Compare(s.Name, Url, StringComparison.OrdinalIgnoreCase) == 0) ||
-                                                                  (String.Compare(s.Name, Uri.EscapeDataString(Url), StringComparison.OrdinalIgnoreCase) == 0)));
+                    var registered = servers.FirstOrDefault(s => ((string.Compare(s.Name, Url, StringComparison.OrdinalIgnoreCase) == 0) ||
+                                                                  (string.Compare(s.Name, Uri.EscapeDataString(Url), StringComparison.OrdinalIgnoreCase) == 0)));
                     if (registered == null)
                         throw new GitTfsException("Given tfs name is not correct URI and not found as a registered TFS instance");
                     uri = registered.Uri;
@@ -1411,7 +1411,7 @@ namespace Sep.Git.Tfs.VsCommon
             }
             catch (Exception)
             {
-                Trace.WriteLine(String.Format("Something went wrong downloading \"{0}\" in changeset {1}", item.ServerItem, item.ChangesetId));
+                Trace.WriteLine(string.Format("Something went wrong downloading \"{0}\" in changeset {1}", item.ServerItem, item.ChangesetId));
                 temp.Dispose();
                 throw;
             }

--- a/GitTfs.VsCommon/TfsHelper.Vs2012Base.cs
+++ b/GitTfs.VsCommon/TfsHelper.Vs2012Base.cs
@@ -1,9 +1,6 @@
 using System;
-using System.IO;
 using System.Linq;
 using Microsoft.TeamFoundation.Client;
-using Microsoft.TeamFoundation.Framework.Client;
-using Microsoft.TeamFoundation.Framework.Common;
 using Microsoft.TeamFoundation.Server;
 using Microsoft.TeamFoundation.VersionControl.Client;
 using StructureMap;

--- a/GitTfs.VsCommon/TfsPlugin.cs
+++ b/GitTfs.VsCommon/TfsPlugin.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace Sep.Git.Tfs
 {
-    internal class TfsPlugin : Sep.Git.Tfs.Core.TfsInterop.TfsPlugin
+    internal class TfsPlugin : Core.TfsInterop.TfsPlugin
     {
         public override void Initialize(StructureMap.Graph.IAssemblyScanner scan)
         {

--- a/GitTfs.VsCommon/Wrappers.cs
+++ b/GitTfs.VsCommon/Wrappers.cs
@@ -540,7 +540,7 @@ namespace Sep.Git.Tfs.VsCommon
 
     public class WrapperForBranchObject : WrapperFor<BranchObject>, IBranchObject
     {
-        private BranchObject _branch;
+        private readonly BranchObject _branch;
 
         public WrapperForBranchObject(BranchObject branch)
             : base(branch)

--- a/GitTfs.VsCommon/Wrappers.cs
+++ b/GitTfs.VsCommon/Wrappers.cs
@@ -110,7 +110,7 @@ namespace Sep.Git.Tfs.VsCommon
 
         public void Get(ITfsWorkspace workspace, IEnumerable<IChange> changes, Action<Exception> ignorableErrorHandler)
         {
-            workspace.Get(this.ChangesetId, changes);
+            workspace.Get(ChangesetId, changes);
         }
     }
 

--- a/GitTfs.VsFake/GitTfs.VsFake.csproj
+++ b/GitTfs.VsFake/GitTfs.VsFake.csproj
@@ -45,6 +45,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <OutputPath>bin\Release\</OutputPath>
@@ -55,6 +56,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="StructureMap, Version=2.5.3.0, Culture=neutral, PublicKeyToken=e60ad81abae3c223, processorArchitecture=MSIL">

--- a/GitTfs.VsFake/Script.cs
+++ b/GitTfs.VsFake/Script.cs
@@ -37,10 +37,10 @@ namespace Sep.Git.Tfs.VsFake
             }
         }
 
-        private List<ScriptedChangeset> _changesets = new List<ScriptedChangeset>();
+        private readonly List<ScriptedChangeset> _changesets = new List<ScriptedChangeset>();
         public List<ScriptedChangeset> Changesets { get { return _changesets; } }
 
-        private List<ScriptedRootBranch> _rootBranches = new List<ScriptedRootBranch>();
+        private readonly List<ScriptedRootBranch> _rootBranches = new List<ScriptedRootBranch>();
         public List<ScriptedRootBranch> RootBranches { get { return _rootBranches; } }
     }
 
@@ -60,7 +60,7 @@ namespace Sep.Git.Tfs.VsFake
         public MergeChangesetDatas MergeChangesetDatas { get; set; }
         public string Committer { get; set; }
 
-        private List<ScriptedChange> _changes = new List<ScriptedChange>();
+        private readonly List<ScriptedChange> _changes = new List<ScriptedChange>();
     }
 
     [Serializable]

--- a/GitTfs.VsFake/TfsHelper.VsFake.cs
+++ b/GitTfs.VsFake/TfsHelper.VsFake.cs
@@ -24,9 +24,9 @@ namespace Sep.Git.Tfs.VsFake
     {
         #region misc/null
 
-        private IContainer _container;
-        private Script _script;
-        private FakeVersionControlServer _versionControlServer;
+        private readonly IContainer _container;
+        private readonly Script _script;
+        private readonly FakeVersionControlServer _versionControlServer;
 
         public TfsHelper(IContainer container, Script script)
         {
@@ -100,8 +100,8 @@ namespace Sep.Git.Tfs.VsFake
 
         private class Changeset : IChangeset
         {
-            private IVersionControlServer _versionControlServer;
-            private ScriptedChangeset _changeset;
+            private readonly IVersionControlServer _versionControlServer;
+            private readonly ScriptedChangeset _changeset;
 
             public Changeset(IVersionControlServer versionControlServer, ScriptedChangeset changeset)
             {
@@ -147,9 +147,9 @@ namespace Sep.Git.Tfs.VsFake
 
         private class Change : IChange, IItem
         {
-            private IVersionControlServer _versionControlServer;
-            private ScriptedChangeset _changeset;
-            private ScriptedChange _change;
+            private readonly IVersionControlServer _versionControlServer;
+            private readonly ScriptedChangeset _changeset;
+            private readonly ScriptedChange _change;
 
             public Change(IVersionControlServer versionControlServer, ScriptedChangeset changeset, ScriptedChange change)
             {
@@ -249,8 +249,8 @@ namespace Sep.Git.Tfs.VsFake
 
         private class FakeWorkspace : IWorkspace
         {
-            private string _directory;
-            private string _repositoryRoot;
+            private readonly string _directory;
+            private readonly string _repositoryRoot;
 
             public FakeWorkspace(string directory, string repositoryRoot)
             {
@@ -524,7 +524,7 @@ namespace Sep.Git.Tfs.VsFake
 
         private class FakeVersionControlServer : IVersionControlServer
         {
-            private Script _script;
+            private readonly Script _script;
 
             public FakeVersionControlServer(Script script)
             {

--- a/GitTfs.VsFake/TfsHelper.VsFake.cs
+++ b/GitTfs.VsFake/TfsHelper.VsFake.cs
@@ -141,7 +141,7 @@ namespace Sep.Git.Tfs.VsFake
 
             public void Get(ITfsWorkspace workspace, IEnumerable<IChange> changes, Action<Exception> ignorableErrorHandler)
             {
-                workspace.Get(this.ChangesetId, changes);
+                workspace.Get(ChangesetId, changes);
             }
         }
 

--- a/GitTfs.VsFake/TfsPlugin.cs
+++ b/GitTfs.VsFake/TfsPlugin.cs
@@ -5,7 +5,7 @@ using Sep.Git.Tfs.VsFake;
 
 namespace Sep.Git.Tfs
 {
-    internal class TfsPlugin : Sep.Git.Tfs.Core.TfsInterop.TfsPlugin
+    internal class TfsPlugin : Core.TfsInterop.TfsPlugin
     {
         /*
         public override void Initialize(StructureMap.Graph.IAssemblyScanner scan)

--- a/GitTfs/Commands/Bootstrap.cs
+++ b/GitTfs/Commands/Bootstrap.cs
@@ -1,5 +1,4 @@
 ﻿using System.ComponentModel;
-using System.IO;
 using NDesk.Options;
 using Sep.Git.Tfs.Core;
 using StructureMap;

--- a/GitTfs/Commands/Branch.cs
+++ b/GitTfs/Commands/Branch.cs
@@ -1,4 +1,3 @@
-using System;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;

--- a/GitTfs/Commands/Branch.cs
+++ b/GitTfs/Commands/Branch.cs
@@ -21,7 +21,7 @@ namespace Sep.Git.Tfs.Commands
     [RequiresValidGitRepository]
     public class Branch : GitTfsCommand
     {
-        private Globals globals;
+        private readonly Globals globals;
         private readonly Help helper;
         private readonly Cleanup cleanup;
         private readonly InitBranch initBranch;

--- a/GitTfs/Commands/Checkin.cs
+++ b/GitTfs/Commands/Checkin.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using System.IO;
 using Sep.Git.Tfs.Core;
 using StructureMap;
 

--- a/GitTfs/Commands/CheckinBase.cs
+++ b/GitTfs/Commands/CheckinBase.cs
@@ -1,7 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using NDesk.Options;
 using Sep.Git.Tfs.Core;
 

--- a/GitTfs/Commands/CheckinOptions.cs
+++ b/GitTfs/Commands/CheckinOptions.cs
@@ -44,9 +44,9 @@ namespace Sep.Git.Tfs.Commands
             }
         }
 
-        private List<string> _workItemsToAssociate = new List<string>();
-        private List<string> _workItemsToResolve = new List<string>();
-        private Dictionary<string, string> _checkinNotes = new Dictionary<string, string>();
+        private readonly List<string> _workItemsToAssociate = new List<string>();
+        private readonly List<string> _workItemsToResolve = new List<string>();
+        private readonly Dictionary<string, string> _checkinNotes = new Dictionary<string, string>();
 
         public string CheckinComment { get; set; }
         // This can be extended to checkin when the $EDITOR is invoked.

--- a/GitTfs/Commands/CheckinTool.cs
+++ b/GitTfs/Commands/CheckinTool.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using System.IO;
 using Sep.Git.Tfs.Core;
 using Sep.Git.Tfs.Util;
 

--- a/GitTfs/Commands/Checkout.cs
+++ b/GitTfs/Commands/Checkout.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.ComponentModel;
-using System.IO;
 using NDesk.Options;
 using Sep.Git.Tfs.Core;
 using StructureMap;

--- a/GitTfs/Commands/Cleanup.cs
+++ b/GitTfs/Commands/Cleanup.cs
@@ -30,10 +30,9 @@ namespace Sep.Git.Tfs.Commands
 
         private int RunAll(params Func<int>[] cleaners)
         {
-            var result = GitTfsExitCodes.OK;
             foreach (var cleaner in cleaners)
             {
-                result = cleaner();
+                var result = cleaner();
                 if (result != GitTfsExitCodes.OK)
                     return result;
             }

--- a/GitTfs/Commands/CleanupWorkspaceLocal.cs
+++ b/GitTfs/Commands/CleanupWorkspaceLocal.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.ComponentModel;
-using System.IO;
 using NDesk.Options;
 using Sep.Git.Tfs.Core;
 using StructureMap;

--- a/GitTfs/Commands/CleanupWorkspaces.cs
+++ b/GitTfs/Commands/CleanupWorkspaces.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.ComponentModel;
-using System.IO;
 using NDesk.Options;
 using Sep.Git.Tfs.Core;
 using StructureMap;

--- a/GitTfs/Commands/Clone.cs
+++ b/GitTfs/Commands/Clone.cs
@@ -91,13 +91,13 @@ namespace Sep.Git.Tfs.Commands
                     catch (IOException e)
                     {
                         // swallow IOException. Smth went wrong before this and we're much more interested in that error
-                        string msg = String.Format("warning: Something went wrong while cleaning file after internal error (See below).\n    Can't clean up files because of IOException:\n{0}\n", e.IndentExceptionMessage());
+                        string msg = string.Format("warning: Something went wrong while cleaning file after internal error (See below).\n    Can't clean up files because of IOException:\n{0}\n", e.IndentExceptionMessage());
                         Trace.WriteLine(msg);
                     }
                     catch (UnauthorizedAccessException e)
                     {
                         // swallow it also
-                        string msg = String.Format("warning: Something went wrong while cleaning file after internal error (See below).\n    Can't clean up files because of UnauthorizedAccessException:\n{0}\n", e.IndentExceptionMessage());
+                        string msg = string.Format("warning: Something went wrong while cleaning file after internal error (See below).\n    Can't clean up files because of UnauthorizedAccessException:\n{0}\n", e.IndentExceptionMessage());
                         Trace.WriteLine(msg);
                     }
                 }

--- a/GitTfs/Commands/Clone.cs
+++ b/GitTfs/Commands/Clone.cs
@@ -1,10 +1,8 @@
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
 using NDesk.Options;
 using Sep.Git.Tfs.Core;
 using StructureMap;

--- a/GitTfs/Commands/Diagnostics.cs
+++ b/GitTfs/Commands/Diagnostics.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using NDesk.Options;
+﻿using NDesk.Options;
 using StructureMap;
 using System.Diagnostics;
 

--- a/GitTfs/Commands/Fetch.cs
+++ b/GitTfs/Commands/Fetch.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using NDesk.Options;
 using Sep.Git.Tfs.Core;

--- a/GitTfs/Commands/Fetch.cs
+++ b/GitTfs/Commands/Fetch.cs
@@ -15,20 +15,18 @@ namespace Sep.Git.Tfs.Commands
     [RequiresValidGitRepository]
     public class Fetch : GitTfsCommand
     {
-        private readonly RemoteOptions remoteOptions;
-        private readonly Globals globals;
-        private readonly ConfigProperties properties;
-        private readonly AuthorsFile authors;
-        private readonly Labels labels;
+        private readonly RemoteOptions _remoteOptions;
+        private readonly Globals _globals;
+        private readonly ConfigProperties _properties;
+        private readonly Labels _labels;
 
-        public Fetch(Globals globals, ConfigProperties properties, RemoteOptions remoteOptions, AuthorsFile authors, Labels labels)
+        public Fetch(Globals globals, ConfigProperties properties, RemoteOptions remoteOptions, Labels labels)
         {
-            this.globals = globals;
-            this.properties = properties;
-            this.remoteOptions = remoteOptions;
-            this.authors = authors;
-            this.labels = labels;
-            this.upToChangeSet = -1;
+            _globals = globals;
+            _properties = properties;
+            _remoteOptions = remoteOptions;
+            _labels = labels;
+            upToChangeSet = -1;
             BranchStrategy = BranchStrategy = BranchStrategy.Auto;
         }
 
@@ -47,7 +45,7 @@ namespace Sep.Git.Tfs.Commands
                 int batchSize;
                 if (!int.TryParse(value, out batchSize))
                     throw new GitTfsException("error: batch size parameter should be an integer.");
-                properties.BatchSize = batchSize;
+                _properties.BatchSize = batchSize;
             }
         }
 
@@ -103,18 +101,18 @@ namespace Sep.Git.Tfs.Commands
                         v => InitialChangeset = Convert.ToInt32(v) },
                     { "t|up-to=", "up-to changeset # (optional, -1 for up to maximum, must be a number, not prefixed with C)",
                         v => UpToChangeSetOption = v }
-                }.Merge(remoteOptions.OptionSet);
+                }.Merge(_remoteOptions.OptionSet);
             }
         }
 
         public int Run()
         {
-            return Run(globals.RemoteId);
+            return Run(_globals.RemoteId);
         }
 
         public void Run(bool stopOnFailMergeCommit)
         {
-            Run(stopOnFailMergeCommit, globals.RemoteId);
+            Run(stopOnFailMergeCommit, _globals.RemoteId);
         }
 
         public int Run(params string[] args)
@@ -125,7 +123,7 @@ namespace Sep.Git.Tfs.Commands
         private int Run(bool stopOnFailMergeCommit, params string[] args)
         {
             if (!FetchAll && BranchStrategy == BranchStrategy.None)
-                globals.Repository.SetConfig(GitTfsConstants.IgnoreBranches, true.ToString());
+                _globals.Repository.SetConfig(GitTfsConstants.IgnoreBranches, true.ToString());
 
             var remotesToFetch = GetRemotesToFetch(args).ToList();
             foreach (var remote in remotesToFetch)
@@ -139,10 +137,10 @@ namespace Sep.Git.Tfs.Commands
         {
             Trace.TraceInformation("Fetching from TFS remote '{0}'...", remote.Id);
             DoFetch(remote, stopOnFailMergeCommit);
-            if (labels != null && FetchLabels)
+            if (_labels != null && FetchLabels)
             {
                 Trace.TraceInformation("Fetching labels from TFS remote '{0}'...", remote.Id);
-                labels.Run(remote);
+                _labels.Run(remote);
             }
         }
 
@@ -172,7 +170,7 @@ namespace Sep.Git.Tfs.Commands
                     new[] { "Remove ahead commits and retry", "use the --force option (ahead commits will be lost!)" });
             }
 
-            var metadataExportInitializer = new ExportMetadatasInitializer(globals);
+            var metadataExportInitializer = new ExportMetadatasInitializer(_globals);
             bool shouldExport = ExportMetadatas || remote.Repository.GetConfig(GitTfsConstants.ExportMetadatasConfigKey) == "true";
 
             if (ExportMetadatas)
@@ -186,8 +184,8 @@ namespace Sep.Git.Tfs.Commands
             {
                 if (InitialChangeset.HasValue)
                 {
-                    properties.InitialChangeset = InitialChangeset.Value;
-                    properties.PersistAllOverrides();
+                    _properties.InitialChangeset = InitialChangeset.Value;
+                    _properties.PersistAllOverrides();
                     remote.QuickFetch(InitialChangeset.Value);
                     remote.Fetch(stopOnFailMergeCommit);
                 }
@@ -210,11 +208,11 @@ namespace Sep.Git.Tfs.Commands
         {
             IEnumerable<IGitTfsRemote> remotesToFetch;
             if (FetchParents)
-                remotesToFetch = globals.Repository.GetLastParentTfsCommits("HEAD").Select(commit => commit.Remote);
+                remotesToFetch = _globals.Repository.GetLastParentTfsCommits("HEAD").Select(commit => commit.Remote);
             else if (FetchAll)
-                remotesToFetch = globals.Repository.ReadAllTfsRemotes();
+                remotesToFetch = _globals.Repository.ReadAllTfsRemotes();
             else
-                remotesToFetch = args.Select(arg => globals.Repository.ReadTfsRemote(arg));
+                remotesToFetch = args.Select(arg => _globals.Repository.ReadTfsRemote(arg));
             return remotesToFetch;
         }
     }

--- a/GitTfs/Commands/Help.cs
+++ b/GitTfs/Commands/Help.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
@@ -7,7 +6,6 @@ using NDesk.Options;
 using Sep.Git.Tfs.Core;
 using Sep.Git.Tfs.Util;
 using StructureMap;
-using StructureMap.Pipeline;
 using StructureMap.Query;
 using IContainer = StructureMap.IContainer;
 using System.Diagnostics;

--- a/GitTfs/Commands/Help.cs
+++ b/GitTfs/Commands/Help.cs
@@ -16,12 +16,12 @@ namespace Sep.Git.Tfs.Commands
     [Description("help [command-name]")]
     public class Help : GitTfsCommand
     {
-        private readonly GitTfsCommandFactory commandFactory;
+        private readonly GitTfsCommandFactory _commandFactory;
         private readonly IContainer _container;
 
         public Help(GitTfsCommandFactory commandFactory, IContainer container)
         {
-            this.commandFactory = commandFactory;
+            _commandFactory = commandFactory;
             _container = container;
         }
 
@@ -38,7 +38,7 @@ namespace Sep.Git.Tfs.Commands
         {
             foreach (var arg in args)
             {
-                var command = commandFactory.GetCommand(arg);
+                var command = _commandFactory.GetCommand(arg);
                 if (command != null)
                 {
                     return Run(command);
@@ -96,7 +96,7 @@ namespace Sep.Git.Tfs.Commands
                     where instance.Name != null
                     orderby instance.Name
                     select instance.Name)
-                .ToDictionary(s => s, s => commandFactory.GetAliasesForCommandName(s));
+                .ToDictionary(s => s, s => _commandFactory.GetAliasesForCommandName(s));
         }
 
         private string GetCommandName(GitTfsCommand command)

--- a/GitTfs/Commands/Helpers.cs
+++ b/GitTfs/Commands/Helpers.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using NDesk.Options;
+﻿using NDesk.Options;
 
 namespace Sep.Git.Tfs.Commands
 {

--- a/GitTfs/Commands/Init.cs
+++ b/GitTfs/Commands/Init.cs
@@ -14,34 +14,32 @@ namespace Sep.Git.Tfs.Commands
     [Description("init [options] tfs-url-or-instance-name repository-path [git-repository]")]
     public class Init : GitTfsCommand
     {
-        private readonly InitOptions initOptions;
-        private readonly RemoteOptions remoteOptions;
-        private readonly Globals globals;
-        private readonly IGitHelpers gitHelper;
-        private readonly IHelpHelper _help;
+        private readonly InitOptions _initOptions;
+        private readonly RemoteOptions _remoteOptions;
+        private readonly Globals _globals;
+        private readonly IGitHelpers _gitHelper;
 
-        public Init(RemoteOptions remoteOptions, InitOptions initOptions, Globals globals, IGitHelpers gitHelper, IHelpHelper help)
+        public Init(RemoteOptions remoteOptions, InitOptions initOptions, Globals globals, IGitHelpers gitHelper)
         {
-            this.remoteOptions = remoteOptions;
-            this.gitHelper = gitHelper;
-            _help = help;
-            this.globals = globals;
-            this.initOptions = initOptions;
+            _remoteOptions = remoteOptions;
+            _gitHelper = gitHelper;
+            _globals = globals;
+            _initOptions = initOptions;
         }
 
         public OptionSet OptionSet
         {
-            get { return initOptions.OptionSet.Merge(remoteOptions.OptionSet); }
+            get { return _initOptions.OptionSet.Merge(_remoteOptions.OptionSet); }
         }
 
         public bool IsBare
         {
-            get { return initOptions.IsBare; }
+            get { return _initOptions.IsBare; }
         }
 
         public IGitHelpers GitHelper
         {
-            get { return gitHelper; }
+            get { return _gitHelper; }
         }
 
         public int Run(string tfsUrl, string tfsRepositoryPath)
@@ -55,19 +53,19 @@ namespace Sep.Git.Tfs.Commands
         public int Run(string tfsUrl, string tfsRepositoryPath, string gitRepositoryPath)
         {
             tfsRepositoryPath.AssertValidTfsPathOrRoot();
-            if (!initOptions.IsBare)
+            if (!_initOptions.IsBare)
             {
                 InitSubdir(gitRepositoryPath);
             }
             else
             {
                 Environment.CurrentDirectory = gitRepositoryPath;
-                globals.GitDir = ".";
+                _globals.GitDir = ".";
             }
             var runResult = Run(tfsUrl, tfsRepositoryPath);
             try
             {
-                File.WriteAllText(@".git\description", tfsRepositoryPath + "\n" + HideUserCredentials(globals.CommandLineRun));
+                File.WriteAllText(@".git\description", tfsRepositoryPath + "\n" + HideUserCredentials(_globals.CommandLineRun));
             }
             catch (Exception)
             {
@@ -89,25 +87,25 @@ namespace Sep.Git.Tfs.Commands
             if (!Directory.Exists(repositoryPath))
                 Directory.CreateDirectory(repositoryPath);
             Environment.CurrentDirectory = repositoryPath;
-            globals.GitDir = ".git";
+            _globals.GitDir = ".git";
         }
 
         private void DoGitInitDb()
         {
-            if (!Directory.Exists(globals.GitDir) || initOptions.IsBare)
+            if (!Directory.Exists(_globals.GitDir) || _initOptions.IsBare)
             {
-                gitHelper.CommandNoisy(BuildInitCommand());
+                _gitHelper.CommandNoisy(BuildInitCommand());
             }
-            globals.Repository = gitHelper.MakeRepository(globals.GitDir);
+            _globals.Repository = _gitHelper.MakeRepository(_globals.GitDir);
 
-            if (!string.IsNullOrWhiteSpace(initOptions.WorkspacePath))
+            if (!string.IsNullOrWhiteSpace(_initOptions.WorkspacePath))
             {
-                Trace.WriteLine("workspace path:" + initOptions.WorkspacePath);
+                Trace.WriteLine("workspace path:" + _initOptions.WorkspacePath);
 
                 try
                 {
-                    var dir = Directory.CreateDirectory(initOptions.WorkspacePath);
-                    globals.Repository.SetConfig(GitTfsConstants.WorkspaceConfigKey, initOptions.WorkspacePath);
+                    Directory.CreateDirectory(_initOptions.WorkspacePath);
+                    _globals.Repository.SetConfig(GitTfsConstants.WorkspaceConfigKey, _initOptions.WorkspacePath);
                 }
                 catch (Exception)
                 {
@@ -115,32 +113,32 @@ namespace Sep.Git.Tfs.Commands
                 }
             }
 
-            globals.Repository.SetConfig(GitTfsConstants.IgnoreBranches, false.ToString());
+            _globals.Repository.SetConfig(GitTfsConstants.IgnoreBranches, false.ToString());
         }
 
         private string[] BuildInitCommand()
         {
             var initCommand = new List<string> { "init" };
-            if (initOptions.GitInitTemplate != null)
-                initCommand.Add("--template=" + initOptions.GitInitTemplate);
-            if (initOptions.IsBare)
+            if (_initOptions.GitInitTemplate != null)
+                initCommand.Add("--template=" + _initOptions.GitInitTemplate);
+            if (_initOptions.IsBare)
                 initCommand.Add("--bare");
-            if (initOptions.GitInitShared is string)
-                initCommand.Add("--shared=" + initOptions.GitInitShared);
-            else if (initOptions.GitInitShared != null)
+            if (_initOptions.GitInitShared is string)
+                initCommand.Add("--shared=" + _initOptions.GitInitShared);
+            else if (_initOptions.GitInitShared != null)
                 initCommand.Add("--shared");
             return initCommand.ToArray();
         }
 
         private void GitTfsInit(string tfsUrl, string tfsRepositoryPath)
         {
-            globals.Repository.CreateTfsRemote(new RemoteInfo
+            _globals.Repository.CreateTfsRemote(new RemoteInfo
             {
-                Id = globals.RemoteId,
+                Id = _globals.RemoteId,
                 Url = tfsUrl,
                 Repository = tfsRepositoryPath,
-                RemoteOptions = remoteOptions,
-            }, initOptions.GitInitAutoCrlf, initOptions.GitInitIgnoreCase);
+                RemoteOptions = _remoteOptions,
+            }, _initOptions.GitInitAutoCrlf, _initOptions.GitInitIgnoreCase);
         }
     }
 
@@ -177,7 +175,7 @@ namespace Sep.Git.Tfs.Commands
 
         public static string ToGitRefName(this string expectedRefName)
         {
-            expectedRefName = System.Text.RegularExpressions.Regex.Replace(expectedRefName, @"[!~$?[*^: \\]", string.Empty);
+            expectedRefName = Regex.Replace(expectedRefName, @"[!~$?[*^: \\]", string.Empty);
             expectedRefName = expectedRefName.Replace("@{", string.Empty);
             expectedRefName = expectedRefName.Replace("..", string.Empty);
             expectedRefName = expectedRefName.Replace("//", string.Empty);
@@ -191,7 +189,7 @@ namespace Sep.Git.Tfs.Commands
             if (includeTeamProjectName)
             {
                 return tfsRepositoryPath
-                    .Replace("$/", String.Empty)
+                    .Replace("$/", string.Empty)
                     .ToGitRefName();
             }
 
@@ -210,12 +208,7 @@ namespace Sep.Git.Tfs.Commands
             }
 
             var index = tfsRepositoryPath.IndexOf('/', 2);
-            if (index == -1)
-            {
-                return tfsRepositoryPath;
-            }
-
-            return tfsRepositoryPath.Remove(index, tfsRepositoryPath.Length - index);
+            return index == -1 ? tfsRepositoryPath : tfsRepositoryPath.Remove(index, tfsRepositoryPath.Length - index);
         }
 
         public static string ToLocalGitRef(this string refName)

--- a/GitTfs/Commands/Init.cs
+++ b/GitTfs/Commands/Init.cs
@@ -146,7 +146,7 @@ namespace Sep.Git.Tfs.Commands
 
     public static class Ext
     {
-        private static Regex ValidTfsPath = new Regex("^\\$/.+");
+        private static readonly Regex ValidTfsPath = new Regex("^\\$/.+");
         public static bool IsValidTfsPath(this string tfsPath)
         {
             return ValidTfsPath.IsMatch(tfsPath);

--- a/GitTfs/Commands/InitBranch.cs
+++ b/GitTfs/Commands/InitBranch.cs
@@ -1,12 +1,9 @@
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using NDesk.Options;
 using Sep.Git.Tfs.Core;
-using StructureMap;
 using Sep.Git.Tfs.Util;
 using Sep.Git.Tfs.Core.TfsInterop;
 

--- a/GitTfs/Commands/InitBranch.cs
+++ b/GitTfs/Commands/InitBranch.cs
@@ -13,7 +13,6 @@ namespace Sep.Git.Tfs.Commands
     {
         private readonly Globals _globals;
         private readonly Help _helper;
-        private readonly AuthorsFile _authors;
 
         private RemoteOptions _remoteOptions;
         public string TfsUsername { get; set; }
@@ -31,7 +30,6 @@ namespace Sep.Git.Tfs.Commands
         {
             _globals = globals;
             _helper = helper;
-            _authors = authors;
         }
 
         public OptionSet OptionSet

--- a/GitTfs/Commands/InitOptions.cs
+++ b/GitTfs/Commands/InitOptions.cs
@@ -7,9 +7,9 @@ namespace Sep.Git.Tfs.Commands
     [StructureMapSingleton]
     public class InitOptions
     {
-        private const string default_autocrlf = "false";
+        private const string DefaultAutocrlf = "false";
 
-        public InitOptions() { GitInitAutoCrlf = default_autocrlf; }
+        public InitOptions() { GitInitAutoCrlf = DefaultAutocrlf; }
 
         public OptionSet OptionSet
         {
@@ -21,7 +21,7 @@ namespace Sep.Git.Tfs.Commands
                         v => GitInitTemplate = v },
                     { "shared:", "Passed to git-init",
                         v => GitInitShared = v == null ? (object)true : (object)v },
-                    { "autocrlf=", "Normalize line endings (default: " + default_autocrlf + ")",
+                    { "autocrlf=", "Normalize line endings (default: " + DefaultAutocrlf + ")",
                         v => GitInitAutoCrlf = ValidateCrlfValue(v) },
                     { "ignorecase=", "Ignore case in file paths (default: system default)",
                         v => GitInitIgnoreCase = ValidateIgnoreCaseValue(v) },

--- a/GitTfs/Commands/InitOptions.cs
+++ b/GitTfs/Commands/InitOptions.cs
@@ -1,5 +1,4 @@
 using System;
-using System.ComponentModel;
 using NDesk.Options;
 using Sep.Git.Tfs.Util;
 

--- a/GitTfs/Commands/Labels.cs
+++ b/GitTfs/Commands/Labels.cs
@@ -1,7 +1,5 @@
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using NDesk.Options;

--- a/GitTfs/Commands/ListRemoteBranches.cs
+++ b/GitTfs/Commands/ListRemoteBranches.cs
@@ -12,39 +12,37 @@ namespace Sep.Git.Tfs.Commands
     [Description("list-remote-branches tfs-url-or-instance-name \n       git tfs list-remote-branches http://myTfsServer:8080/tfs/TfsRepository\n")]
     public class ListRemoteBranches : GitTfsCommand
     {
-        private readonly Globals globals;
-        private readonly ITfsHelper tfsHelper;
-        private readonly RemoteOptions remoteOptions;
+        private readonly ITfsHelper _tfsHelper;
+        private readonly RemoteOptions _remoteOptions;
 
-        public ListRemoteBranches(Globals globals, ITfsHelper tfsHelper, RemoteOptions remoteOptions)
+        public ListRemoteBranches(ITfsHelper tfsHelper, RemoteOptions remoteOptions)
         {
-            this.globals = globals;
-            this.tfsHelper = tfsHelper;
-            this.remoteOptions = remoteOptions;
+            _tfsHelper = tfsHelper;
+            _remoteOptions = remoteOptions;
         }
 
         public OptionSet OptionSet
         {
             get
             {
-                return remoteOptions.OptionSet;
+                return _remoteOptions.OptionSet;
             }
         }
 
         public int Run(string tfsUrl)
         {
-            tfsHelper.Url = tfsUrl;
-            tfsHelper.Username = remoteOptions.Username;
-            tfsHelper.Password = remoteOptions.Password;
-            tfsHelper.EnsureAuthenticated();
+            _tfsHelper.Url = tfsUrl;
+            _tfsHelper.Username = _remoteOptions.Username;
+            _tfsHelper.Password = _remoteOptions.Password;
+            _tfsHelper.EnsureAuthenticated();
 
-            if (!tfsHelper.CanGetBranchInformation)
+            if (!_tfsHelper.CanGetBranchInformation)
             {
                 throw new GitTfsException("error: this version of TFS doesn't support this functionality");
             }
 
             string convertBranchMessage = "  -> Open 'Source Control Explorer' and for each folder corresponding to a branch, right click on the folder and select 'Branching and Merging' > 'Convert to branch'.";
-            var branches = tfsHelper.GetBranches().Where(b => b.IsRoot).ToList();
+            var branches = _tfsHelper.GetBranches().Where(b => b.IsRoot).ToList();
             if (branches.IsEmpty())
             {
                 Trace.TraceWarning("No TFS branches were found!");
@@ -56,7 +54,7 @@ namespace Sep.Git.Tfs.Commands
                 Trace.TraceInformation("TFS branches that could be cloned:");
                 foreach (var branchObject in branches.Where(b => b.IsRoot))
                 {
-                    Branch.WriteRemoteTfsBranchStructure(tfsHelper, branchObject.Path);
+                    Branch.WriteRemoteTfsBranchStructure(_tfsHelper, branchObject.Path);
                 }
                 Trace.TraceInformation("\nCloning root branches (marked by [*]) is recommended!");
                 Trace.TraceInformation("\n\nPS:if your branch is not listed here, perhaps you should convert its containing folder into a branch in TFS:");

--- a/GitTfs/Commands/ListRemoteBranches.cs
+++ b/GitTfs/Commands/ListRemoteBranches.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using System.IO;
 using System.Linq;
 using NDesk.Options;
 using StructureMap;

--- a/GitTfs/Commands/Pull.cs
+++ b/GitTfs/Commands/Pull.cs
@@ -10,50 +10,50 @@ namespace Sep.Git.Tfs.Commands
     [RequiresValidGitRepository]
     public class Pull : GitTfsCommand
     {
-        private readonly Fetch fetch;
-        private readonly Globals globals;
+        private readonly Fetch _fetch;
+        private readonly Globals _globals;
         private bool _shouldRebase;
 
         public OptionSet OptionSet
         {
             get
             {
-                return fetch.OptionSet
+                return _fetch.OptionSet
                             .Add("r|rebase", "Rebase your modifications on tfs changes", v => _shouldRebase = v != null);
             }
         }
 
         public Pull(Globals globals, Fetch fetch)
         {
-            this.fetch = fetch;
-            this.globals = globals;
+            _fetch = fetch;
+            _globals = globals;
         }
 
         public int Run()
         {
-            return Run(globals.RemoteId);
+            return Run(_globals.RemoteId);
         }
 
         public int Run(string remoteId)
         {
-            var retVal = fetch.Run(remoteId);
+            var retVal = _fetch.Run(remoteId);
 
             if (retVal == 0)
             {
-                var remote = globals.Repository.ReadTfsRemote(remoteId);
+                var remote = _globals.Repository.ReadTfsRemote(remoteId);
                 if (_shouldRebase)
                 {
-                    globals.WarnOnGitVersion();
+                    _globals.WarnOnGitVersion();
 
-                    if (globals.Repository.WorkingCopyHasUnstagedOrUncommitedChanges)
+                    if (_globals.Repository.WorkingCopyHasUnstagedOrUncommitedChanges)
                     {
                         throw new GitTfsException("error: You have local changes; rebase-workflow only possible with clean working directory.")
                             .WithRecommendation("Try 'git stash' to stash your local changes and pull again.");
                     }
-                    globals.Repository.CommandNoisy("rebase", "--preserve-merges", remote.RemoteRef);
+                    _globals.Repository.CommandNoisy("rebase", "--preserve-merges", remote.RemoteRef);
                 }
                 else
-                    globals.Repository.Merge(remote.RemoteRef);
+                    _globals.Repository.Merge(remote.RemoteRef);
             }
 
             return retVal;

--- a/GitTfs/Commands/Pull.cs
+++ b/GitTfs/Commands/Pull.cs
@@ -1,7 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.IO;
 using NDesk.Options;
 using Sep.Git.Tfs.Core;
 using StructureMap;

--- a/GitTfs/Commands/QuickClone.cs
+++ b/GitTfs/Commands/QuickClone.cs
@@ -1,5 +1,4 @@
 ﻿using System.ComponentModel;
-using System.IO;
 using StructureMap;
 
 namespace Sep.Git.Tfs.Commands

--- a/GitTfs/Commands/QuickFetch.cs
+++ b/GitTfs/Commands/QuickFetch.cs
@@ -1,5 +1,4 @@
 ﻿using Sep.Git.Tfs.Core;
-using Sep.Git.Tfs.Util;
 
 namespace Sep.Git.Tfs.Commands
 {
@@ -12,9 +11,9 @@ namespace Sep.Git.Tfs.Commands
     //  2. Load the correct set of extant casing.
     public class QuickFetch : Fetch
     {
-        private ConfigProperties _properties;
-        public QuickFetch(Globals globals, ConfigProperties properties, RemoteOptions remoteOptions, AuthorsFile authors)
-            : base(globals, properties, remoteOptions, authors, null)
+        private readonly ConfigProperties _properties;
+        public QuickFetch(Globals globals, ConfigProperties properties, RemoteOptions remoteOptions)
+            : base(globals, properties, remoteOptions, null)
         {
             _properties = properties;
         }

--- a/GitTfs/Commands/QuickFetch.cs
+++ b/GitTfs/Commands/QuickFetch.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.ComponentModel;
-using System.IO;
-using NDesk.Options;
-using Sep.Git.Tfs.Core;
+﻿using Sep.Git.Tfs.Core;
 using Sep.Git.Tfs.Util;
 
 namespace Sep.Git.Tfs.Commands

--- a/GitTfs/Commands/Rcheckin.cs
+++ b/GitTfs/Commands/Rcheckin.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using NDesk.Options;
 using Sep.Git.Tfs.Core;

--- a/GitTfs/Commands/RemoteOptions.cs
+++ b/GitTfs/Commands/RemoteOptions.cs
@@ -25,11 +25,8 @@ namespace Sep.Git.Tfs.Commands
         }
 
         public string IgnoreRegex { get; set; }
-
         public string ExceptRegex { get; set; }
-
         public string Username { get; set; }
-
         public string Password { get; set; }
     }
 }

--- a/GitTfs/Commands/RemoteOptions.cs
+++ b/GitTfs/Commands/RemoteOptions.cs
@@ -1,11 +1,8 @@
-using System.ComponentModel;
 using NDesk.Options;
 using Sep.Git.Tfs.Util;
 
 namespace Sep.Git.Tfs.Commands
 {
-    using System;
-
     [StructureMapSingleton]
     public class RemoteOptions
     {

--- a/GitTfs/Commands/ResetRemote.cs
+++ b/GitTfs/Commands/ResetRemote.cs
@@ -12,12 +12,12 @@ namespace Sep.Git.Tfs.Commands
     [RequiresValidGitRepository]
     public class ResetRemote : GitTfsCommand
     {
-        private readonly Globals globals;
+        private readonly Globals _globals;
         private bool ForceResetRemote;
 
         public ResetRemote(Globals globals)
         {
-            this.globals = globals;
+            _globals = globals;
         }
 
         public virtual OptionSet OptionSet
@@ -33,13 +33,13 @@ namespace Sep.Git.Tfs.Commands
 
         public int Run(string commitRef)
         {
-            var targetCommit = globals.Repository.GetTfsCommit(commitRef);
+            var targetCommit = _globals.Repository.GetTfsCommit(commitRef);
             if (targetCommit == null)
                 throw new GitTfsException("error : the commit where you want to reset the tfs remote does not belong to a tfs remote!");
 
             if (!ForceResetRemote)
             {
-                var currentTfsCommit = globals.Repository.GetCurrentTfsCommit();
+                var currentTfsCommit = _globals.Repository.GetCurrentTfsCommit();
                 if (currentTfsCommit == null)
                     throw new GitTfsException("error : the current commit does not belong to a tfs remote!",
                         new List<string> { "Use '--force' option to reset a remote from a commit not belonging a tfs remote" });
@@ -52,7 +52,7 @@ namespace Sep.Git.Tfs.Commands
                                               + currentTfsCommit.Remote.Id + "\"" });
             }
 
-            globals.Repository.ResetRemote(targetCommit.Remote, targetCommit.GitCommit);
+            _globals.Repository.ResetRemote(targetCommit.Remote, targetCommit.GitCommit);
 
             Trace.TraceInformation("Remote 'tfs/" + targetCommit.Remote.Id + "' reset successfully.\n");
             Trace.TraceInformation("Note: remember to use the '--force' option when doing the next 'fetch' to force git-tfs to fetch again the changesets!");

--- a/GitTfs/Commands/ResetRemote.cs
+++ b/GitTfs/Commands/ResetRemote.cs
@@ -1,7 +1,5 @@
-using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.IO;
 using NDesk.Options;
 using Sep.Git.Tfs.Core;
 using StructureMap;

--- a/GitTfs/Commands/Shelve.cs
+++ b/GitTfs/Commands/Shelve.cs
@@ -1,5 +1,4 @@
 ﻿using System.ComponentModel;
-using System.IO;
 using NDesk.Options;
 using Sep.Git.Tfs.Core;
 using Sep.Git.Tfs.Util;

--- a/GitTfs/Commands/ShelveList.cs
+++ b/GitTfs/Commands/ShelveList.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.IO;
-using System.Linq;
+﻿using System.ComponentModel;
 using NDesk.Options;
 using Sep.Git.Tfs.Core;
 using StructureMap;

--- a/GitTfs/Commands/Subtree.cs
+++ b/GitTfs/Commands/Subtree.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
-using System.Text;
 using NDesk.Options;
 using Sep.Git.Tfs.Core;
 using StructureMap;

--- a/GitTfs/Commands/Subtree.cs
+++ b/GitTfs/Commands/Subtree.cs
@@ -1,12 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using NDesk.Options;
 using Sep.Git.Tfs.Core;
 using StructureMap;
-using System.Diagnostics;
 
 namespace Sep.Git.Tfs.Commands
 {
@@ -21,7 +21,7 @@ namespace Sep.Git.Tfs.Commands
         private readonly RemoteOptions _remoteOptions;
 
         private string Prefix;
-        private bool Squash = false;
+        private bool Squash;
 
         public OptionSet OptionSet
         {
@@ -32,7 +32,7 @@ namespace Sep.Git.Tfs.Commands
                     { "p|prefix=",
                         v => Prefix = v},
                     { "squash",
-                        v => Squash = v != null},
+                        v => Squash = v != null}
                     //                    { "r|revision=",
                     //                        v => RevisionToFetch = Convert.ToInt32(v) },
                 }
@@ -80,7 +80,7 @@ namespace Sep.Git.Tfs.Commands
         {
             if (File.Exists(Prefix) || Directory.Exists(Prefix))
             {
-                Trace.TraceInformation(string.Format("Directory {0} already exists", Prefix));
+                Trace.TraceInformation("Directory {0} already exists", Prefix);
                 return GitTfsExitCodes.InvalidArguments;
             }
 
@@ -133,7 +133,7 @@ namespace Sep.Git.Tfs.Commands
                     Id = remoteId,
                     Url = tfsUrl,
                     Repository = tfsRepositoryPath,
-                    RemoteOptions = _remoteOptions,
+                    RemoteOptions = _remoteOptions
                 });
 
             Trace.TraceInformation("-> new remote " + remote.Id);

--- a/GitTfs/Commands/Unshelve.cs
+++ b/GitTfs/Commands/Unshelve.cs
@@ -1,8 +1,6 @@
 using System;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.IO;
-using System.Linq;
 using NDesk.Options;
 using StructureMap;
 using Sep.Git.Tfs.Core;

--- a/GitTfs/Commands/Verify.cs
+++ b/GitTfs/Commands/Verify.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using NDesk.Options;

--- a/GitTfs/Commands/Version.cs
+++ b/GitTfs/Commands/Version.cs
@@ -1,6 +1,4 @@
-using System;
 using System.ComponentModel;
-using System.IO;
 using NDesk.Options;
 using StructureMap;
 using Sep.Git.Tfs.Core;
@@ -12,26 +10,23 @@ namespace Sep.Git.Tfs.Commands
     [Description("version")]
     public class Version : GitTfsCommand
     {
-        private Globals globals;
-        private IGitTfsVersionProvider versionProvider;
+        private readonly IGitTfsVersionProvider _versionProvider;
 
         /// <summary>
         /// Initializes a new instance of the Version class.
         /// </summary>
-        /// <param name="stdout"></param>
+        /// <param name="globals"></param>
         /// <param name="versionProvider"></param>
         public Version(Globals globals, IGitTfsVersionProvider versionProvider)
         {
-            this.globals = globals;
-            this.versionProvider = versionProvider;
-
-            this.OptionSet = globals.OptionSet;
+            _versionProvider = versionProvider;
+            OptionSet = globals.OptionSet;
         }
 
         public int Run()
         {
-            Trace.TraceInformation(versionProvider.GetVersionString());
-            Trace.TraceInformation(versionProvider.GetPathToGitTfsExecutable());
+            Trace.TraceInformation(_versionProvider.GetVersionString());
+            Trace.TraceInformation(_versionProvider.GetPathToGitTfsExecutable());
 
             Trace.TraceInformation(GitTfsConstants.MessageForceVersion);
 

--- a/GitTfs/ConfigProperties.cs
+++ b/GitTfs/ConfigProperties.cs
@@ -1,4 +1,3 @@
-using System;
 using Sep.Git.Tfs.Util;
 
 namespace Sep.Git.Tfs
@@ -7,7 +6,7 @@ namespace Sep.Git.Tfs
     // or overridden by some other means, like from the command line.
     public class ConfigProperties
     {
-        private ConfigPropertyLoader _loader;
+        private readonly ConfigPropertyLoader _loader;
 
         public ConfigProperties(ConfigPropertyLoader loader)
         {
@@ -33,7 +32,7 @@ namespace Sep.Git.Tfs
             }
             get
             {
-                int? initialChangeset = _loader.Get<int>(GitTfsConstants.InitialChangeset, -1);
+                int? initialChangeset = _loader.Get(GitTfsConstants.InitialChangeset, -1);
                 return initialChangeset == -1 ? null : initialChangeset;
             }
         }

--- a/GitTfs/Core/Bootstrapper.cs
+++ b/GitTfs/Core/Bootstrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using Sep.Git.Tfs.Commands; // ToGitRefName() and RemoteOptions
 using System.Diagnostics;
 

--- a/GitTfs/Core/BranchVisitors/BranchTreeContainsPathVisitor.cs
+++ b/GitTfs/Core/BranchVisitors/BranchTreeContainsPathVisitor.cs
@@ -4,13 +4,13 @@ namespace Sep.Git.Tfs.Core.BranchVisitors
 {
     public class BranchTreeContainsPathVisitor : IBranchTreeVisitor
     {
-        private readonly string searchPath;
-        private readonly bool searchExactPath;
+        private readonly string _searchPath;
+        private readonly bool _searchExactPath;
 
         public BranchTreeContainsPathVisitor(string searchPath, bool searchExactPath)
         {
-            this.searchPath = searchPath;
-            this.searchExactPath = searchExactPath;
+            _searchPath = searchPath;
+            _searchExactPath = searchExactPath;
         }
 
         public bool Found { get; private set; }
@@ -18,8 +18,8 @@ namespace Sep.Git.Tfs.Core.BranchVisitors
         public void Visit(BranchTree childBranch, int level)
         {
             if (Found == false
-                && ((searchExactPath && searchPath.ToLower() == childBranch.Path.ToLower())
-                || (!searchExactPath && searchPath.ToLower().IndexOf(childBranch.Path.ToLower()) == 0)))
+                && ((_searchExactPath && _searchPath.ToLower() == childBranch.Path.ToLower())
+                || (!_searchExactPath && _searchPath.ToLower().IndexOf(childBranch.Path.ToLower()) == 0)))
             {
                 Found = true;
             }

--- a/GitTfs/Core/BranchVisitors/BranchTreeContainsPathVisitor.cs
+++ b/GitTfs/Core/BranchVisitors/BranchTreeContainsPathVisitor.cs
@@ -1,5 +1,3 @@
-using System.Linq;
-using System.Collections.Generic;
 using Sep.Git.Tfs.Core.TfsInterop;
 
 namespace Sep.Git.Tfs.Core.BranchVisitors

--- a/GitTfs/Core/BranchVisitors/BranchTreeContainsPathVisitor.cs
+++ b/GitTfs/Core/BranchVisitors/BranchTreeContainsPathVisitor.cs
@@ -4,8 +4,8 @@ namespace Sep.Git.Tfs.Core.BranchVisitors
 {
     public class BranchTreeContainsPathVisitor : IBranchTreeVisitor
     {
-        private string searchPath;
-        private bool searchExactPath;
+        private readonly string searchPath;
+        private readonly bool searchExactPath;
 
         public BranchTreeContainsPathVisitor(string searchPath, bool searchExactPath)
         {

--- a/GitTfs/Core/Changes/Git/Modify.cs
+++ b/GitTfs/Core/Changes/Git/Modify.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Sep.Git.Tfs.Core.Changes.Git
+﻿namespace Sep.Git.Tfs.Core.Changes.Git
 {
     public class Modify : IGitChangedFile
     {

--- a/GitTfs/Core/DelimitedReader.cs
+++ b/GitTfs/Core/DelimitedReader.cs
@@ -4,11 +4,11 @@ namespace Sep.Git.Tfs.Core
 {
     public class DelimitedReader
     {
-        private readonly TextReader reader;
+        private readonly TextReader _reader;
 
         public DelimitedReader(TextReader reader)
         {
-            this.reader = reader;
+            _reader = reader;
             Delimiter = "\0";
         }
 
@@ -16,10 +16,10 @@ namespace Sep.Git.Tfs.Core
 
         public string Read()
         {
-            if (-1 == reader.Peek()) return null;
+            if (-1 == _reader.Peek()) return null;
             var nextString = "";
             int nextChar;
-            while (-1 != (nextChar = reader.Read()))
+            while (-1 != (nextChar = _reader.Read()))
             {
                 nextString = nextString + (char)nextChar;
                 if (nextString.EndsWith(Delimiter))

--- a/GitTfs/Core/DirectoryTidier.cs
+++ b/GitTfs/Core/DirectoryTidier.cs
@@ -17,10 +17,10 @@ namespace Sep.Git.Tfs.Core
             EditAndRenameFrom,
         }
 
-        private ITfsWorkspaceModifier _workspace;
-        private Func<IEnumerable<TfsTreeEntry>> _getInitialTfsTree;
+        private readonly ITfsWorkspaceModifier _workspace;
+        private readonly Func<IEnumerable<TfsTreeEntry>> _getInitialTfsTree;
         private List<string> _filesInTfs;
-        private Dictionary<string, FileOperation> _fileOperations;
+        private readonly Dictionary<string, FileOperation> _fileOperations;
         private bool _disposed;
 
         public DirectoryTidier(ITfsWorkspaceModifier workspace, Func<IEnumerable<TfsTreeEntry>> getInitialTfsTree)

--- a/GitTfs/Core/Ext.cs
+++ b/GitTfs/Core/Ext.cs
@@ -77,7 +77,7 @@ namespace Sep.Git.Tfs.Core
 
         public static void SetArguments(this ProcessStartInfo startInfo, params string[] args)
         {
-            startInfo.Arguments = String.Join(" ", args.Select(arg => QuoteProcessArgument(arg)).ToArray());
+            startInfo.Arguments = string.Join(" ", args.Select(arg => QuoteProcessArgument(arg)).ToArray());
         }
 
         private static string QuoteProcessArgument(string arg)

--- a/GitTfs/Core/GitChangeInfo.cs
+++ b/GitTfs/Core/GitChangeInfo.cs
@@ -48,7 +48,7 @@ namespace Sep.Git.Tfs.Core
             string line;
             while (null != (line = GetDiffTreeLine(reader)))
             {
-                var change = GitChangeInfo.Parse(line);
+                var change = Parse(line);
 
                 if (FileMode.GitLink == change.NewMode)
                     continue;

--- a/GitTfs/Core/GitHelpers.cs
+++ b/GitTfs/Core/GitHelpers.cs
@@ -15,7 +15,7 @@ namespace Sep.Git.Tfs.Core
         /// Starting with version 1.7.10, Git uses UTF-8.
         /// Use this encoding for Git input and output.
         /// </summary>
-        private static Encoding _encoding = new UTF8Encoding(false, true);
+        private static readonly Encoding _encoding = new UTF8Encoding(false, true);
 
         public GitHelpers(IContainer container)
         {
@@ -281,7 +281,7 @@ namespace Sep.Git.Tfs.Core
 
         protected class GitProcess
         {
-            private Process _process;
+            private readonly Process _process;
 
             public GitProcess(Process process)
             {

--- a/GitTfs/Core/GitHelpers.cs
+++ b/GitTfs/Core/GitHelpers.cs
@@ -187,7 +187,7 @@ namespace Sep.Git.Tfs.Core
             finally
             {
                 var end = DateTime.Now;
-                Trace.WriteLine(String.Format("[{0}] {1}", end - start, String.Join(" ", command)), "git command time");
+                Trace.WriteLine(string.Format("[{0}] {1}", end - start, string.Join(" ", command)), "git command time");
             }
         }
 
@@ -261,7 +261,7 @@ namespace Sep.Git.Tfs.Core
             }
             catch (GitCommandException e)
             {
-                throw new Exception(String.Format(exceptionMessage, e.Process.StartInfo.FileName + " " + e.Process.StartInfo.Arguments, e.Process.ExitCode), e);
+                throw new Exception(string.Format(exceptionMessage, e.Process.StartInfo.FileName + " " + e.Process.StartInfo.Arguments, e.Process.ExitCode), e);
             }
         }
 

--- a/GitTfs/Core/GitHelpers.cs
+++ b/GitTfs/Core/GitHelpers.cs
@@ -76,28 +76,28 @@ namespace Sep.Git.Tfs.Core
 
         private class ProcessStdoutReader : TextReader
         {
-            private readonly GitProcess process;
-            private readonly GitHelpers helper;
+            private readonly GitProcess _process;
+            private readonly GitHelpers _helper;
 
             public ProcessStdoutReader(GitHelpers helper, GitProcess process)
             {
-                this.helper = helper;
-                this.process = process;
+                _helper = helper;
+                _process = process;
             }
 
             public override void Close()
             {
-                helper.Close(process);
+                _helper.Close(_process);
             }
 
             public override System.Runtime.Remoting.ObjRef CreateObjRef(Type requestedType)
             {
-                return process.StandardOutput.CreateObjRef(requestedType);
+                return _process.StandardOutput.CreateObjRef(requestedType);
             }
 
             protected override void Dispose(bool disposing)
             {
-                if (disposing && process != null)
+                if (disposing && _process != null)
                 {
                     Close();
                 }
@@ -106,52 +106,52 @@ namespace Sep.Git.Tfs.Core
 
             public override bool Equals(object obj)
             {
-                return process.StandardOutput.Equals(obj);
+                return _process.StandardOutput.Equals(obj);
             }
 
             public override int GetHashCode()
             {
-                return process.StandardOutput.GetHashCode();
+                return _process.StandardOutput.GetHashCode();
             }
 
             public override object InitializeLifetimeService()
             {
-                return process.StandardOutput.InitializeLifetimeService();
+                return _process.StandardOutput.InitializeLifetimeService();
             }
 
             public override int Peek()
             {
-                return process.StandardOutput.Peek();
+                return _process.StandardOutput.Peek();
             }
 
             public override int Read()
             {
-                return process.StandardOutput.Read();
+                return _process.StandardOutput.Read();
             }
 
             public override int Read(char[] buffer, int index, int count)
             {
-                return process.StandardOutput.Read(buffer, index, count);
+                return _process.StandardOutput.Read(buffer, index, count);
             }
 
             public override int ReadBlock(char[] buffer, int index, int count)
             {
-                return process.StandardOutput.ReadBlock(buffer, index, count);
+                return _process.StandardOutput.ReadBlock(buffer, index, count);
             }
 
             public override string ReadLine()
             {
-                return process.StandardOutput.ReadLine();
+                return _process.StandardOutput.ReadLine();
             }
 
             public override string ReadToEnd()
             {
-                return process.StandardOutput.ReadToEnd();
+                return _process.StandardOutput.ReadToEnd();
             }
 
             public override string ToString()
             {
-                return process.StandardOutput.ToString();
+                return _process.StandardOutput.ToString();
             }
         }
 

--- a/GitTfs/Core/GitRepository.cs
+++ b/GitTfs/Core/GitRepository.cs
@@ -16,8 +16,8 @@ namespace Sep.Git.Tfs.Core
         private readonly IContainer _container;
         private readonly Globals _globals;
         private IDictionary<string, IGitTfsRemote> _cachedRemotes;
-        private Repository _repository;
-        private RemoteConfigConverter _remoteConfigReader;
+        private readonly Repository _repository;
+        private readonly RemoteConfigConverter _remoteConfigReader;
 
         public GitRepository(string gitDir, IContainer container, Globals globals, RemoteConfigConverter remoteConfigReader)
             : base(container)

--- a/GitTfs/Core/GitRepository.cs
+++ b/GitTfs/Core/GitRepository.cs
@@ -25,7 +25,7 @@ namespace Sep.Git.Tfs.Core
             _container = container;
             _globals = globals;
             GitDir = gitDir;
-            _repository = new LibGit2Sharp.Repository(GitDir);
+            _repository = new Repository(GitDir);
             _remoteConfigReader = remoteConfigReader;
         }
 
@@ -177,7 +177,7 @@ namespace Sep.Git.Tfs.Core
             // When creating branches we use the empty string to indicate that we do not want to set the value at all.
             if (autocrlf == null)
                 autocrlf = "false";
-            if (autocrlf != String.Empty)
+            if (autocrlf != string.Empty)
                 _repository.Config.Set("core.autocrlf", autocrlf);
 
             if (ignorecase != null)
@@ -274,7 +274,7 @@ namespace Sep.Git.Tfs.Core
         public bool IsInSameTeamProjectAsDefaultRepository(string tfsRepositoryPath)
         {
             IGitTfsRemote defaultRepository;
-            if (!this.GetTfsRemotes().TryGetValue(GitTfsConstants.DefaultRepositoryId, out defaultRepository))
+            if (!GetTfsRemotes().TryGetValue(GitTfsConstants.DefaultRepositoryId, out defaultRepository))
             {
                 return true;
             }
@@ -633,7 +633,7 @@ namespace Sep.Git.Tfs.Core
             return commit;
         }
 
-        public void CreateTag(string name, string sha, string comment, string Owner, string emailOwner, System.DateTime creationDate)
+        public void CreateTag(string name, string sha, string comment, string Owner, string emailOwner, DateTime creationDate)
         {
             if (_repository.Tags[name] == null)
                 _repository.ApplyTag(name, sha, new Signature(Owner, emailOwner, new DateTimeOffset(creationDate)), comment);

--- a/GitTfs/Core/GitTfsException.cs
+++ b/GitTfs/Core/GitTfsException.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 
 namespace Sep.Git.Tfs.Core
 {

--- a/GitTfs/Core/GitTfsRemote.cs
+++ b/GitTfs/Core/GitTfsRemote.cs
@@ -498,7 +498,7 @@ namespace Sep.Git.Tfs.Core
                             workitemUrl = workitemUrl.Replace(oldWorkitemId, workitemId);
                         }
                     }
-                    workitemNote += String.Format("[{0}] {1}\n    {2}\n", workitemId, workitem.Title, workitemUrl);
+                    workitemNote += string.Format("[{0}] {1}\n    {2}\n", workitemId, workitem.Title, workitemUrl);
                 }
                 metadatas.Append(workitemNote);
             }
@@ -777,7 +777,7 @@ namespace Sep.Git.Tfs.Core
                 result = changeset.Apply(parent, treeBuilder, workspace, entries, ignorableErrorHandler);
                 result.Tree = treeBuilder.GetTree();
             });
-            if (!String.IsNullOrEmpty(parent)) result.CommitParents.Add(parent);
+            if (!string.IsNullOrEmpty(parent)) result.CommitParents.Add(parent);
             return result;
         }
 
@@ -790,7 +790,7 @@ namespace Sep.Git.Tfs.Core
                 result = changeset.CopyTree(treeBuilder, workspace);
                 result.Tree = treeBuilder.GetTree();
             });
-            if (!String.IsNullOrEmpty(lastCommit)) result.CommitParents.Add(lastCommit);
+            if (!string.IsNullOrEmpty(lastCommit)) result.CommitParents.Add(lastCommit);
             return result;
         }
 

--- a/GitTfs/Core/GitTfsVersionProvider.cs
+++ b/GitTfs/Core/GitTfsVersionProvider.cs
@@ -6,18 +6,18 @@ namespace Sep.Git.Tfs.Core
 {
     public class GitTfsVersionProvider : IGitTfsVersionProvider
     {
-        private readonly ITfsHelper tfsHelper;
+        private readonly ITfsHelper _tfsHelper;
 
         public GitTfsVersionProvider(ITfsHelper tfsHelper)
         {
-            this.tfsHelper = tfsHelper;
+            _tfsHelper = tfsHelper;
         }
 
         public string GetVersionString()
         {
             return string.Format("git-tfs version {0} (TFS client library {1}) ({2}-bit)",
                        GetType().Assembly.GetName().Version,
-                       tfsHelper.TfsClientLibraryVersion,
+                       _tfsHelper.TfsClientLibraryVersion,
                        (Environment.Is64BitProcess ? "64" : "32"));
         }
 

--- a/GitTfs/Core/GitTfsVersionProvider.cs
+++ b/GitTfs/Core/GitTfsVersionProvider.cs
@@ -6,7 +6,7 @@ namespace Sep.Git.Tfs.Core
 {
     public class GitTfsVersionProvider : IGitTfsVersionProvider
     {
-        private ITfsHelper tfsHelper;
+        private readonly ITfsHelper tfsHelper;
 
         public GitTfsVersionProvider(ITfsHelper tfsHelper)
         {

--- a/GitTfs/Core/GitTreeBuilder.cs
+++ b/GitTfs/Core/GitTreeBuilder.cs
@@ -4,8 +4,8 @@ namespace Sep.Git.Tfs.Core
 {
     public class GitTreeBuilder : IGitTreeBuilder
     {
-        private TreeDefinition _treeDefinition;
-        private ObjectDatabase _objectDatabase;
+        private readonly TreeDefinition _treeDefinition;
+        private readonly ObjectDatabase _objectDatabase;
 
         public GitTreeBuilder(ObjectDatabase objectDatabase)
         {

--- a/GitTfs/Core/GitTreeEntry.cs
+++ b/GitTfs/Core/GitTreeEntry.cs
@@ -26,8 +26,7 @@ namespace Sep.Git.Tfs.Core
             {
                 return ((Blob)_entry.Target).GetContentStream();
             }
-            else
-                throw new InvalidOperationException("Invalid object type");
+            throw new InvalidOperationException("Invalid object type");
         }
     }
 }

--- a/GitTfs/Core/IBranchTreeVisitor.cs
+++ b/GitTfs/Core/IBranchTreeVisitor.cs
@@ -1,5 +1,3 @@
-using System.Linq;
-using System.Collections.Generic;
 using Sep.Git.Tfs.Core.TfsInterop;
 
 namespace Sep.Git.Tfs.Core

--- a/GitTfs/Core/IGitRepository.cs
+++ b/GitTfs/Core/IGitRepository.cs
@@ -44,7 +44,7 @@ namespace Sep.Git.Tfs.Core
         bool CreateBranch(string gitBranchName, string target);
         Branch RenameBranch(string oldName, string newName);
         string FindCommitHashByChangesetId(int changesetId);
-        void CreateTag(string name, string sha, string comment, string Owner, string emailOwner, System.DateTime creationDate);
+        void CreateTag(string name, string sha, string comment, string Owner, string emailOwner, DateTime creationDate);
         void CreateNote(string sha, string content, string owner, string emailOwner, DateTime creationDate);
         void MoveRemote(string oldRemoteName, string newRemoteName);
         void ResetHard(string sha);

--- a/GitTfs/Core/IGitTfsVersionProvider.cs
+++ b/GitTfs/Core/IGitTfsVersionProvider.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Sep.Git.Tfs.Core
 {
     public interface IGitTfsVersionProvider

--- a/GitTfs/Core/Janitor.cs
+++ b/GitTfs/Core/Janitor.cs
@@ -8,7 +8,7 @@ namespace Sep.Git.Tfs.Core
     [StructureMapSingleton]
     public class Janitor : IDisposable
     {
-        private Queue<Action> _actions = new Queue<Action>();
+        private readonly Queue<Action> _actions = new Queue<Action>();
 
         public void CleanThisUpWhenWeClose(Action action)
         {

--- a/GitTfs/Core/Mode.cs
+++ b/GitTfs/Core/Mode.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using LibGit2Sharp.Core;
 
 namespace Sep.Git.Tfs.Core
 {

--- a/GitTfs/Core/RemoteConfigConverter.cs
+++ b/GitTfs/Core/RemoteConfigConverter.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using LibGit2Sharp;
 

--- a/GitTfs/Core/TfsChangeset.cs
+++ b/GitTfs/Core/TfsChangeset.cs
@@ -189,13 +189,13 @@ namespace Sep.Git.Tfs.Core
                 //This can be null if the user was deleted from AD.
                 //We want to keep their original history around with as little 
                 //hassle to the end user as possible
-                if (!String.IsNullOrWhiteSpace(identity.DisplayName))
+                if (!string.IsNullOrWhiteSpace(identity.DisplayName))
                     name = identity.DisplayName;
 
-                if (!String.IsNullOrWhiteSpace(identity.MailAddress))
+                if (!string.IsNullOrWhiteSpace(identity.MailAddress))
                     email = identity.MailAddress;
             }
-            else if (!String.IsNullOrWhiteSpace(changesetToLog.Committer))
+            else if (!string.IsNullOrWhiteSpace(changesetToLog.Committer))
             {
                 string[] split = changesetToLog.Committer.Split('\\');
                 if (split.Length == 2)
@@ -208,11 +208,11 @@ namespace Sep.Git.Tfs.Core
             // committer's & author's name and email MUST NOT be empty as otherwise they would be picked
             // by git from user.name and user.email config settings which is bad thing because commit could
             // be different depending on whose machine it fetched
-            if (String.IsNullOrWhiteSpace(name))
+            if (string.IsNullOrWhiteSpace(name))
             {
                 name = "Unknown TFS user";
             }
-            if (String.IsNullOrWhiteSpace(email))
+            if (string.IsNullOrWhiteSpace(email))
             {
                 email = "unknown@tfs.local";
             }

--- a/GitTfs/Core/TfsInterop/IBranch.cs
+++ b/GitTfs/Core/TfsInterop/IBranch.cs
@@ -42,7 +42,7 @@ namespace Sep.Git.Tfs.Core.TfsInterop
 
         public override string ToString()
         {
-            return string.Format("{0} [{1} children]", this.Path, this.ChildBranches.Count);
+            return string.Format("{0} [{1} children]", Path, ChildBranches.Count);
         }
     }
 

--- a/GitTfs/Core/TfsInterop/IItem.cs
+++ b/GitTfs/Core/TfsInterop/IItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using Sep.Git.Tfs.Util;
 
 namespace Sep.Git.Tfs.Core.TfsInterop

--- a/GitTfs/Core/TfsInterop/TfsPlugin.cs
+++ b/GitTfs/Core/TfsInterop/TfsPlugin.cs
@@ -32,7 +32,7 @@ namespace Sep.Git.Tfs.Core.TfsInterop
 
         private class PluginLoader
         {
-            private List<Exception> _failures = new List<Exception>();
+            private readonly List<Exception> _failures = new List<Exception>();
             private static string VsPluginAssemblyFolder { get; set; }
             private static readonly Dictionary<string, string> VisualStudioVersions = new Dictionary<string, string>()
             {

--- a/GitTfs/Core/TfsInterop/TfsPlugin.cs
+++ b/GitTfs/Core/TfsInterop/TfsPlugin.cs
@@ -17,7 +17,7 @@ namespace Sep.Git.Tfs.Core.TfsInterop
             var pluginLoader = new PluginLoader();
             var explicitVersion = Environment.GetEnvironmentVariable("GIT_TFS_CLIENT");
             if (explicitVersion == "11") explicitVersion = "2012"; // GitTfs.Vs2012 was formerly called GitTfs.Vs11
-            if (!String.IsNullOrEmpty(explicitVersion))
+            if (!string.IsNullOrEmpty(explicitVersion))
             {
                 return pluginLoader.TryLoadVsPluginVersion(explicitVersion) ??
                        pluginLoader.Fail("Unable to load TFS version specified in GIT_TFS_CLIENT (" + explicitVersion + ")!");

--- a/GitTfs/Core/TfsWorkspace.cs
+++ b/GitTfs/Core/TfsWorkspace.cs
@@ -108,7 +108,7 @@ namespace Sep.Git.Tfs.Core
                 {
                     throw new GitTfsException("No changes checked in.");
                 }
-                if (String.IsNullOrWhiteSpace(options.OverrideReason))
+                if (string.IsNullOrWhiteSpace(options.OverrideReason))
                 {
                     throw new GitTfsException("A reason must be supplied (-f REASON) to override the policy violations.");
                 }
@@ -160,7 +160,7 @@ namespace Sep.Git.Tfs.Core
 
         private TfsPolicyOverrideInfo GetPolicyOverrides(CheckinOptions options, ICheckinEvaluationResult checkinProblems)
         {
-            if (!options.Force || String.IsNullOrWhiteSpace(options.OverrideReason))
+            if (!options.Force || string.IsNullOrWhiteSpace(options.OverrideReason))
                 return null;
             return new TfsPolicyOverrideInfo { Comment = options.OverrideReason, Failures = checkinProblems.PolicyFailures };
         }

--- a/GitTfs/Core/TfsWorkspace.cs
+++ b/GitTfs/Core/TfsWorkspace.cs
@@ -29,7 +29,7 @@ namespace Sep.Git.Tfs.Core
             _tfsHelper = tfsHelper;
             _localDirectory = remote.Repository.IsBare ? Path.GetFullPath(localDirectory) : localDirectory;
 
-            this.Remote = remote;
+            Remote = remote;
         }
 
         public void Shelve(string shelvesetName, bool evaluateCheckinPolicies, CheckinOptions checkinOptions, Func<string> generateCheckinComment)

--- a/GitTfs/Core/TfsWriter.cs
+++ b/GitTfs/Core/TfsWriter.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
-using System.Text;
 
 namespace Sep.Git.Tfs.Core
 {

--- a/GitTfs/Core/TfsWriter.cs
+++ b/GitTfs/Core/TfsWriter.cs
@@ -42,7 +42,7 @@ namespace Sep.Git.Tfs.Core
                         var lastChangeSet = tfsParents.OrderByDescending(x => x.ChangesetId).First();
                         if (lastChangeSet.Remote.IsSubtree)
                             lastChangeSet.Remote = _globals.Repository.ReadTfsRemote(lastChangeSet.Remote.OwningRemoteId);
-                        Trace.TraceInformation(string.Format("Basing from parent '{0}:{1}', use -i to override", lastChangeSet.Remote.Id, lastChangeSet.ChangesetId));
+                        Trace.TraceInformation("Basing from parent '{0}:{1}', use -i to override", lastChangeSet.Remote.Id, lastChangeSet.ChangesetId);
                         return write(lastChangeSet, refToWrite);
                     }
 

--- a/GitTfs/GitTfs.cs
+++ b/GitTfs/GitTfs.cs
@@ -3,33 +3,28 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
 using StructureMap;
 using Sep.Git.Tfs.Commands;
 using Sep.Git.Tfs.Core;
-using Sep.Git.Tfs.Core.TfsInterop;
 using Sep.Git.Tfs.Util;
 using NLog;
-using NLog.Targets;
 
 namespace Sep.Git.Tfs
 {
     public class GitTfs
     {
-        private IGitTfsVersionProvider _gitTfsVersionProvider;
-        private ITfsHelper tfsHelper;
-        private GitTfsCommandFactory commandFactory;
+        private readonly IGitTfsVersionProvider _gitTfsVersionProvider;
+        private readonly GitTfsCommandFactory _commandFactory;
         private readonly IHelpHelper _help;
         private readonly IContainer _container;
         private readonly GitTfsCommandRunner _runner;
         private readonly Globals _globals;
-        private Bootstrapper _bootstrapper;
+        private readonly Bootstrapper _bootstrapper;
 
-        public GitTfs(ITfsHelper tfsHelper, GitTfsCommandFactory commandFactory, IHelpHelper help, IContainer container,
+        public GitTfs(GitTfsCommandFactory commandFactory, IHelpHelper help, IContainer container,
             IGitTfsVersionProvider gitTfsVersionProvider, GitTfsCommandRunner runner, Globals globals, Bootstrapper bootstrapper)
         {
-            this.tfsHelper = tfsHelper;
-            this.commandFactory = commandFactory;
+            _commandFactory = commandFactory;
             _help = help;
             _container = container;
             _gitTfsVersionProvider = gitTfsVersionProvider;
@@ -168,7 +163,7 @@ namespace Sep.Git.Tfs
         {
             for (int i = 0; i < args.Count; i++)
             {
-                var command = commandFactory.GetCommand(args[i]);
+                var command = _commandFactory.GetCommand(args[i]);
                 if (command != null)
                 {
                     args.RemoveAt(i);

--- a/GitTfs/GitTfs.cs
+++ b/GitTfs/GitTfs.cs
@@ -142,11 +142,11 @@ namespace Sep.Git.Tfs
                                          () =>
                                              {
                                                  cdUp = git.CommandOneline("rev-parse", "--show-cdup");
-                                                 if (String.IsNullOrEmpty(cdUp))
+                                                 if (string.IsNullOrEmpty(cdUp))
                                                      gitDir = ".";
                                                  else
                                                      cdUp = cdUp.TrimEnd();
-                                                 if (String.IsNullOrEmpty(cdUp))
+                                                 if (string.IsNullOrEmpty(cdUp))
                                                      cdUp = ".";
                                              });
                 Environment.CurrentDirectory = cdUp;

--- a/GitTfs/GitTfs.csproj
+++ b/GitTfs/GitTfs.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\LibGit2Sharp.NativeBinaries\build\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\packages\LibGit2Sharp.NativeBinaries\build\LibGit2Sharp.NativeBinaries.props')" Label="Paket" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
@@ -280,6 +279,14 @@
     </BootstrapperPackage>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5')">
+      <PropertyGroup>
+        <__paket__LibGit2Sharp_NativeBinaries_props>LibGit2Sharp.NativeBinaries</__paket__LibGit2Sharp_NativeBinaries_props>
+      </PropertyGroup>
+    </When>
+  </Choose>
+  <Import Project="..\packages\LibGit2Sharp.NativeBinaries\build\$(__paket__LibGit2Sharp_NativeBinaries_props).props" Condition="Exists('..\packages\LibGit2Sharp.NativeBinaries\build\$(__paket__LibGit2Sharp_NativeBinaries_props).props')" Label="Paket" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
@@ -300,7 +307,7 @@
   </PropertyGroup>
   <Import Project="..\.paket\paket.targets" />
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5')">
       <ItemGroup>
         <Reference Include="LibGit2Sharp">
           <HintPath>..\packages\LibGit2Sharp\lib\net40\LibGit2Sharp.dll</HintPath>
@@ -311,24 +318,6 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == 'MonoAndroid'">
-      <ItemGroup>
-        <Reference Include="NLog">
-          <HintPath>..\packages\NLog\lib\MonoAndroid10\NLog.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v3.5'">
-      <ItemGroup>
-        <Reference Include="NLog">
-          <HintPath>..\packages\NLog\lib\net35\NLog.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.0'">
       <ItemGroup>
         <Reference Include="NLog">
@@ -338,46 +327,10 @@
         </Reference>
       </ItemGroup>
     </When>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.5'">
       <ItemGroup>
         <Reference Include="NLog">
           <HintPath>..\packages\NLog\lib\net45\NLog.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-    <When Condition="$(TargetFrameworkIdentifier) == 'Silverlight' And $(TargetFrameworkVersion) == 'v4.0'">
-      <ItemGroup>
-        <Reference Include="NLog">
-          <HintPath>..\packages\NLog\lib\sl4\NLog.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-    <When Condition="$(TargetFrameworkIdentifier) == 'Silverlight' And $(TargetFrameworkVersion) == 'v5.0'">
-      <ItemGroup>
-        <Reference Include="NLog">
-          <HintPath>..\packages\NLog\lib\sl5\NLog.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-    <When Condition="$(TargetFrameworkIdentifier) == 'WindowsPhone' And ($(TargetFrameworkVersion) == 'v8.0' Or $(TargetFrameworkVersion) == 'v8.1')">
-      <ItemGroup>
-        <Reference Include="NLog">
-          <HintPath>..\packages\NLog\lib\wp8\NLog.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-    <When Condition="$(TargetFrameworkIdentifier) == 'Xamarin.iOS'">
-      <ItemGroup>
-        <Reference Include="NLog">
-          <HintPath>..\packages\NLog\lib\Xamarin.iOS10\NLog.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>

--- a/GitTfs/GitTfs.csproj
+++ b/GitTfs/GitTfs.csproj
@@ -53,6 +53,7 @@
     <CodeAnalysisIgnoreBuiltInRules>true</CodeAnalysisIgnoreBuiltInRules>
     <CodeAnalysisFailOnMissingRules>false</CodeAnalysisFailOnMissingRules>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <OutputPath>bin\Release\</OutputPath>
@@ -67,6 +68,7 @@
     <CodeAnalysisIgnoreBuiltInRuleSets>true</CodeAnalysisIgnoreBuiltInRuleSets>
     <CodeAnalysisIgnoreBuiltInRules>true</CodeAnalysisIgnoreBuiltInRules>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/GitTfs/GitTfsCommand.cs
+++ b/GitTfs/GitTfsCommand.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using NDesk.Options;
 using StructureMap;
 

--- a/GitTfs/Globals.cs
+++ b/GitTfs/Globals.cs
@@ -1,13 +1,10 @@
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using NDesk.Options;
 using Sep.Git.Tfs.Core;
 using Sep.Git.Tfs.Util;
-using NLog;
 
 namespace Sep.Git.Tfs
 {

--- a/GitTfs/Program.cs
+++ b/GitTfs/Program.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Reflection;
 using Sep.Git.Tfs.Core;
 using Sep.Git.Tfs.Core.Changes.Git;

--- a/GitTfs/Util/AuthorsFile.cs
+++ b/GitTfs/Util/AuthorsFile.cs
@@ -119,8 +119,8 @@ namespace Sep.Git.Tfs.Util
                     //regex pulled from git svn script here: https://github.com/git/git/blob/master/git-svn.perl
                     Regex ex = new Regex(@"^(.+?|\(no author\))\s*=\s*(.+?)\s*<(.+)>\s*$");
                     Match match = ex.Match(line);
-                    if (match.Groups.Count != 4 || String.IsNullOrWhiteSpace(match.Groups[1].Value) || String.IsNullOrWhiteSpace(match.Groups[2].Value) ||
-                        String.IsNullOrWhiteSpace(match.Groups[3].Value))
+                    if (match.Groups.Count != 4 || string.IsNullOrWhiteSpace(match.Groups[1].Value) || string.IsNullOrWhiteSpace(match.Groups[2].Value) ||
+                        string.IsNullOrWhiteSpace(match.Groups[3].Value))
                     {
                         throw new GitTfsException("Invalid format of Authors file on line " + lineCount + ".");
                     }
@@ -149,7 +149,7 @@ namespace Sep.Git.Tfs.Util
         public bool Parse(string authorsFilePath, string gitDir)
         {
             var savedAuthorFile = Path.Combine(gitDir, GitTfsCachedAuthorsFileName);
-            if (!String.IsNullOrWhiteSpace(authorsFilePath))
+            if (!string.IsNullOrWhiteSpace(authorsFilePath))
             {
                 if (!File.Exists(authorsFilePath))
                 {

--- a/GitTfs/Util/AuthorsFile.cs
+++ b/GitTfs/Util/AuthorsFile.cs
@@ -57,8 +57,8 @@ namespace Sep.Git.Tfs.Util
         }
 
         #region (private)
-        private Tuple<string, string> _gitAuthor;
-        private string _gitUserId;
+        private readonly Tuple<string, string> _gitAuthor;
+        private readonly string _gitUserId;
         #endregion
     }
 

--- a/GitTfs/Util/Bouncer.cs
+++ b/GitTfs/Util/Bouncer.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 

--- a/GitTfs/Util/Bouncer.cs
+++ b/GitTfs/Util/Bouncer.cs
@@ -10,8 +10,8 @@ namespace Sep.Git.Tfs.Util
     /// </summary>
     public class Bouncer
     {
-        private List<Regex> includes = new List<Regex>();
-        private List<Regex> excludes = new List<Regex>();
+        private readonly List<Regex> includes = new List<Regex>();
+        private readonly List<Regex> excludes = new List<Regex>();
 
         /// <summary>
         /// Add a regular expression for inclusion in the set.

--- a/GitTfs/Util/ChangeSieve.cs
+++ b/GitTfs/Util/ChangeSieve.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using Sep.Git.Tfs.Core;

--- a/GitTfs/Util/CheckinOptionsExtensions.cs
+++ b/GitTfs/Util/CheckinOptionsExtensions.cs
@@ -24,7 +24,7 @@ namespace Sep.Git.Tfs.Util
             try
             {
                 string re = globals.Repository.GetConfig(GitTfsConstants.WorkItemAssociateRegexConfigKey);
-                if (String.IsNullOrEmpty(re))
+                if (string.IsNullOrEmpty(re))
                     clone.WorkItemAssociateRegex = GitTfsConstants.TfsWorkItemAssociateRegex;
                 else
                     clone.WorkItemAssociateRegex = new Regex(re);

--- a/GitTfs/Util/CheckinOptionsExtensions.cs
+++ b/GitTfs/Util/CheckinOptionsExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.IO;
 using System.Text.RegularExpressions;
 using Sep.Git.Tfs.Commands;
 using Sep.Git.Tfs.Core;

--- a/GitTfs/Util/CheckinOptionsFactory.cs
+++ b/GitTfs/Util/CheckinOptionsFactory.cs
@@ -14,16 +14,16 @@ namespace Sep.Git.Tfs.Util
     /// </remarks>
     public class CheckinOptionsFactory
     {
-        private readonly Globals globals;
+        private readonly Globals _globals;
 
         public CheckinOptionsFactory(Globals globals)
         {
-            this.globals = globals;
+            _globals = globals;
         }
 
         public CheckinOptions BuildCommitSpecificCheckinOptions(CheckinOptions sourceCheckinOptions, string commitMessage)
         {
-            var customCheckinOptions = sourceCheckinOptions.Clone(globals);
+            var customCheckinOptions = sourceCheckinOptions.Clone(_globals);
 
             customCheckinOptions.CheckinComment = commitMessage;
 
@@ -49,7 +49,7 @@ namespace Sep.Git.Tfs.Util
         public CheckinOptions BuildShelveSetSpecificCheckinOptions(CheckinOptions sourceCheckinOptions,
             string commitMessage)
         {
-            var customCheckinOptions = sourceCheckinOptions.Clone(globals);
+            var customCheckinOptions = sourceCheckinOptions.Clone(_globals);
 
             customCheckinOptions.CheckinComment = commitMessage;
 

--- a/GitTfs/Util/CheckinOptionsFactory.cs
+++ b/GitTfs/Util/CheckinOptionsFactory.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using Sep.Git.Tfs.Commands;
 using Sep.Git.Tfs.Core;
 

--- a/GitTfs/Util/ConfigPropertyLoader.cs
+++ b/GitTfs/Util/ConfigPropertyLoader.cs
@@ -6,8 +6,8 @@ namespace Sep.Git.Tfs.Util
     [StructureMapSingleton]
     public class ConfigPropertyLoader
     {
-        private Globals _globals;
-        private Dictionary<string, object> _overrides = new Dictionary<string, object>();
+        private readonly Globals _globals;
+        private readonly Dictionary<string, object> _overrides = new Dictionary<string, object>();
 
         public ConfigPropertyLoader(Globals globals)
         {

--- a/GitTfs/Util/ConfigPropertyLoader.cs
+++ b/GitTfs/Util/ConfigPropertyLoader.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 
 namespace Sep.Git.Tfs.Util

--- a/GitTfs/Util/ExportMetadatasInitializer.cs
+++ b/GitTfs/Util/ExportMetadatasInitializer.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using Sep.Git.Tfs.Core;
 
 namespace Sep.Git.Tfs.Util

--- a/GitTfs/Util/GitTfsCommandFactory.cs
+++ b/GitTfs/Util/GitTfsCommandFactory.cs
@@ -7,11 +7,11 @@ namespace Sep.Git.Tfs.Util
     [StructureMapSingleton]
     public class GitTfsCommandFactory
     {
-        private readonly IContainer container;
+        private readonly IContainer _container;
 
         public GitTfsCommandFactory(IContainer container)
         {
-            this.container = container;
+            _container = container;
         }
 
         private Dictionary<string, string> _aliasMap;
@@ -23,7 +23,7 @@ namespace Sep.Git.Tfs.Util
         private Dictionary<string, string> CreateAliasMap()
         {
             var aliasMap = new Dictionary<string, string>();
-            var commandPluginType = container.Model.PluginTypes.First(p => p.PluginType == typeof(GitTfsCommand));
+            var commandPluginType = _container.Model.PluginTypes.First(p => p.PluginType == typeof(GitTfsCommand));
 
             foreach (var instance in commandPluginType.Instances)
             {
@@ -44,7 +44,7 @@ namespace Sep.Git.Tfs.Util
 
         public GitTfsCommand GetCommand(string name)
         {
-            return container.TryGetInstance<GitTfsCommand>(GetCommandName(name));
+            return _container.TryGetInstance<GitTfsCommand>(GetCommandName(name));
         }
 
         private string GetCommandName(string name)

--- a/GitTfs/Util/InspectExtensions.cs
+++ b/GitTfs/Util/InspectExtensions.cs
@@ -27,20 +27,20 @@ namespace SEP.Extensions
         {
             if (o == null) return Inspect((object)o);
             var entries = o.Keys.Cast<object>().Select(key => InspectSimple(key) + " => " + InspectSimple(o[key]));
-            return "{" + String.Join(", ", entries.ToArray()) + "}";
+            return "{" + string.Join(", ", entries.ToArray()) + "}";
         }
 
         public static string Inspect(this IEnumerable o)
         {
             if (o == null) return Inspect((object)o);
-            return "[" + String.Join(", ", o.Cast<object>().Select(obj => InspectSimple(obj)).ToArray()) + "]";
+            return "[" + string.Join(", ", o.Cast<object>().Select(obj => InspectSimple(obj)).ToArray()) + "]";
         }
 
         private static string InspectWithProperties(object o)
         {
             var inspected = "#<";
             inspected += InspectType(o.GetType());
-            inspected += String.Join(",",
+            inspected += string.Join(",",
                                      o.GetType().GetProperties().Select(p => " " + p.Name + "=" + InspectSimple(p.GetValue(o, null)))
                                          .ToArray());
             inspected += ">";
@@ -111,7 +111,7 @@ namespace SEP.Extensions
         {
             var name = Undecorate(type.FullName);
             name += "<";
-            name += String.Join(",", type.GetGenericArguments().Select(t => InspectType(t)).ToArray());
+            name += string.Join(",", type.GetGenericArguments().Select(t => InspectType(t)).ToArray());
             name += ">";
             return name;
         }

--- a/GitTfs/Util/PathResolver.cs
+++ b/GitTfs/Util/PathResolver.cs
@@ -35,7 +35,7 @@ namespace Sep.Git.Tfs.Util
 
         public bool ShouldIncludeGitItem(string gitPath)
         {
-            return !String.IsNullOrEmpty(gitPath) && !_remote.ShouldSkip(gitPath);
+            return !string.IsNullOrEmpty(gitPath) && !_remote.ShouldSkip(gitPath);
         }
 
         public bool Contains(string pathInGitRepo)

--- a/GitTfs/Util/StructureMapSingletonAttribute.cs
+++ b/GitTfs/Util/StructureMapSingletonAttribute.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using StructureMap;
-using StructureMap.Attributes;
 
 namespace Sep.Git.Tfs.Util
 {

--- a/GitTfsTest/Commands/CloneTest.cs
+++ b/GitTfsTest/Commands/CloneTest.cs
@@ -1,11 +1,5 @@
-﻿using System.IO;
-using Rhino.Mocks;
-using Rhino.Mocks.Constraints;
-using Sep.Git.Tfs.Commands;
-using Sep.Git.Tfs.Core;
-using StructureMap.AutoMocking;
+﻿using Sep.Git.Tfs.Commands;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Sep.Git.Tfs.Test.Commands
 {

--- a/GitTfsTest/Commands/HelpTest.cs
+++ b/GitTfsTest/Commands/HelpTest.cs
@@ -1,14 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using Sep.Git.Tfs.Commands;
-using Sep.Git.Tfs.Test.TestHelpers;
 using StructureMap.AutoMocking;
 using NDesk.Options;
 using Xunit;
 using NLog;
-using System.ComponentModel;
-using System.Threading.Tasks;
 using System.Diagnostics;
 using NLog.Config;
 using NLog.Targets;

--- a/GitTfsTest/Commands/HelpTest.cs
+++ b/GitTfsTest/Commands/HelpTest.cs
@@ -12,7 +12,7 @@ namespace Sep.Git.Tfs.Test.Commands
 {
     public class HelpTest : BaseTest
     {
-        private RhinoAutoMocker<Help> mocks;
+        private readonly RhinoAutoMocker<Help> mocks;
 
         public HelpTest()
         {
@@ -65,7 +65,7 @@ namespace Sep.Git.Tfs.Test.Commands
         {
             public bool Flag { get; set; }
 
-            private OptionSet TestOptions = new OptionSet();
+            private readonly OptionSet TestOptions = new OptionSet();
 
             public OptionSet OptionSet
             {

--- a/GitTfsTest/Commands/InitBranchTest.cs
+++ b/GitTfsTest/Commands/InitBranchTest.cs
@@ -31,7 +31,7 @@ namespace Sep.Git.Tfs.Test.Commands
             remote.TfsPassword = "pwd";
             remote.TfsRepositoryPath = "$/MyProject/Trunk";
             remote.TfsUrl = "http://myTfsServer:8080/tfs";
-            remote.Tfs = new VsFake.TfsHelper(mocks.Container, null);
+            remote.Tfs = new TfsHelper(mocks.Container, null);
             gitRepository.Stub(r => r.GitDir).Return(".");
             gitRepository.Stub(r => r.HasRemote(Arg<string>.Is.Anything)).Return(true);
 
@@ -97,7 +97,7 @@ namespace Sep.Git.Tfs.Test.Commands
             existingBranchRemote.TfsPassword = "pwd";
             existingBranchRemote.TfsRepositoryPath = "$/MyProject/MyBranch";
             existingBranchRemote.TfsUrl = "http://myTfsServer:8080/tfs";
-            existingBranchRemote.Tfs = new VsFake.TfsHelper(mocks.Container, null);
+            existingBranchRemote.Tfs = new TfsHelper(mocks.Container, null);
 
             gitRepository.Expect(x => x.ReadTfsRemote("default")).Return(remote).Repeat.Once();
             gitRepository.Expect(x => x.ReadAllTfsRemotes()).Return(new List<IGitTfsRemote> { remote, existingBranchRemote }).Repeat.Once();
@@ -391,7 +391,7 @@ namespace Sep.Git.Tfs.Test.Commands
             remote.TfsPassword = "pwd";
             remote.TfsRepositoryPath = "$/MyProject/Trunk";
             remote.TfsUrl = "http://myTfsServer:8080/tfs";
-            remote.Tfs = new VsFake.TfsHelper(mocks.Container, null);
+            remote.Tfs = new TfsHelper(mocks.Container, null);
             gitRepository.Expect(x => x.ReadTfsRemote("default")).Return(remote).Repeat.Never();
 
             //Not Very Clean!!! Don't know how to test that :(

--- a/GitTfsTest/Commands/InitBranchTest.cs
+++ b/GitTfsTest/Commands/InitBranchTest.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using Rhino.Mocks;
 using Sep.Git.Tfs.Commands;
 using Sep.Git.Tfs.Core;
@@ -8,7 +7,6 @@ using Sep.Git.Tfs.Core.TfsInterop;
 using Sep.Git.Tfs.VsFake;
 using StructureMap.AutoMocking;
 using Xunit;
-using Sep.Git.Tfs.Util;
 
 namespace Sep.Git.Tfs.Test.Commands
 {

--- a/GitTfsTest/Commands/InitBranchTest.cs
+++ b/GitTfsTest/Commands/InitBranchTest.cs
@@ -13,7 +13,7 @@ namespace Sep.Git.Tfs.Test.Commands
     public class InitBranchTest : BaseTest
     {
         #region Test Init
-        private RhinoAutoMocker<InitBranch> mocks;
+        private readonly RhinoAutoMocker<InitBranch> mocks;
 
         public InitBranchTest()
         {

--- a/GitTfsTest/Commands/InitOptionsTest.cs
+++ b/GitTfsTest/Commands/InitOptionsTest.cs
@@ -1,5 +1,4 @@
-﻿using System.IO;
-using Sep.Git.Tfs.Commands;
+﻿using Sep.Git.Tfs.Commands;
 using StructureMap.AutoMocking;
 using NDesk.Options;
 using Xunit;

--- a/GitTfsTest/Commands/InitOptionsTest.cs
+++ b/GitTfsTest/Commands/InitOptionsTest.cs
@@ -7,7 +7,7 @@ namespace Sep.Git.Tfs.Test.Commands
 {
     public class InitOptionsTest : BaseTest
     {
-        private RhinoAutoMocker<InitOptions> mocks;
+        private readonly RhinoAutoMocker<InitOptions> mocks;
 
         public InitOptionsTest()
         {

--- a/GitTfsTest/Commands/ShelveTest.cs
+++ b/GitTfsTest/Commands/ShelveTest.cs
@@ -1,5 +1,4 @@
-﻿using System.IO;
-using Rhino.Mocks;
+﻿using Rhino.Mocks;
 using Rhino.Mocks.Constraints;
 using Sep.Git.Tfs.Commands;
 using Sep.Git.Tfs.Core;

--- a/GitTfsTest/Commands/ShelveTest.cs
+++ b/GitTfsTest/Commands/ShelveTest.cs
@@ -9,7 +9,7 @@ namespace Sep.Git.Tfs.Test.Commands
 {
     public class ShelveTest : BaseTest
     {
-        private RhinoAutoMocker<Shelve> mocks;
+        private readonly RhinoAutoMocker<Shelve> mocks;
 
         public ShelveTest()
         {

--- a/GitTfsTest/Core/BranchVisitors/BranchContainsPathVisitorTest.cs
+++ b/GitTfsTest/Core/BranchVisitors/BranchContainsPathVisitorTest.cs
@@ -7,7 +7,7 @@ namespace Sep.Git.Tfs.Test.Core.BranchVisitors
 {
     public class BranchContainsPathVisitorTest : BaseTest
     {
-        private BranchTree branch;
+        private readonly BranchTree branch;
 
         public BranchContainsPathVisitorTest()
         {

--- a/GitTfsTest/Core/ChangeSieveTests.cs
+++ b/GitTfsTest/Core/ChangeSieveTests.cs
@@ -154,12 +154,12 @@ namespace Sep.Git.Tfs.Test.Core
 
             private const int ChangesetId = 10;
 
-            private TfsChangeType _tfsChangeType;
-            private TfsItemType _tfsItemType;
-            private string _serverItem;
-            private int _deletionId;
-            private string _renamedFrom;
-            private int _itemId;
+            private readonly TfsChangeType _tfsChangeType;
+            private readonly TfsItemType _tfsItemType;
+            private readonly string _serverItem;
+            private readonly int _deletionId;
+            private readonly string _renamedFrom;
+            private readonly int _itemId;
             private static int _maxItemId = 0;
 
             private FakeChange(TfsChangeType tfsChangeType, TfsItemType itemType, string serverItem, int deletionId = 0, string renamedFrom = null)
@@ -231,7 +231,7 @@ namespace Sep.Git.Tfs.Test.Core
 
             private class PreviousItem : IItem
             {
-                private string _oldName;
+                private readonly string _oldName;
 
                 public PreviousItem(string oldName)
                 {

--- a/GitTfsTest/Core/ChangeSieveTests.cs
+++ b/GitTfsTest/Core/ChangeSieveTests.cs
@@ -189,7 +189,7 @@ namespace Sep.Git.Tfs.Test.Core
 
             int IItem.ChangesetId
             {
-                get { return FakeChange.ChangesetId; }
+                get { return ChangesetId; }
             }
 
             string IItem.ServerItem

--- a/GitTfsTest/Core/CommitParserTests.cs
+++ b/GitTfsTest/Core/CommitParserTests.cs
@@ -1,10 +1,6 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using Sep.Git.Tfs.Core;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Sep.Git.Tfs.Test.Core
 {

--- a/GitTfsTest/Core/ConfigPropertyLoaderTests.cs
+++ b/GitTfsTest/Core/ConfigPropertyLoaderTests.cs
@@ -1,12 +1,8 @@
 ﻿using System;
-using System.IO;
-using System.Linq;
 using Sep.Git.Tfs.Core;
-using Sep.Git.Tfs.Core.TfsInterop;
 using Sep.Git.Tfs.Util;
 using StructureMap;
 using Xunit;
-using LibGit2Sharp;
 
 namespace Sep.Git.Tfs.Test.Integration
 {

--- a/GitTfsTest/Core/ConfigPropertyLoaderTests.cs
+++ b/GitTfsTest/Core/ConfigPropertyLoaderTests.cs
@@ -8,7 +8,7 @@ namespace Sep.Git.Tfs.Test.Integration
 {
     public class ConfigPropertyLoaderTests : BaseTest, IDisposable
     {
-        private IntegrationHelper h = new IntegrationHelper();
+        private readonly IntegrationHelper h = new IntegrationHelper();
 
         public ConfigPropertyLoaderTests()
         {

--- a/GitTfsTest/Core/DirectoryTidierTests.cs
+++ b/GitTfsTest/Core/DirectoryTidierTests.cs
@@ -9,9 +9,9 @@ namespace Sep.Git.Tfs.Test.Core
 {
     public class DirectoryTidierTests : BaseTest, IDisposable
     {
-        private MockRepository mocks;
-        private ITfsWorkspaceModifier mockWorkspace;
-        private TfsTreeEntry[] initialTfsTree;
+        private readonly MockRepository mocks;
+        private readonly ITfsWorkspaceModifier mockWorkspace;
+        private readonly TfsTreeEntry[] initialTfsTree;
         private DirectoryTidier _tidy;
 
         public DirectoryTidierTests()

--- a/GitTfsTest/Core/DirectoryTidierTests.cs
+++ b/GitTfsTest/Core/DirectoryTidierTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 using Rhino.Mocks;

--- a/GitTfsTest/Core/GitChangeInfoTests.cs
+++ b/GitTfsTest/Core/GitChangeInfoTests.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using Sep.Git.Tfs.Core;
 using Sep.Git.Tfs.Core.Changes.Git;
 using StructureMap;
-using LibGit2Sharp;
 using Xunit;
 
 namespace Sep.Git.Tfs.Test.Core

--- a/GitTfsTest/Core/GitTfsConstantsTest.cs
+++ b/GitTfsTest/Core/GitTfsConstantsTest.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Xunit;
+﻿using Xunit;
 
 namespace Sep.Git.Tfs.Test.Core
 {

--- a/GitTfsTest/Core/GitTfsRemoteTests.cs
+++ b/GitTfsTest/Core/GitTfsRemoteTests.cs
@@ -56,8 +56,8 @@ namespace Sep.Git.Tfs.Test.Core
                 Aliases = legacyUrls,
             };
             var mocks = new RhinoAutoMocker<GitTfsRemote>();
-            mocks.Inject<RemoteInfo>(info);
-            mocks.Inject<ITfsHelper>(MockRepository.GenerateStub<ITfsHelper>()); // GitTfsRemote backs the TfsUrl with this.
+            mocks.Inject(info);
+            mocks.Inject(MockRepository.GenerateStub<ITfsHelper>()); // GitTfsRemote backs the TfsUrl with this.
             return mocks.ClassUnderTest;
         }
 
@@ -109,13 +109,13 @@ namespace Sep.Git.Tfs.Test.Core
                 Repository = null,
             };
             var mocks = new RhinoAutoMocker<GitTfsRemote>();
-            mocks.Inject<RemoteInfo>(info);
-            mocks.Inject<ITfsHelper>(MockRepository.GenerateStub<ITfsHelper>()); // GitTfsRemote backs the TfsUrl with this.
+            mocks.Inject(info);
+            mocks.Inject(MockRepository.GenerateStub<ITfsHelper>()); // GitTfsRemote backs the TfsUrl with this.
 
             var mockGitRepository = mocks.Get<IGitRepository>();
             mockGitRepository.Stub(t => t.GetSubtrees(Arg<IGitTfsRemote>.Is.Anything)).Return(remotes);
 
-            mocks.Inject<Globals>(new Globals() { Repository = mockGitRepository });
+            mocks.Inject(new Globals() { Repository = mockGitRepository });
             return mocks.ClassUnderTest;
         }
     }

--- a/GitTfsTest/Core/GitTfsRemoteTests.cs
+++ b/GitTfsTest/Core/GitTfsRemoteTests.cs
@@ -1,9 +1,7 @@
 ﻿using System.Collections.Generic;
-using System.IO;
 using Rhino.Mocks;
 using Sep.Git.Tfs.Core;
 using Sep.Git.Tfs.Core.TfsInterop;
-using Sep.Git.Tfs.Util;
 using StructureMap.AutoMocking;
 using Xunit;
 

--- a/GitTfsTest/Core/GlobalsTests.cs
+++ b/GitTfsTest/Core/GlobalsTests.cs
@@ -1,10 +1,8 @@
 ﻿using System.Collections.Generic;
-using System.IO;
 using Rhino.Mocks;
 using Sep.Git.Tfs.Commands;
 using Sep.Git.Tfs.Core;
 using Sep.Git.Tfs.Core.TfsInterop;
-using Sep.Git.Tfs.Util;
 using StructureMap.AutoMocking;
 using Xunit;
 

--- a/GitTfsTest/Core/ModeTests.cs
+++ b/GitTfsTest/Core/ModeTests.cs
@@ -8,7 +8,7 @@ namespace Sep.Git.Tfs.Test.Core
         [Fact]
         public void ShouldGetNewFileMode()
         {
-            Assert.Equal("100644", Sep.Git.Tfs.Core.Mode.NewFile);
+            Assert.Equal("100644", Mode.NewFile);
         }
 
         [Fact]

--- a/GitTfsTest/Core/RemoteConfigConverterTests.cs
+++ b/GitTfsTest/Core/RemoteConfigConverterTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 using Sep.Git.Tfs.Core;

--- a/GitTfsTest/Core/RemoteConfigConverterTests.cs
+++ b/GitTfsTest/Core/RemoteConfigConverterTests.cs
@@ -11,7 +11,7 @@ namespace Sep.Git.Tfs.Test.Core
     {
         public class DumpTests : BaseTest
         {
-            private RemoteConfigConverter _dumper = new RemoteConfigConverter();
+            private readonly RemoteConfigConverter _dumper = new RemoteConfigConverter();
 
             [Fact]
             public void DumpsNothingWithNoId()
@@ -133,7 +133,7 @@ namespace Sep.Git.Tfs.Test.Core
 
         public class LoadTests : BaseTest
         {
-            private RemoteConfigConverter _loader = new RemoteConfigConverter();
+            private readonly RemoteConfigConverter _loader = new RemoteConfigConverter();
 
             private IEnumerable<RemoteInfo> Load(params ConfigurationEntry<string>[] configs)
             {
@@ -207,7 +207,7 @@ namespace Sep.Git.Tfs.Test.Core
             }
         }
 
-        private RemoteConfigConverter _converter = new RemoteConfigConverter();
+        private readonly RemoteConfigConverter _converter = new RemoteConfigConverter();
 
         [Fact]
         public void MultipleRemotes()
@@ -248,8 +248,8 @@ namespace Sep.Git.Tfs.Test.Core
 
         private class TestConfigurationEntry : ConfigurationEntry<string>
         {
-            private string _key;
-            private string _value;
+            private readonly string _key;
+            private readonly string _value;
 
             public override string Key { get { return _key; } }
             public override string Value { get { return _value; } }

--- a/GitTfsTest/Core/StubbedCheckinEvaluationResult.cs
+++ b/GitTfsTest/Core/StubbedCheckinEvaluationResult.cs
@@ -51,13 +51,13 @@ namespace Sep.Git.Tfs.Test.Core
 
         public StubbedCheckinEvaluationResult WithException(Exception ex)
         {
-            this.PolicyEvaluationException = ex;
+            PolicyEvaluationException = ex;
             return this;
         }
 
         public StubbedCheckinEvaluationResult WithException(string message)
         {
-            return this.WithException(new Exception(message ?? string.Empty));
+            return WithException(new Exception(message ?? string.Empty));
         }
     }
 

--- a/GitTfsTest/Core/StubbedCheckinEvaluationResult.cs
+++ b/GitTfsTest/Core/StubbedCheckinEvaluationResult.cs
@@ -7,9 +7,9 @@ namespace Sep.Git.Tfs.Test.Core
 {
     public class StubbedCheckinEvaluationResult : ICheckinEvaluationResult
     {
-        private HashSet<ICheckinConflict> conflicts;
-        private HashSet<ICheckinNoteFailure> noteFailures;
-        private HashSet<IPolicyFailure> policyFailures;
+        private readonly HashSet<ICheckinConflict> conflicts;
+        private readonly HashSet<ICheckinNoteFailure> noteFailures;
+        private readonly HashSet<IPolicyFailure> policyFailures;
 
         public StubbedCheckinEvaluationResult()
         {

--- a/GitTfsTest/Core/TfsApiBridgeTest.cs
+++ b/GitTfsTest/Core/TfsApiBridgeTest.cs
@@ -8,7 +8,7 @@ namespace GitTfsTest.Core
 {
     public class TfsApiBridgeTest : BaseTest
     {
-        private RhinoAutoMocker<TfsApiBridge> _mocks;
+        private readonly RhinoAutoMocker<TfsApiBridge> _mocks;
 
         public TfsApiBridgeTest()
         {

--- a/GitTfsTest/Core/TfsInterop/BranchExtensionsTest.cs
+++ b/GitTfsTest/Core/TfsInterop/BranchExtensionsTest.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Rhino.Mocks;
 using Sep.Git.Tfs.Core.TfsInterop;

--- a/GitTfsTest/FactExceptOnUnix.cs
+++ b/GitTfsTest/FactExceptOnUnix.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Collections.Generic;
 using Xunit;
-using Xunit.Sdk;
 
 namespace Sep.Git.Tfs.Test
 {

--- a/GitTfsTest/Fixtures/vtccds.cs
+++ b/GitTfsTest/Fixtures/vtccds.cs
@@ -3,7 +3,6 @@
 using System;
 using System.IO;
 using System.IO.Compression;
-using System.Text;
 using Sep.Git.Tfs.Core.TfsInterop;
 using Sep.Git.Tfs.Test.Integration;
 

--- a/GitTfsTest/GitTfsTest.csproj
+++ b/GitTfsTest/GitTfsTest.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\LibGit2Sharp.NativeBinaries\build\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\packages\LibGit2Sharp.NativeBinaries\build\LibGit2Sharp.NativeBinaries.props')" Label="Paket" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
@@ -195,30 +194,21 @@
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v2.0' Or $(TargetFrameworkVersion) == 'v3.0' Or $(TargetFrameworkVersion) == 'v3.5' Or $(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5')">
       <PropertyGroup>
         <__paket__xunit_runner_visualstudio_props>net20\xunit.runner.visualstudio</__paket__xunit_runner_visualstudio_props>
       </PropertyGroup>
     </When>
-    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v1.2' Or $(TargetFrameworkVersion) == 'v1.3' Or $(TargetFrameworkVersion) == 'v1.4' Or $(TargetFrameworkVersion) == 'v1.5' Or $(TargetFrameworkVersion) == 'v1.6')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And $(TargetFrameworkVersion) == 'v1.0') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile31') Or ($(TargetFrameworkProfile) == 'Profile32') Or ($(TargetFrameworkProfile) == 'Profile44') Or ($(TargetFrameworkProfile) == 'Profile49') Or ($(TargetFrameworkProfile) == 'Profile78') Or ($(TargetFrameworkProfile) == 'Profile84') Or ($(TargetFrameworkProfile) == 'Profile111') Or ($(TargetFrameworkProfile) == 'Profile151') Or ($(TargetFrameworkProfile) == 'Profile157') Or ($(TargetFrameworkProfile) == 'Profile259')">
+  </Choose>
+  <Import Project="..\packages\xunit.runner.visualstudio\build\$(__paket__xunit_runner_visualstudio_props).props" Condition="Exists('..\packages\xunit.runner.visualstudio\build\$(__paket__xunit_runner_visualstudio_props).props')" Label="Paket" />
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5')">
       <PropertyGroup>
-        <__paket__xunit_runner_visualstudio_props>portable-net45+win8+wp8+wpa81\xunit.runner.visualstudio</__paket__xunit_runner_visualstudio_props>
-      </PropertyGroup>
-    </When>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETCore' And $(TargetFrameworkVersion) == 'v4.5.1'">
-      <PropertyGroup>
-        <__paket__xunit_runner_visualstudio_props>win81\xunit.runner.visualstudio</__paket__xunit_runner_visualstudio_props>
-        <__paket__xunit_runner_visualstudio_targets>win81\xunit.runner.visualstudio</__paket__xunit_runner_visualstudio_targets>
-      </PropertyGroup>
-    </When>
-    <When Condition="$(TargetFrameworkIdentifier) == 'WindowsPhoneApp'">
-      <PropertyGroup>
-        <__paket__xunit_runner_visualstudio_props>wpa81\xunit.runner.visualstudio</__paket__xunit_runner_visualstudio_props>
-        <__paket__xunit_runner_visualstudio_targets>wpa81\xunit.runner.visualstudio</__paket__xunit_runner_visualstudio_targets>
+        <__paket__LibGit2Sharp_NativeBinaries_props>LibGit2Sharp.NativeBinaries</__paket__LibGit2Sharp_NativeBinaries_props>
       </PropertyGroup>
     </When>
   </Choose>
-  <Import Project="..\packages\xunit.runner.visualstudio\build\$(__paket__xunit_runner_visualstudio_props).props" Condition="Exists('..\packages\xunit.runner.visualstudio\build\$(__paket__xunit_runner_visualstudio_props).props')" Label="Paket" />
+  <Import Project="..\packages\LibGit2Sharp.NativeBinaries\build\$(__paket__LibGit2Sharp_NativeBinaries_props).props" Condition="Exists('..\packages\LibGit2Sharp.NativeBinaries\build\$(__paket__LibGit2Sharp_NativeBinaries_props).props')" Label="Paket" />
   <PropertyGroup>
     <PreBuildEvent Condition="'$(OS)' == 'Windows_NT'">xcopy /S /Y "$(SolutionDir)\lib\libgit2sharp\Lib\NativeBinaries" "$(TargetDir)"\NativeBinaries\</PreBuildEvent>
     <PreBuildEvent Condition="'$(OS)' != 'Windows_NT'">cp -Rp "$(SolutionDir)/lib/libgit2sharp/Lib/NativeBinaries" "$(TargetDir)"</PreBuildEvent>
@@ -235,7 +225,7 @@
   -->
   <Import Project="..\.paket\paket.targets" />
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5')">
       <ItemGroup>
         <Reference Include="LibGit2Sharp">
           <HintPath>..\packages\LibGit2Sharp\lib\net40\LibGit2Sharp.dll</HintPath>
@@ -246,24 +236,6 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == 'MonoAndroid'">
-      <ItemGroup>
-        <Reference Include="NLog">
-          <HintPath>..\packages\NLog\lib\MonoAndroid10\NLog.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v3.5'">
-      <ItemGroup>
-        <Reference Include="NLog">
-          <HintPath>..\packages\NLog\lib\net35\NLog.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.0'">
       <ItemGroup>
         <Reference Include="NLog">
@@ -273,7 +245,7 @@
         </Reference>
       </ItemGroup>
     </When>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.5'">
       <ItemGroup>
         <Reference Include="NLog">
           <HintPath>..\packages\NLog\lib\net45\NLog.dll</HintPath>
@@ -282,45 +254,9 @@
         </Reference>
       </ItemGroup>
     </When>
-    <When Condition="$(TargetFrameworkIdentifier) == 'Silverlight' And $(TargetFrameworkVersion) == 'v4.0'">
-      <ItemGroup>
-        <Reference Include="NLog">
-          <HintPath>..\packages\NLog\lib\sl4\NLog.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-    <When Condition="$(TargetFrameworkIdentifier) == 'Silverlight' And $(TargetFrameworkVersion) == 'v5.0'">
-      <ItemGroup>
-        <Reference Include="NLog">
-          <HintPath>..\packages\NLog\lib\sl5\NLog.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-    <When Condition="$(TargetFrameworkIdentifier) == 'WindowsPhone' And ($(TargetFrameworkVersion) == 'v8.0' Or $(TargetFrameworkVersion) == 'v8.1')">
-      <ItemGroup>
-        <Reference Include="NLog">
-          <HintPath>..\packages\NLog\lib\wp8\NLog.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-    <When Condition="$(TargetFrameworkIdentifier) == 'Xamarin.iOS'">
-      <ItemGroup>
-        <Reference Include="NLog">
-          <HintPath>..\packages\NLog\lib\Xamarin.iOS10\NLog.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.5'">
       <ItemGroup>
         <Reference Include="xunit.abstractions">
           <HintPath>..\packages\xunit.abstractions\lib\net35\xunit.abstractions.dll</HintPath>
@@ -331,7 +267,7 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.5'">
       <ItemGroup>
         <Reference Include="xunit.assert">
           <HintPath>..\packages\xunit.assert\lib\portable-net45+win8+wp8+wpa81\xunit.assert.dll</HintPath>
@@ -342,7 +278,7 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.5'">
       <ItemGroup>
         <Reference Include="xunit.core">
           <HintPath>..\packages\xunit.extensibility.core\lib\portable-net45+win8+wp8+wpa81\xunit.core.dll</HintPath>
@@ -353,7 +289,7 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.5'">
       <ItemGroup>
         <Reference Include="xunit.execution.desktop">
           <HintPath>..\packages\xunit.extensibility.execution\lib\net45\xunit.execution.desktop.dll</HintPath>
@@ -363,5 +299,4 @@
       </ItemGroup>
     </When>
   </Choose>
-  <Import Project="..\packages\xunit.runner.visualstudio\build\$(__paket__xunit_runner_visualstudio_targets).targets" Condition="Exists('..\packages\xunit.runner.visualstudio\build\$(__paket__xunit_runner_visualstudio_targets).targets')" Label="Paket" />
 </Project>

--- a/GitTfsTest/GitTfsTest.csproj
+++ b/GitTfsTest/GitTfsTest.csproj
@@ -49,6 +49,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <OutputPath>bin\Release\</OutputPath>

--- a/GitTfsTest/Integration/BootstrapTests.cs
+++ b/GitTfsTest/Integration/BootstrapTests.cs
@@ -7,7 +7,7 @@ namespace Sep.Git.Tfs.Test.Integration
 {
     public class BootstrapTests : BaseTest, IDisposable
     {
-        private IntegrationHelper h = new IntegrationHelper();
+        private readonly IntegrationHelper h = new IntegrationHelper();
 
         public BootstrapTests()
         {

--- a/GitTfsTest/Integration/CloneTests.cs
+++ b/GitTfsTest/Integration/CloneTests.cs
@@ -255,11 +255,11 @@ namespace Sep.Git.Tfs.Test.Integration
         private void AssertNewClone(string repodir, string[] refs, string commit = null, string tree = null)
         {
             const string format = "{0}: {1} / {2}";
-            var expected = String.Join("\n", refs.Select(gitref => String.Format(format, gitref, commit, tree)));
-            var actual = String.Join("\n", refs.Select(gitref =>
+            var expected = string.Join("\n", refs.Select(gitref => string.Format(format, gitref, commit, tree)));
+            var actual = string.Join("\n", refs.Select(gitref =>
             {
                 var actualCommit = h.RevParseCommit(repodir, gitref);
-                return String.Format(format, gitref,
+                return string.Format(format, gitref,
                     commit == null || actualCommit == null ? null : actualCommit.Sha,
                     tree == null || actualCommit == null ? null : actualCommit.Tree.Sha);
             }));

--- a/GitTfsTest/Integration/CloneTests.cs
+++ b/GitTfsTest/Integration/CloneTests.cs
@@ -11,7 +11,7 @@ namespace Sep.Git.Tfs.Test.Integration
     //      This will cause the hashes to differ on computers in different time zones.
     public class CloneTests : BaseTest, IDisposable
     {
-        private IntegrationHelper h;
+        private readonly IntegrationHelper h;
 
         public CloneTests()
         {

--- a/GitTfsTest/Integration/GitRepositoryTests.cs
+++ b/GitTfsTest/Integration/GitRepositoryTests.cs
@@ -9,7 +9,7 @@ namespace Sep.Git.Tfs.Test.Integration
 {
     public class GitRepositoryTests : BaseTest, IDisposable
     {
-        private IntegrationHelper h = new IntegrationHelper();
+        private readonly IntegrationHelper h = new IntegrationHelper();
 
         public GitRepositoryTests()
         {

--- a/GitTfsTest/Integration/GitRepositoryTests.cs
+++ b/GitTfsTest/Integration/GitRepositoryTests.cs
@@ -1,11 +1,9 @@
 ﻿using System;
-using System.IO;
 using System.Linq;
 using Sep.Git.Tfs.Core;
 using Sep.Git.Tfs.Core.TfsInterop;
 using StructureMap;
 using Xunit;
-using LibGit2Sharp;
 
 namespace Sep.Git.Tfs.Test.Integration
 {

--- a/GitTfsTest/Integration/InitTests.cs
+++ b/GitTfsTest/Integration/InitTests.cs
@@ -5,7 +5,7 @@ namespace Sep.Git.Tfs.Test.Integration
 {
     public class InitTests : BaseTest, IDisposable
     {
-        private IntegrationHelper h;
+        private readonly IntegrationHelper h;
 
         public InitTests()
         {

--- a/GitTfsTest/Integration/IntegrationHelper.cs
+++ b/GitTfsTest/Integration/IntegrationHelper.cs
@@ -297,7 +297,7 @@ namespace Sep.Git.Tfs.Test.Integration
 
         public void ChangeConfigSetting(string repodir, string key, string value)
         {
-            var repo = new LibGit2Sharp.Repository(Path.Combine(Workdir, repodir));
+            var repo = new Repository(Path.Combine(Workdir, repodir));
             repo.Config.Set(key, value);
         }
 

--- a/GitTfsTest/Integration/IntegrationHelper.cs
+++ b/GitTfsTest/Integration/IntegrationHelper.cs
@@ -52,7 +52,7 @@ namespace Sep.Git.Tfs.Test.Integration
             }
         }
 
-        private Dictionary<string, Repository> _repositories = new Dictionary<string, Repository>();
+        private readonly Dictionary<string, Repository> _repositories = new Dictionary<string, Repository>();
         public Repository Repository(string path)
         {
             path = Path.Combine(Workdir, path);
@@ -86,7 +86,7 @@ namespace Sep.Git.Tfs.Test.Integration
 
         public class RepoBuilder
         {
-            private Repository _repo;
+            private readonly Repository _repo;
 
             public RepoBuilder(Repository repo)
             {
@@ -145,7 +145,7 @@ namespace Sep.Git.Tfs.Test.Integration
 
         public class FakeHistoryBuilder
         {
-            private Script _script;
+            private readonly Script _script;
             public FakeHistoryBuilder(Script script)
             {
                 _script = script;
@@ -217,7 +217,7 @@ namespace Sep.Git.Tfs.Test.Integration
 
         public class FakeChangesetBuilder
         {
-            private ScriptedChangeset _changeset;
+            private readonly ScriptedChangeset _changeset;
 
             public FakeChangesetBuilder(ScriptedChangeset changeset)
             {

--- a/GitTfsTest/Properties/AssemblyInfo.cs
+++ b/GitTfsTest/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Xunit;
 

--- a/GitTfsTest/TestHelpers/ExtensionMethods.cs
+++ b/GitTfsTest/TestHelpers/ExtensionMethods.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Xunit;
 using Xunit.Sdk;
 
 namespace Sep.Git.Tfs.Test.TestHelpers

--- a/GitTfsTest/Util/AuthorsFileUnitTest.cs
+++ b/GitTfsTest/Util/AuthorsFileUnitTest.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Text;
-using System.Collections.Generic;
-using System.Linq;
 using System.IO;
 using Sep.Git.Tfs.Util;
 using Sep.Git.Tfs.Core;

--- a/GitTfsTest/Util/BouncerTest.cs
+++ b/GitTfsTest/Util/BouncerTest.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Xunit;
+﻿using Xunit;
 using Sep.Git.Tfs.Util;
 
 namespace Sep.Git.Tfs.Test.Util

--- a/GitTfsTest/Util/BouncerTest.cs
+++ b/GitTfsTest/Util/BouncerTest.cs
@@ -5,7 +5,7 @@ namespace Sep.Git.Tfs.Test.Util
 {
     public class BouncerTest : BaseTest
     {
-        private Bouncer bouncer = new Bouncer();
+        private readonly Bouncer bouncer = new Bouncer();
 
         [Fact]
         public void NoExpressionsMeansNotMatched()

--- a/GitTfsTest/Util/CamelCaseToDelimitedStringConverterTests.cs
+++ b/GitTfsTest/Util/CamelCaseToDelimitedStringConverterTests.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace Sep.Git.Tfs.Test.Util
 {
-    using Sep.Git.Tfs.Util;
+    using Tfs.Util;
     using Xunit;
 
     public class CamelCaseToDelimitedStringConverterTests

--- a/GitTfsTest/Util/CamelCaseToDelimitedStringConverterTests.cs
+++ b/GitTfsTest/Util/CamelCaseToDelimitedStringConverterTests.cs
@@ -3,7 +3,6 @@ namespace Sep.Git.Tfs.Test.Util
 {
     using Sep.Git.Tfs.Util;
     using Xunit;
-    using Xunit.Extensions;
 
     public class CamelCaseToDelimitedStringConverterTests
     {

--- a/GitTfsTest/Util/CommitSpecificCheckinOptionsFactoryTests.cs
+++ b/GitTfsTest/Util/CommitSpecificCheckinOptionsFactoryTests.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.IO;
-using System.Linq;
 using Sep.Git.Tfs.Commands;
 using Sep.Git.Tfs.Util;
 using Xunit;

--- a/GitTfsTest/Util/CommitSpecificCheckinOptionsFactoryTests.cs
+++ b/GitTfsTest/Util/CommitSpecificCheckinOptionsFactoryTests.cs
@@ -10,7 +10,7 @@ namespace Sep.Git.Tfs.Test.Util
 {
     public class CommitSpecificCheckinOptionsFactoryTests : BaseTest
     {
-        private RhinoAutoMocker<CheckinOptionsFactory> mocks;
+        private readonly RhinoAutoMocker<CheckinOptionsFactory> mocks;
 
         public CommitSpecificCheckinOptionsFactoryTests()
         {

--- a/GitTfsTest/Util/GitTfsCommandRunnerTests.cs
+++ b/GitTfsTest/Util/GitTfsCommandRunnerTests.cs
@@ -35,7 +35,7 @@ namespace Sep.Git.Tfs.Test.Util
         }
         #endregion
 
-        private RhinoAutoMocker<GitTfsCommandRunner> _mocks;
+        private readonly RhinoAutoMocker<GitTfsCommandRunner> _mocks;
 
         public GitTfsCommandRunnerTests()
         {

--- a/GitTfsTest/Util/GitTfsCommandRunnerTests.cs
+++ b/GitTfsTest/Util/GitTfsCommandRunnerTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using Rhino.Mocks;
 using Sep.Git.Tfs.Commands;
 using Sep.Git.Tfs.Util;

--- a/GitTfsTest/Util/ShelveSpecificCheckinOptionsFactoryTests.cs
+++ b/GitTfsTest/Util/ShelveSpecificCheckinOptionsFactoryTests.cs
@@ -8,7 +8,7 @@ namespace Sep.Git.Tfs.Test.Util
 {
     public class ShelveSpecificCheckinOptionsFactoryTests
     {
-        private RhinoAutoMocker<CheckinOptionsFactory> mocks;
+        private readonly RhinoAutoMocker<CheckinOptionsFactory> mocks;
 
         public ShelveSpecificCheckinOptionsFactoryTests()
         {

--- a/GitTfsTest/Util/ShelveSpecificCheckinOptionsFactoryTests.cs
+++ b/GitTfsTest/Util/ShelveSpecificCheckinOptionsFactoryTests.cs
@@ -1,5 +1,4 @@
-﻿using System.IO;
-using Sep.Git.Tfs.Commands;
+﻿using Sep.Git.Tfs.Commands;
 using Sep.Git.Tfs.Core;
 using Sep.Git.Tfs.Util;
 using StructureMap.AutoMocking;

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,3 +1,4 @@
+framework: auto-detect
 source https://www.nuget.org/api/v2/
 
 //If you plan to update this file, you must first absolutly read our documentation on the subject
@@ -6,15 +7,15 @@ source https://www.nuget.org/api/v2/
 
 nuget nlog
 nuget NuGet.CommandLine
-nuget LibGit2Sharp 0.22
-nuget Microsoft.TeamFoundationServer.Client 14.102.0 framework: >= net45
-nuget Microsoft.TeamFoundationServer.ExtendedClient 14.102.0 framework: >= net45
+nuget LibGit2Sharp
+nuget Microsoft.TeamFoundationServer.Client
+nuget Microsoft.TeamFoundationServer.ExtendedClient
 nuget WixSharp 1.0.22.3 framework: >= net40
-nuget xunit 2.1.0 framework: >= net45
-nuget xunit.assert 2.1.0 framework: >= net45
-nuget xunit.runner.msbuild 2.1.0 framework: >= net45
+nuget xunit
+nuget xunit.assert
+nuget xunit.runner.msbuild
 nuget MSBuildTasks 1.4.0.45 framework: >= net40
-nuget xunit.runner.visualstudio 2.1.0
+nuget xunit.runner.visualstudio
 
 //console runner to be able to run it in the console
 nuget xunit.runner.console

--- a/paket.lock
+++ b/paket.lock
@@ -1,44 +1,19 @@
+FRAMEWORK: NET40, NET45
 NUGET
   remote: https://www.nuget.org/api/v2
     LibGit2Sharp (0.22)
       LibGit2Sharp.NativeBinaries (1.0.129)
     LibGit2Sharp.NativeBinaries (1.0.129)
-    Microsoft.AspNet.WebApi.Client (5.2.3) - framework: >= net45
-      Newtonsoft.Json (>= 6.0.4) - framework: >= net45, portable-wp80+win+wp81+wpa81
-    Microsoft.AspNet.WebApi.Core (5.2.3) - framework: >= net45
+    Microsoft.AspNet.WebApi.Client (5.2.3)
+      Newtonsoft.Json (>= 6.0.4) - framework: net45
+    Microsoft.AspNet.WebApi.Core (5.2.3)
       Microsoft.AspNet.WebApi.Client (>= 5.2.3)
-    Microsoft.IdentityModel.Clients.ActiveDirectory (3.13.5) - framework: >= net45
-      System.Collections (>= 4.0.11) - framework: >= net461, >= netstandard14
-      System.Collections.Concurrent (>= 4.0.12) - framework: >= net461, >= netstandard14
-      System.Diagnostics.Debug (>= 4.0.11) - framework: >= net461, >= netstandard14
-      System.Globalization (>= 4.0.11) - framework: >= net461, >= netstandard14
-      System.IO (>= 4.1) - framework: >= net461, >= netstandard14
-      System.Linq (>= 4.1) - framework: >= net461, >= netstandard14
-      System.Net.Http (>= 4.0.1) - framework: >= net461, >= netstandard14
-      System.Net.Primitives (>= 4.0.11) - framework: >= net461, >= netstandard14
-      System.Reflection (>= 4.1) - framework: >= net461, >= netstandard14
-      System.Reflection.Extensions (>= 4.0.1) - framework: >= net461, >= netstandard14
-      System.Runtime (>= 4.1) - framework: >= net461, >= netstandard14
-      System.Runtime.Extensions (>= 4.1) - framework: >= net461, >= netstandard14
-      System.Runtime.InteropServices (>= 4.1) - framework: >= net461, >= netstandard14
-      System.Runtime.Serialization.Json (>= 4.0.2) - framework: >= net461, >= netstandard14
-      System.Runtime.Serialization.Primitives (>= 4.1.1) - framework: >= net461, >= netstandard14
-      System.Text.Encoding (>= 4.0.11) - framework: >= net461, >= netstandard14
-      System.Text.Encoding.Extensions (>= 4.0.11) - framework: >= net461, >= netstandard14
-      System.Text.RegularExpressions (>= 4.0.12) - framework: >= net461, >= netstandard14
-      System.Threading (>= 4.0.11) - framework: >= net461, >= netstandard14
-      System.Threading.Tasks (>= 4.0.11) - framework: >= net461, >= netstandard14
-      System.Xml.ReaderWriter (>= 4.0.11) - framework: >= net461, >= netstandard14
-      System.Xml.XDocument (>= 4.0.11) - framework: >= net461, >= netstandard14
-    Microsoft.IdentityModel.Logging (1.0) - framework: >= net451
-    Microsoft.IdentityModel.Tokens (5.0) - framework: >= net451
-      Microsoft.IdentityModel.Logging (>= 1.0) - framework: >= net451, >= netstandard14
-      Newtonsoft.Json (>= 9.0.1) - framework: >= net451, >= netstandard14
-    Microsoft.TeamFoundationServer.Client (14.102) - framework: >= net45
-      Microsoft.AspNet.WebApi.Client (>= 5.2.2) - framework: >= net45
-      Microsoft.VisualStudio.Services.Client (14.102) - framework: >= net45
-      Newtonsoft.Json (>= 6.0.8) - framework: >= net45
-    Microsoft.TeamFoundationServer.ExtendedClient (14.102) - framework: >= net45
+    Microsoft.IdentityModel.Clients.ActiveDirectory (3.13.5)
+    Microsoft.TeamFoundationServer.Client (14.102)
+      Microsoft.AspNet.WebApi.Client (>= 5.2.2) - framework: net45
+      Microsoft.VisualStudio.Services.Client (14.102) - framework: net45
+      Newtonsoft.Json (>= 6.0.8) - framework: net45
+    Microsoft.TeamFoundationServer.ExtendedClient (14.102)
       Microsoft.AspNet.WebApi.Client (>= 5.2.2)
       Microsoft.AspNet.WebApi.Core (>= 5.2.2)
       Microsoft.IdentityModel.Clients.ActiveDirectory (>= 2.16.204221202)
@@ -47,74 +22,35 @@ NUGET
       Microsoft.VisualStudio.Services.InteractiveClient (14.102)
       Newtonsoft.Json (>= 6.0.8)
       System.IdentityModel.Tokens.Jwt (>= 4.0)
-    Microsoft.VisualStudio.Services.Client (14.102) - framework: >= net45
-      Microsoft.AspNet.WebApi.Client (>= 5.2.2) - framework: >= net45
-      Newtonsoft.Json (>= 6.0.8) - framework: >= net45
-    Microsoft.VisualStudio.Services.InteractiveClient (14.102) - framework: >= net45
-      Microsoft.AspNet.WebApi.Client (>= 5.2.2) - framework: >= net45
-      Microsoft.IdentityModel.Clients.ActiveDirectory (>= 2.16.204221202) - framework: >= net45
-      Microsoft.VisualStudio.Services.Client (14.102) - framework: >= net45
-      Newtonsoft.Json (>= 6.0.8) - framework: >= net45
-      System.IdentityModel.Tokens.Jwt (>= 4.0) - framework: >= net45
-      WindowsAzure.ServiceBus (>= 2.5.1) - framework: >= net45
-    Microsoft.Win32.Primitives (4.0.1) - framework: >= net461
+    Microsoft.VisualStudio.Services.Client (14.102)
+      Microsoft.AspNet.WebApi.Client (>= 5.2.2) - framework: net45
+      Newtonsoft.Json (>= 6.0.8) - framework: net45
+    Microsoft.VisualStudio.Services.InteractiveClient (14.102)
+      Microsoft.AspNet.WebApi.Client (>= 5.2.2) - framework: net45
+      Microsoft.IdentityModel.Clients.ActiveDirectory (>= 2.16.204221202) - framework: net45
+      Microsoft.VisualStudio.Services.Client (14.102) - framework: net45
+      Newtonsoft.Json (>= 6.0.8) - framework: net45
+      System.IdentityModel.Tokens.Jwt (>= 4.0) - framework: net45
+      WindowsAzure.ServiceBus (>= 2.5.1) - framework: net45
     MSBuildTasks (1.4.0.45) - framework: >= net40
-    Newtonsoft.Json (9.0.1) - framework: >= net45
-    NLog (4.3.9)
-    NuGet.CommandLine (3.3)
-    System.Collections (4.0.11) - framework: >= net461
-    System.Collections.Concurrent (4.0.12) - framework: >= net461
-    System.Diagnostics.Debug (4.0.11) - framework: >= net461
-    System.Diagnostics.DiagnosticSource (4.0) - framework: >= net461
-    System.Globalization (4.0.11) - framework: >= net461
-    System.IdentityModel.Tokens.Jwt (5.0) - framework: >= net45
-      Microsoft.IdentityModel.Tokens (>= 5.0) - framework: >= net451, >= netstandard14
-    System.IO (4.1) - framework: >= net461
-    System.Linq (4.1) - framework: >= net461
-    System.Net.Http (4.1) - framework: >= net461
-      Microsoft.Win32.Primitives (>= 4.0.1) - framework: >= net46, netstandard13
-      System.Diagnostics.DiagnosticSource (>= 4.0) - framework: >= net46, dnxcore50, netstandard13, >= netstandard16
-      System.Security.Cryptography.X509Certificates (>= 4.1) - framework: >= net46, dnxcore50, netstandard13, >= netstandard16
-    System.Net.Primitives (4.0.11) - framework: >= net461
-    System.Reflection (4.1) - framework: >= net461
-    System.Reflection.Extensions (4.0.1) - framework: >= net461
-    System.Runtime (4.1) - framework: >= net461
-    System.Runtime.Extensions (4.1) - framework: >= net461
-    System.Runtime.InteropServices (4.1) - framework: >= net461
-      System.Runtime (>= 4.1) - framework: >= net462, dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15
-    System.Runtime.Serialization.Json (4.0.2) - framework: >= net461
-    System.Runtime.Serialization.Primitives (4.1.1) - framework: >= net461
-    System.Security.Cryptography.Algorithms (4.2) - framework: >= net461
-      System.IO (>= 4.1) - framework: >= net463, dnxcore50, netstandard13, netstandard14, >= netstandard16
-      System.Runtime (>= 4.1) - framework: >= net463, dnxcore50, netstandard13, netstandard14, >= netstandard16
-      System.Security.Cryptography.Encoding (>= 4.0) - framework: >= net463, dnxcore50, >= netstandard16
-      System.Security.Cryptography.Primitives (>= 4.0) - framework: net46, net461, >= net463, dnxcore50, netstandard13, netstandard14, >= netstandard16
-    System.Security.Cryptography.Encoding (4.0) - framework: >= net461
-    System.Security.Cryptography.Primitives (4.0) - framework: net461, >= net463
-    System.Security.Cryptography.X509Certificates (4.1) - framework: >= net461
-      System.Security.Cryptography.Algorithms (>= 4.2) - framework: net46, >= net461, dnxcore50, netstandard13, netstandard14, >= netstandard16
-      System.Security.Cryptography.Encoding (>= 4.0) - framework: net46, >= net461, dnxcore50, netstandard13, netstandard14, >= netstandard16
-    System.Text.Encoding (4.0.11) - framework: >= net461
-    System.Text.Encoding.Extensions (4.0.11) - framework: >= net461
-    System.Text.RegularExpressions (4.1) - framework: >= net461
-    System.Threading (4.0.11) - framework: >= net461
-    System.Threading.Tasks (4.0.11) - framework: >= net461
-    System.Xml.ReaderWriter (4.0.11) - framework: >= net461
-    System.Xml.XDocument (4.0.11) - framework: >= net461
-    WindowsAzure.ServiceBus (3.4) - framework: >= net45
+    Newtonsoft.Json (9.0.1)
+    NLog (4.3.10)
+    NuGet.CommandLine (3.4.3)
+    System.IdentityModel.Tokens.Jwt (5.0)
+    WindowsAzure.ServiceBus (3.4) - framework: net45
     WixSharp (1.0.22.3) - framework: >= net40
-    xunit (2.1) - framework: >= net45
+    xunit (2.1)
       xunit.assert (2.1)
       xunit.core (2.1)
-    xunit.abstractions (2.0) - framework: >= net45
-    xunit.assert (2.1) - framework: >= net45
-    xunit.core (2.1) - framework: >= net45
-      xunit.extensibility.core (2.1) - framework: >= net45, dnx451, dnxcore50, monoandroid, monotouch, portable-net45+win80+wp80+wpa81, xamarinios, winv4.5, wpv8.0, wpav8.1
-      xunit.extensibility.execution (2.1) - framework: >= net45, dnx451, dnxcore50, monoandroid, monotouch, portable-net45+win80+wp80+wpa81, xamarinios, winv4.5, wpv8.0, wpav8.1
-    xunit.extensibility.core (2.1) - framework: >= net45
+    xunit.abstractions (2.0) - framework: net45
+    xunit.assert (2.1)
+    xunit.core (2.1)
+      xunit.extensibility.core (2.1) - framework: net45
+      xunit.extensibility.execution (2.1) - framework: net45
+    xunit.extensibility.core (2.1) - framework: net45
       xunit.abstractions (2.0)
-    xunit.extensibility.execution (2.1) - framework: >= net45
-      xunit.extensibility.core (2.1) - framework: >= net45, dnx451, dnxcore50, monoandroid, monotouch, xamarinios, winv4.5, wpv8.0, wpav8.1
+    xunit.extensibility.execution (2.1) - framework: net45
+      xunit.extensibility.core (2.1) - framework: net45
     xunit.runner.console (2.1)
-    xunit.runner.msbuild (2.1) - framework: >= net45
+    xunit.runner.msbuild (2.1)
     xunit.runner.visualstudio (2.1)


### PR DESCRIPTION
- Some cleaning
- Some renaming
- Use C#5 to prevent changes not being able to be built without VS2015 (Should we discard other VS version now that VS2015 community is free)
- paket: auto detect framework used in projects + remove fixed versions