### PR TITLE
Fix xcopy invocation for spaces in path

### DIFF
--- a/GitTfs.Vs2010/GitTfs.Vs2010.csproj
+++ b/GitTfs.Vs2010/GitTfs.Vs2010.csproj
@@ -1,4 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Changed 2017 by Sijmen J. Mulder <s.mulder@betabit.nl>:
+   - fix xcopy invocation for paths with spaces
+-->
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -145,6 +149,11 @@
   </Target>
   -->
   <PropertyGroup>
-    <PostBuildEvent>xcopy /y /I "$(TargetDir)*.dll" "$(SolutionDir)GitTfs\$(OutDir)$(ProjectName)" /EXCLUDE:$(SolutionDir)files_to_ignore_during_post_build_copy.txt</PostBuildEvent>
+    <PostBuildEvent>
+      <!-- Change to the solution directory instead of passing it directly to
+           /escape since that option can't deal with paths with spaces -->
+      cd $(SolutionDir)
+      xcopy /y /I "$(TargetDir)*.dll" "$(SolutionDir)GitTfs\$(OutDir)$(ProjectName)" /EXCLUDE:files_to_ignore_during_post_build_copy.txt
+    </PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/GitTfs.Vs2012/GitTfs.Vs2012.csproj
+++ b/GitTfs.Vs2012/GitTfs.Vs2012.csproj
@@ -1,4 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Changed 2017 by Sijmen J. Mulder <s.mulder@betabit.nl>:
+   - fix xcopy invocation for paths with spaces
+-->
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -95,7 +99,12 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>xcopy /y /I "$(TargetDir)*.dll" "$(SolutionDir)GitTfs\$(OutDir)$(ProjectName)" /EXCLUDE:$(SolutionDir)files_to_ignore_during_post_build_copy.txt</PostBuildEvent>
+    <PostBuildEvent>
+      <!-- Change to the solution directory instead of passing it directly to
+           /escape since that option can't deal with paths with spaces -->
+      cd $(SolutionDir)
+      xcopy /y /I "$(TargetDir)*.dll" "$(SolutionDir)GitTfs\$(OutDir)$(ProjectName)" /EXCLUDE:files_to_ignore_during_post_build_copy.txt
+    </PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/GitTfs.Vs2013/GitTfs.Vs2013.csproj
+++ b/GitTfs.Vs2013/GitTfs.Vs2013.csproj
@@ -1,4 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Changed 2017 by Sijmen J. Mulder <s.mulder@betabit.nl>:
+   - fix xcopy invocation for paths with spaces
+-->
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -97,7 +101,12 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>xcopy /y /I "$(TargetDir)*.dll" "$(SolutionDir)GitTfs\$(OutDir)$(ProjectName)" /EXCLUDE:$(SolutionDir)files_to_ignore_during_post_build_copy.txt</PostBuildEvent>
+    <PostBuildEvent>
+      <!-- Change to the solution directory instead of passing it directly to
+           /escape since that option can't deal with paths with spaces -->
+      cd $(SolutionDir)
+      xcopy /y /I "$(TargetDir)*.dll" "$(SolutionDir)GitTfs\$(OutDir)$(ProjectName)" /EXCLUDE:files_to_ignore_during_post_build_copy.txt
+    </PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/GitTfs.Vs2015/GitTfs.Vs2015.csproj
+++ b/GitTfs.Vs2015/GitTfs.Vs2015.csproj
@@ -1,4 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Changed 2017 by Sijmen J. Mulder <s.mulder@betabit.nl>:
+   - fix xcopy invocation for paths with spaces
+-->
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -98,7 +102,12 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>xcopy /y /I "$(TargetDir)*.dll" "$(SolutionDir)GitTfs\$(OutDir)$(ProjectName)" /EXCLUDE:$(SolutionDir)files_to_ignore_during_post_build_copy.txt</PostBuildEvent>
+    <PostBuildEvent>
+      <!-- Change to the solution directory instead of passing it directly to
+           /escape since that option can't deal with paths with spaces -->
+      cd $(SolutionDir)
+      xcopy /y /I "$(TargetDir)*.dll" "$(SolutionDir)GitTfs\$(OutDir)$(ProjectName)" /EXCLUDE:files_to_ignore_during_post_build_copy.txt
+    </PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -6,3 +6,4 @@
 * Allow using both "--changeset" and "--up-to" options at the same time (#1057) to fetch a specific range of TFS changesets
 * Added a TraceWarning message when the authors file fails to copy to the cache location (#1071)
 * Prevent infinite loop when parent changeset cannot be found
+* Fix xcopy error on build with spaces in solution path


### PR DESCRIPTION
The post-build xcopy invocation failed because `/EXCLUDE` cannot deal with spaces, not even quoted. Fixed by adding a `cd` to `$(SolutionDir)` and using a relative path in the argument.

I have not written a test for this fix.