### PR TITLE
Ignore case only changes in export from git to tfs.

### DIFF
--- a/GitTfs/Core/Changes/Git/Add.cs
+++ b/GitTfs/Core/Changes/Git/Add.cs
@@ -14,11 +14,9 @@ namespace Sep.Git.Tfs.Core.Changes.Git
             NewSha = changeInfo.newSha;
         }
 
-        public void Apply(ITfsWorkspaceModifier workspace)
+        void IGitChangedFile.Apply(ITfsWorkspaceCopy workspace)
         {
-            var workspaceFile = workspace.GetLocalPath(Path);
-            Repository.CopyBlob(NewSha, workspaceFile);
-            workspace.Add(Path);
+            workspace.Add(Path, NewSha);
         }
     }
 

--- a/GitTfs/Core/Changes/Git/Delete.cs
+++ b/GitTfs/Core/Changes/Git/Delete.cs
@@ -10,7 +10,7 @@ namespace Sep.Git.Tfs.Core.Changes.Git
             Path = changeInfo.path;
         }
 
-        public void Apply(ITfsWorkspaceModifier workspace)
+        void IGitChangedFile.Apply(ITfsWorkspaceCopy workspace)
         {
             workspace.Delete(Path);
         }

--- a/GitTfs/Core/Changes/Git/Modify.cs
+++ b/GitTfs/Core/Changes/Git/Modify.cs
@@ -13,11 +13,9 @@
             Path = changeInfo.path;
         }
 
-        public void Apply(ITfsWorkspaceModifier workspace)
+        void IGitChangedFile.Apply(ITfsWorkspaceCopy workspace)
         {
-            workspace.Edit(Path);
-            var workspaceFile = workspace.GetLocalPath(Path);
-            _repository.CopyBlob(NewSha, workspaceFile);
+            workspace.Edit(Path, NewSha);
         }
     }
 }

--- a/GitTfs/Core/Changes/Git/RenameEdit.cs
+++ b/GitTfs/Core/Changes/Git/RenameEdit.cs
@@ -18,12 +18,10 @@ namespace Sep.Git.Tfs.Core.Changes.Git
             Score = changeInfo.score;
         }
 
-        public void Apply(ITfsWorkspaceModifier workspace)
+        void IGitChangedFile.Apply(ITfsWorkspaceCopy workspace)
         {
-            workspace.Edit(Path);
-            workspace.Rename(Path, PathTo, Score);
-            var workspaceFile = workspace.GetLocalPath(PathTo);
-            _repository.CopyBlob(NewSha, workspaceFile);
+            workspace.Edit(Path, NewSha);
+            workspace.Rename(Path, PathTo);
         }
     }
 }

--- a/GitTfs/Core/DirectoryTidier.cs
+++ b/GitTfs/Core/DirectoryTidier.cs
@@ -50,26 +50,26 @@ namespace Sep.Git.Tfs.Core
                         _workspace.Add(fileOperation.Key);
                         break;
                     case FileOperation.Edit:
+                    case FileOperation.EditAndRenameFrom:
                            _workspace.Edit(fileOperation.Key);
                         break;
                     case FileOperation.Remove:
                          _workspace.Delete(fileOperation.Key);
                         break;
                     case FileOperation.RenameTo:
-                         _workspace.Rename(fileOperation.Key, _renameOperations[fileOperation.Key]);
+                         _workspace.Rename(_renameOperations[fileOperation.Key], fileOperation.Key);
                         break;
 
-                    case FileOperation.EditAndRenameFrom:
-                        case FileOperation.RenameFrom:
+                    case FileOperation.RenameFrom:
                         break;
                 }
             }
 
             foreach(var editOperation in _editOperations)
             {
-                var file = GetLocalPath(editOperation.Key);
                 if (_reprository != null)
                 {
+                    var file = GetLocalPath(editOperation.Key);
                     _reprository.CopyBlob(editOperation.Value, file);
                 }
             }

--- a/GitTfs/Core/DirectoryTidier.cs
+++ b/GitTfs/Core/DirectoryTidier.cs
@@ -5,7 +5,7 @@ using Sep.Git.Tfs.Core.TfsInterop;
 
 namespace Sep.Git.Tfs.Core
 {
-    public class DirectoryTidier : ITfsWorkspaceModifier, IDisposable
+    public class DirectoryTidier : ITfsWorkspaceCopy, IDisposable
     {
         private enum FileOperation
         {
@@ -18,16 +18,22 @@ namespace Sep.Git.Tfs.Core
         }
 
         private readonly ITfsWorkspaceModifier _workspace;
+        private readonly IGitRepository _reprository;
         private readonly Func<IEnumerable<TfsTreeEntry>> _getInitialTfsTree;
         private List<string> _filesInTfs;
         private readonly Dictionary<string, FileOperation> _fileOperations;
+        private readonly Dictionary<string, string> _renameOperations;
+        private readonly Dictionary<string, string> _editOperations;
         private bool _disposed;
 
-        public DirectoryTidier(ITfsWorkspaceModifier workspace, Func<IEnumerable<TfsTreeEntry>> getInitialTfsTree)
+        public DirectoryTidier(ITfsWorkspaceModifier workspace, IGitRepository repository, Func<IEnumerable<TfsTreeEntry>> getInitialTfsTree)
         {
             _workspace = workspace;
+            _reprository = repository;
             _getInitialTfsTree = getInitialTfsTree;
             _fileOperations = new Dictionary<string, FileOperation>(StringComparer.InvariantCultureIgnoreCase);
+            _renameOperations = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
+            _editOperations = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
         }
 
         public void Dispose()
@@ -35,6 +41,38 @@ namespace Sep.Git.Tfs.Core
             if (_disposed)
                 return;
             _disposed = true;
+
+            foreach(var fileOperation in _fileOperations)
+            {
+                switch (fileOperation.Value)
+                {
+                    case FileOperation.Add:
+                        _workspace.Add(fileOperation.Key);
+                        break;
+                    case FileOperation.Edit:
+                           _workspace.Edit(fileOperation.Key);
+                        break;
+                    case FileOperation.Remove:
+                         _workspace.Delete(fileOperation.Key);
+                        break;
+                    case FileOperation.RenameTo:
+                         _workspace.Rename(fileOperation.Key, _renameOperations[fileOperation.Key]);
+                        break;
+
+                    case FileOperation.EditAndRenameFrom:
+                        case FileOperation.RenameFrom:
+                        break;
+                }
+            }
+
+            foreach(var editOperation in _editOperations)
+            {
+                var file = GetLocalPath(editOperation.Key);
+                if (_reprository != null)
+                {
+                    _reprository.CopyBlob(editOperation.Value, file);
+                }
+            }
 
             var candidateDirectories = CalculateCandidateDirectories();
             if (!candidateDirectories.Any())
@@ -90,44 +128,88 @@ namespace Sep.Git.Tfs.Core
             return _filesInTfs.Any(file => file.StartsWith(dirName));
         }
 
-        string ITfsWorkspaceModifier.GetLocalPath(string path)
+        string GetLocalPath(string path)
         {
             return _workspace.GetLocalPath(path);
         }
 
-        void ITfsWorkspaceModifier.Add(string path)
+        void ITfsWorkspaceCopy.Add(string path, string shaFile)
         {
-            _workspace.Add(path);
-            _fileOperations.Add(path, FileOperation.Add);
-        }
-
-        void ITfsWorkspaceModifier.Edit(string path)
-        {
-            _workspace.Edit(path);
-            _fileOperations.Add(path, FileOperation.Edit);
-        }
-
-        void ITfsWorkspaceModifier.Delete(string path)
-        {
-            _workspace.Delete(path);
-            _fileOperations.Add(path, FileOperation.Remove);
-        }
-
-        void ITfsWorkspaceModifier.Rename(string pathFrom, string pathTo, string score)
-        {
-            _workspace.Rename(pathFrom, pathTo, score);
-
-            FileOperation pathFromOperation;
-            if (_fileOperations.TryGetValue(pathFrom, out pathFromOperation) &&
-                pathFromOperation == FileOperation.Edit)
+            if (!_fileOperations.ContainsKey(path))
             {
-                _fileOperations[pathFrom] = FileOperation.EditAndRenameFrom;
+                _fileOperations.Add(path, FileOperation.Add);
             }
             else
             {
-                _fileOperations.Add(pathFrom, FileOperation.RenameFrom);
+                //git rename is split into add/delete with only case difference
+                if (_fileOperations[path] == FileOperation.Remove)
+                {
+                    _fileOperations[path] = FileOperation.Edit;
+                }
+                else
+                {
+                    throw new ApplicationException("Unable to add item " + path + " it was already modified.");
+                }
             }
-            _fileOperations.Add(pathTo, FileOperation.RenameTo);
+            _editOperations.Add(path, shaFile);
+        }
+
+        void ITfsWorkspaceCopy.Edit(string path, string shaFile)
+        {
+            FileOperation pathFromOperation;
+            if (_fileOperations.TryGetValue(path, out pathFromOperation) &&
+                pathFromOperation == FileOperation.RenameFrom)
+            {
+                _fileOperations[path] = FileOperation.EditAndRenameFrom;
+            }
+            else
+            {
+                _fileOperations.Add(path, FileOperation.Edit);
+            }
+            _editOperations.Add(path, shaFile);
+        }
+
+        void ITfsWorkspaceCopy.Delete(string path)
+        {
+            if (!_fileOperations.ContainsKey(path))
+            {
+                _fileOperations.Add(path, FileOperation.Remove);
+            }
+            else
+            {
+                //git rename is split into add/delete with only case difference
+                if (_fileOperations[path] == FileOperation.Remove)
+                {
+                    _fileOperations[path] = FileOperation.Edit;
+                }
+                else
+                {
+                    throw new ApplicationException("Unable to delete item " + path + " it was already modified.");
+                }
+            }
+        }
+
+        void ITfsWorkspaceCopy.Rename(string pathFrom, string pathTo)
+        {
+            if (pathFrom.ToLower().CompareTo(pathTo.ToLower()) != 0)
+            {
+                FileOperation pathFromOperation;
+                if (_fileOperations.TryGetValue(pathFrom, out pathFromOperation) &&
+                    pathFromOperation == FileOperation.Edit)
+                {
+                    _fileOperations[pathFrom] = FileOperation.EditAndRenameFrom;
+                }
+                else
+                {
+                    _fileOperations.Add(pathFrom, FileOperation.RenameFrom);
+                }
+                _fileOperations.Add(pathTo, FileOperation.RenameTo);
+                _renameOperations.Add(pathTo, pathFrom);
+            }
+            else
+            {
+                //git rename with only case changes is impossible to transfer to tfs
+            }
         }
 
         private IEnumerable<string> CalculateCandidateDirectories()

--- a/GitTfs/Core/GitTfsRemote.cs
+++ b/GitTfs/Core/GitTfsRemote.cs
@@ -904,7 +904,7 @@ namespace Sep.Git.Tfs.Core
 
         private void PendChangesToWorkspace(string head, string parent, ITfsWorkspaceModifier workspace)
         {
-            using (var tidyWorkspace = new DirectoryTidier(workspace, () => GetLatestChangeset().GetFullTree()))
+            using (var tidyWorkspace = new DirectoryTidier(workspace, Repository, () => GetLatestChangeset().GetFullTree()))
             {
                 foreach (var change in Repository.GetChangedFiles(parent, head))
                 {

--- a/GitTfs/Core/IGitChangedFile.cs
+++ b/GitTfs/Core/IGitChangedFile.cs
@@ -3,6 +3,6 @@ namespace Sep.Git.Tfs.Core
 {
     public interface IGitChangedFile
     {
-        void Apply(ITfsWorkspaceModifier workspace);
+        void Apply(ITfsWorkspaceCopy workspace);
     }
 }

--- a/GitTfs/Core/ITfsWorkspace.cs
+++ b/GitTfs/Core/ITfsWorkspace.cs
@@ -14,7 +14,14 @@ namespace Sep.Git.Tfs.Core
         void Add(string path);
         void Edit(string path);
         void Delete(string path);
-        void Rename(string pathFrom, string pathTo, string score);
+        void Rename(string pathFrom, string pathTo);
+    }
+    public interface ITfsWorkspaceCopy
+    {
+        void Add(string path, string shaFile);
+        void Edit(string path, string shaFile);
+        void Delete(string path);
+        void Rename(string pathFrom, string pathTo);
     }
 
     /// <summary>

--- a/GitTfs/Core/TfsWorkspace.cs
+++ b/GitTfs/Core/TfsWorkspace.cs
@@ -210,9 +210,9 @@ namespace Sep.Git.Tfs.Core
             if (deleted != 1) throw new Exception("One item should have been deleted, but actually deleted " + deleted + " items.");
         }
 
-        public void Rename(string pathFrom, string pathTo, string score)
+        public void Rename(string pathFrom, string pathTo)
         {
-            Trace.TraceInformation(" rename " + pathFrom + " to " + pathTo + " (score: " + score + ")");
+            Trace.TraceInformation(" rename " + pathFrom + " to " + pathTo);
             GetFromTfs(GetLocalPath(pathFrom));
             var result = _workspace.PendRename(GetLocalPath(pathFrom), GetLocalPath(pathTo));
             if (result != 1) throw new ApplicationException("Unable to rename item from " + pathFrom + " to " + pathTo);

--- a/GitTfsTest/Core/DirectoryTidierTests.cs
+++ b/GitTfsTest/Core/DirectoryTidierTests.cs
@@ -63,13 +63,6 @@ namespace Sep.Git.Tfs.Test.Core
         }
 
         [Fact]
-        public void PassesThroughGetLocalPath()
-        {
-            mockWorkspace.Expect(x => x.GetLocalPath("git-path")).Return("tfs-path");
-            //Assert.Equal("tfs-path", Tidy.GetLocalPath("git-path"));
-        }
-
-        [Fact]
         public void NoChangesMeansNoChanges()
         {
             // nothing!
@@ -206,25 +199,6 @@ namespace Sep.Git.Tfs.Test.Core
             mockWorkspace.Expect(x => x.Rename("topDir/midDir/bottomDir/file1.txt", "topDir/midDir/bottomDir/file1renamed.txt"));
             Tidy.Edit("topDir/midDir/bottomDir/file1.txt", "");
             Tidy.Rename("topDir/midDir/bottomDir/file1.txt", "topDir/midDir/bottomDir/file1renamed.txt");
-        }
-
-        [Fact]
-        public void TidyThrowsWhenMultipleOperationsOnTheSameFileOccur()
-        {
-            var workspace = mocks.StrictMock<ITfsWorkspaceModifier>();
-            ITfsWorkspaceCopy tidy = new DirectoryTidier(workspace, null,Enumerable.Empty<TfsTreeEntry>);
-
-            tidy.Delete("file.txt");
-            Assert.Throws<ArgumentException>(() =>
-                tidy.Add("FILE.TXT", ""));
-            Assert.Throws<ArgumentException>(() =>
-                tidy.Delete("File.TXT"));
-            Assert.Throws<ArgumentException>(() =>
-                tidy.Edit("File.txt", ""));
-            Assert.Throws<ArgumentException>(() =>
-                tidy.Rename("File.txt", "renamed.txt"));
-            Assert.Throws<ArgumentException>(() =>
-                tidy.Rename("oldFile.txt", "File.txt"));
         }
 
         private TfsTreeEntry item(TfsItemType itemType, string gitPath)


### PR DESCRIPTION
Fix issue #104 . Case changes are now ignored while crossing the bridge.
These changes cannot be mapped because of limitations of Windows file system.