### PR TITLE
Fixing infinite loop when merging from a rename changeset

### DIFF
--- a/GitTfs/Core/GitTfsRemote.cs
+++ b/GitTfs/Core/GitTfsRemote.cs
@@ -677,7 +677,14 @@ namespace Sep.Git.Tfs.Core
                 {
                     try
                     {
-                        remote.Fetch(renameResult: renameResult);
+                        var fetchResult = remote.Fetch(renameResult: renameResult);
+                        if (fetchResult.IsProcessingRenameChangeset)
+                        {
+                            if (renameResult == null) renameResult = new FetchResult();
+                            renameResult.IsProcessingRenameChangeset = true;
+                            renameResult.LastParentCommitBeforeRename = fetchResult.LastParentCommitBeforeRename;
+                            remote.Fetch(renameResult: renameResult);
+                        }
                     }
                     finally
                     {

--- a/GitTfsTest/GitTfsTest.csproj
+++ b/GitTfsTest/GitTfsTest.csproj
@@ -128,6 +128,7 @@
     <Compile Include="Integration\InitTests.cs" />
     <Compile Include="Integration\IntegrationHelper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestHelpers\AssertTimeout.cs" />
     <Compile Include="TestHelpers\ExtensionMethods.cs" />
     <Compile Include="Util\AuthorsFileUnitTest.cs" />
     <Compile Include="Util\CamelCaseToDelimitedStringConverterTests.cs" />

--- a/GitTfsTest/TestHelpers/AssertTimeout.cs
+++ b/GitTfsTest/TestHelpers/AssertTimeout.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Diagnostics;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+
+namespace Sep.Git.Tfs.Test.TestHelpers
+{
+    public static class AssertTimeout
+    {
+        /// <summary>
+        /// Fails tests which would otherwise run indefinitely.
+        /// </summary>
+        public static void For(TimeSpan limit, Action actionToLimit, string message = null)
+        {
+            if (actionToLimit == null) throw new ArgumentNullException("actionToLimit");
+
+            var exceptionDispatchInfo = (ExceptionDispatchInfo)null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    actionToLimit.Invoke();
+                }
+                catch (Exception ex)
+                {
+                    // Preserve the call stack
+                    exceptionDispatchInfo = ExceptionDispatchInfo.Capture(ex);
+                }
+            })
+            {
+                Name = "AssertTimeout " + actionToLimit.Method.Name
+            };
+
+            thread.Start();
+
+            if (Debugger.IsAttached)
+            {
+                thread.Join();
+            }
+            else
+            {
+                if (!thread.Join(limit))
+                {
+                    thread.Abort();
+                    throw new TimeoutException(message ?? (actionToLimit.Method.Name + " took longer than " + limit + "."));
+                }
+            }
+
+            if (exceptionDispatchInfo != null)
+                exceptionDispatchInfo.Throw();
+        }
+    }
+}


### PR DESCRIPTION
Please do not merge until the fix is finished. (Will fix #873)

Currently when git-tfs tries to clone a merge changeset and a merge parent is itself a rename changeset, git-tfs loops forever. It looks similar to this:

```
Tfs branches found:
- $/A
- $/B
=> Working on TFS branch : $/A
=> Working on TFS branch : $/B
=> Working on TFS branch : $/Trunk
        Fetching from dependent TFS remote B'...
=> Working on TFS branch : $/Trunk
        Fetching from dependent TFS remote B'...
=> Working on TFS branch : $/Trunk
        Fetching from dependent TFS remote B'...
=> Working on TFS branch : $/Trunk
        Fetching from dependent TFS remote B'...
=> Working on TFS branch : $/Trunk
        Fetching from dependent TFS remote B'...
=> Working on TFS branch : $/Trunk
        Fetching from dependent TFS remote B'...
[...endless]
```

@spraints @pmiossec @ivan-danilov I want to get your comments on this. There seem to be several ways to fix this so that all the tests pass, but I'm not sure which way is the right approach.

@elangelo's PR [#956](https://github.com/git-tfs/git-tfs/pull/956/files?w=1) doesn't come with any tests but it does make my test pass. I'm having doubts it is the right approach, especially [this line](https://github.com/git-tfs/git-tfs/pull/956/files?w=1#diff-bc06152b842b2133c8a7eefb9d446644R63).

@icnocop's PR #927 was also supposed to address this issue, but at least for my scenario, it had no effect.