### PR TITLE
Allow both initial and up-to changeset IDs

### DIFF
--- a/GitTfs/Commands/Fetch.cs
+++ b/GitTfs/Commands/Fetch.cs
@@ -146,7 +146,7 @@ namespace Sep.Git.Tfs.Commands
 
         protected virtual void DoFetch(IGitTfsRemote remote, bool stopOnFailMergeCommit)
         {
-            if (upToChangeSet > 0 && InitialChangeset.HasValue && InitialChangeset.Value > upToChangeSet)
+            if (upToChangeSet != -1 && InitialChangeset.HasValue && InitialChangeset.Value > upToChangeSet)
                 throw new GitTfsException("error: up-to changeset # must not be less than the initial one");
 
             var bareBranch = string.IsNullOrEmpty(BareBranch) ? remote.Id : BareBranch;

--- a/GitTfs/Commands/Fetch.cs
+++ b/GitTfs/Commands/Fetch.cs
@@ -146,6 +146,9 @@ namespace Sep.Git.Tfs.Commands
 
         protected virtual void DoFetch(IGitTfsRemote remote, bool stopOnFailMergeCommit)
         {
+            if (upToChangeSet > 0 && InitialChangeset.HasValue && InitialChangeset.Value > upToChangeSet)
+                throw new GitTfsException("error: up-to changeset # must not be less than the initial one");
+
             var bareBranch = string.IsNullOrEmpty(BareBranch) ? remote.Id : BareBranch;
 
             // It is possible that we have outdated refs/remotes/tfs/<id>.
@@ -187,7 +190,7 @@ namespace Sep.Git.Tfs.Commands
                     _properties.InitialChangeset = InitialChangeset.Value;
                     _properties.PersistAllOverrides();
                     remote.QuickFetch(InitialChangeset.Value);
-                    remote.Fetch(stopOnFailMergeCommit);
+                    remote.Fetch(stopOnFailMergeCommit, upToChangeSet);
                 }
                 else
                 {

--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -3,3 +3,4 @@
 * Add support of `.gitignore` to ignore files in `clone` and `init` commands (#897)
 * Improve branch point changeset detection (#1017 & #973, @fourpastmidnight & @jeremy-sylvis-tmg)
 * Add support for deleting TFS shelvesets using the shelve-delete command
+* Allow using both "--changeset" and "--up-to" options at the same time (#1057) to fetch a specific range of TFS changesets


### PR DESCRIPTION
Currently "--changeset=X" has precedence over "--up-to=Y" if both options are specified. This PR fixes this behavior, making it possible to fetch a specific range of TFS changesets. 'X' being greater than 'Y' is considered an error so no fetching changesets in reverse order. :)

The change is so trivial that I'm not even sure it deserves being mentioned in the release notes.