### PR TITLE
Prevent an infinite loop that was occurring when a Merge failed due to missing parent commit

### DIFF
--- a/GitTfs/Core/GitTfsRemote.cs
+++ b/GitTfs/Core/GitTfsRemote.cs
@@ -366,6 +366,7 @@ namespace Sep.Git.Tfs.Core
                     string parentCommitSha = null;
                     if (changeset.IsMergeChangeset && !ProcessMergeChangeset(changeset, stopOnFailMergeCommit, ref parentCommitSha))
                     {
+                        fetchResult.NewChangesetCount--; // Merge wasn't successful - so don't count the changeset we found
                         fetchResult.IsSuccess = false;
                         return fetchResult;
                     }

--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -5,3 +5,4 @@
 * Add support for deleting TFS shelvesets using the shelve-delete command
 * Allow using both "--changeset" and "--up-to" options at the same time (#1057) to fetch a specific range of TFS changesets
 * Added a TraceWarning message when the authors file fails to copy to the cache location (#1071)
+* Prevent infinite loop when barent changeset cannot be found

--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -5,4 +5,4 @@
 * Add support for deleting TFS shelvesets using the shelve-delete command
 * Allow using both "--changeset" and "--up-to" options at the same time (#1057) to fetch a specific range of TFS changesets
 * Added a TraceWarning message when the authors file fails to copy to the cache location (#1071)
-* Prevent infinite loop when barent changeset cannot be found
+* Prevent infinite loop when parent changeset cannot be found


### PR DESCRIPTION
ChangesetCount was incrementing, indicating work had been done, even when the merge process failed.

This resulted in an endless loop in InitBranch.cs, as "somethingDone" was always true, even though nothing was done.