### PR TITLE
Copy export settings to new branches

### DIFF
--- a/GitTfs/Core/GitTfsRemote.cs
+++ b/GitTfs/Core/GitTfsRemote.cs
@@ -1033,6 +1033,8 @@ namespace Sep.Git.Tfs.Core
                     Repository = tfsRepositoryPath,
                     RemoteOptions = remoteOptions
                 }, string.Empty);
+                tfsRemote.ExportMetadatas = ExportMetadatas;
+                tfsRemote.ExportWorkitemsMapping = ExportWorkitemsMapping;
             }
             if (sha1RootCommit != null && !Repository.HasRef(tfsRemote.RemoteRef))
             {

--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -7,3 +7,4 @@
 * Added a TraceWarning message when the authors file fails to copy to the cache location (#1071)
 * Prevent infinite loop when parent changeset cannot be found
 * Fix xcopy error on build with spaces in solution path (#1092)
+* Apply export argument to all branches rather than just the trunk (#975)


### PR DESCRIPTION
When cloning a bunch of branches with the export option on, the option was only being honoured for the branches fetched directly. Any branches that were fetched indirectly in order to provide the history for the direct branches were missing the work items field in the comments.

This fix works in my case, and the tests pass, however I'm new to this project. If there's a better place for the fix, anything I've missed, or any other suggestions please let me know.

I've tagged it as fixing #975 as it looked like the issue I was having, but until I hear from anyone else on that issue I can't be sure.