### PR TITLE
Improve branch point changeset detection

### DIFF
--- a/GitTfs.VsFake/TfsHelper.VsFake.cs
+++ b/GitTfs.VsFake/TfsHelper.VsFake.cs
@@ -389,20 +389,25 @@ namespace Sep.Git.Tfs.VsFake
 
         public IList<RootBranch> GetRootChangesetForBranch(string tfsPathBranchToCreate, int lastChangesetIdToCheck = -1, string tfsPathParentBranch = null)
         {
-            var firstChangesetOfBranch = _script.Changesets.FirstOrDefault(c => c.IsBranchChangeset && c.BranchChangesetDatas.BranchPath == tfsPathBranchToCreate);
+            var branchChangesets = _script.Changesets.Where(c => c.IsBranchChangeset);
+            var firstBranchChangeset = branchChangesets.FirstOrDefault(c => c.BranchChangesetDatas.BranchPath == tfsPathBranchToCreate);
+
             var rootBranches = new List<RootBranch>();
-            var branchChangeset = _script.Changesets.Where(c => c.IsBranchChangeset).ToList();
-            if (firstChangesetOfBranch != null)
+            if (firstBranchChangeset != null)
             {
                 do
                 {
-                    var branch = new RootBranch(firstChangesetOfBranch.BranchChangesetDatas.RootChangesetId,
-                        firstChangesetOfBranch.BranchChangesetDatas.BranchPath);
-                    branch.IsRenamedBranch = DeletedBranchesPathes.Contains(branch.TfsBranchPath);
-                    rootBranches.Add(branch);
-                    firstChangesetOfBranch = branchChangeset.FirstOrDefault(
-                            c => c.BranchChangesetDatas.BranchPath == firstChangesetOfBranch.BranchChangesetDatas.ParentBranch);
-                } while (firstChangesetOfBranch != null);
+                    var rootBranch = new RootBranch(
+                        firstBranchChangeset.BranchChangesetDatas.RootChangesetId,
+                        firstBranchChangeset.Id,
+                        firstBranchChangeset.BranchChangesetDatas.BranchPath
+                    );
+
+                    rootBranch.IsRenamedBranch = DeletedBranchesPathes.Contains(rootBranch.TfsBranchPath);
+                    rootBranches.Add(rootBranch);
+
+                    firstBranchChangeset = branchChangesets.FirstOrDefault(c => c.BranchChangesetDatas.BranchPath == firstBranchChangeset.BranchChangesetDatas.ParentBranch);
+                } while (firstBranchChangeset != null);
                 rootBranches.Reverse();
                 return rootBranches;
             }

--- a/GitTfs/Core/DerivedGitTfsRemote.cs
+++ b/GitTfs/Core/DerivedGitTfsRemote.cs
@@ -190,6 +190,16 @@ namespace Sep.Git.Tfs.Core
         public bool ExportMetadatas { get; set; }
         public Dictionary<string, string> ExportWorkitemsMapping { get; set; }
 
+        public int? GetInitialChangeset()
+        {
+            throw DerivedRemoteException;
+        }
+
+        public void SetInitialChangeset(int? changesetId)
+        {
+            throw DerivedRemoteException;
+        }
+
         public bool ShouldSkip(string path)
         {
             throw DerivedRemoteException;

--- a/GitTfs/Core/IGitTfsRemote.cs
+++ b/GitTfs/Core/IGitTfsRemote.cs
@@ -47,6 +47,8 @@ namespace Sep.Git.Tfs.Core
         string Prefix { get; }
         bool ExportMetadatas { get; set; }
         Dictionary<string, string> ExportWorkitemsMapping { get; set; }
+        int? GetInitialChangeset();
+        void SetInitialChangeset(int? changesetId);
         bool ShouldSkip(string path);
         IGitTfsRemote InitBranch(RemoteOptions remoteOptions, string tfsRepositoryPath, int rootChangesetId = -1, bool fetchParentBranch = false, string gitBranchNameExpected = null, IRenameResult renameResult = null);
         string GetPathInGitRepo(string tfsPath);

--- a/GitTfs/Core/TfsInterop/RootBranch.cs
+++ b/GitTfs/Core/TfsInterop/RootBranch.cs
@@ -5,19 +5,35 @@ namespace Sep.Git.Tfs.Core.TfsInterop
     [DebuggerDisplay("{DebuggerDisplay}")]
     public class RootBranch
     {
-        public RootBranch(int rootChangeset, string tfsBranchPath)
+        public RootBranch(int sourceBranchChangesetId, string tfsBranchPath)
+            : this(sourceBranchChangesetId, -1, tfsBranchPath)
         {
-            RootChangeset = rootChangeset;
+
+        }
+
+        public RootBranch(int sourceBranchChangesetId, int targetBranchChangesetId, string tfsBranchPath)
+        {
+            SourceBranchChangesetId = sourceBranchChangesetId;
+            TargetBranchChangesetId = targetBranchChangesetId;
             TfsBranchPath = tfsBranchPath;
         }
 
-        public int RootChangeset { get; private set; }
+        public int SourceBranchChangesetId { get; private set; }
+        public int TargetBranchChangesetId { get; private set; }
         public string TfsBranchPath { get; private set; }
         public bool IsRenamedBranch { get; set; }
 
         private string DebuggerDisplay
         {
-            get { return string.Format("{0} C{1}{2}", TfsBranchPath, RootChangeset, (IsRenamedBranch ? " renamed" : "")); }
+            get
+            {
+                return string.Format("{0} C{1}{2}{3}",
+                    /* {0} */ TfsBranchPath,
+                    /* {1} */ SourceBranchChangesetId,
+                    /* {2} */ TargetBranchChangesetId > -1 ? string.Format(" (target C{0})", TargetBranchChangesetId) : string.Empty,
+                    /* {3} */ IsRenamedBranch ? " renamed" : ""
+                );
+            }
         }
     }
 }

--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -1,7 +1,5 @@
 * Custom TFS check-in notes are not exported to commit message (#1004, @EdwinEngelen)
 * Log in a file git-tfs actions (#999, @pmiossec)
 * Add support of `.gitignore` to ignore files in `clone` and `init` commands (#897)
-* Improve branch point changeset detection (as reported on #955)
-    * This was originally authored by @jeremy-sylvis-tmg on PR #973; requested changes were unable to be made due to time constraints
-    * @fourpastmidnight made the requested changes to PR #973 and resubmitted as PR #1017
+* Improve branch point changeset detection (#1017 & #973, @fourpastmidnight & @jeremy-sylvis-tmg)
 

--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -1,3 +1,7 @@
 * Custom TFS check-in notes are not exported to commit message (#1004, @EdwinEngelen)
 * Log in a file git-tfs actions (#999, @pmiossec)
 * Add support of `.gitignore` to ignore files in `clone` and `init` commands (#897)
+* Improve branch point changeset detection (as reported on #955)
+    * This was originally authored by @jeremy-sylvis-tmg on PR #973; requested changes were unable to be made due to time constraints
+    * @fourpastmidnight made the requested changes to PR #973 and resubmitted as PR #1017
+


### PR DESCRIPTION
This PR contains a single commit which re-implements the changes made in PR #973. The original author of #973 declined to make the requested changes due to time constraints.

Since the contribution of those changes could have a significant, positive impact on enabling Git-TFS to better clone TFS repositories into Git repositories, I have made the requested changes to PR #973 and am submitting this PR in its place. 