### PR TITLE
Added a TraceWarning when the authors file fails to copy.

### DIFF
--- a/GitTfs/Util/AuthorsFile.cs
+++ b/GitTfs/Util/AuthorsFile.cs
@@ -168,7 +168,10 @@ namespace Sep.Git.Tfs.Util
                         File.Copy(authorsFilePath, savedAuthorFile, true);
                         return parseSuccess;
                     }
-                    catch (Exception) { }
+                    catch (Exception)
+                    {
+                        Trace.TraceWarning("Failed to copy authors file from \"" + authorsFilePath + "\" to \"" + savedAuthorFile + "\".");
+                    }
                 }
             }
             else if (File.Exists(savedAuthorFile))

--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -4,3 +4,4 @@
 * Improve branch point changeset detection (#1017 & #973, @fourpastmidnight & @jeremy-sylvis-tmg)
 * Add support for deleting TFS shelvesets using the shelve-delete command
 * Allow using both "--changeset" and "--up-to" options at the same time (#1057) to fetch a specific range of TFS changesets
+* Added a TraceWarning message when the authors file fails to copy to the cache location (#1071)


### PR DESCRIPTION
This is a partial fix for issue #1071, now a `TraceWarning` message will be displayed when the file fails to copy.