### PR TITLE
Fix creation of log entries with default remote

### DIFF
--- a/GitTfs/Core/TfsChangeset.cs
+++ b/GitTfs/Core/TfsChangeset.cs
@@ -216,6 +216,8 @@ namespace Sep.Git.Tfs.Core
             {
                 email = "unknown@tfs.local";
             }
+            if (remote == null)
+                remote = Summary.Remote;
             return new LogEntry
             {
                 Date = changesetToLog.CreationDate,


### PR DESCRIPTION
`Sep.Git.Tfs.Core.TfsChangeset.MakeNewLogEntry()` allows its 'remote' parameter to be null (even uses it as the default value) but doesn't handle this situation, returning a log entry not associated with any TFS remote. The proposed change is to associate the log entry with the same TFS remote as the changeset if no remote is specified explicitly.