### PR TITLE
rcheckin with --check-lock option

### DIFF
--- a/GitTfs.VsCommon/TfsHelper.Common.cs
+++ b/GitTfs.VsCommon/TfsHelper.Common.cs
@@ -1448,6 +1448,23 @@ namespace Sep.Git.Tfs.VsCommon
         {
             return queuedBuild.Build;
         }
+
+        public IPendingSet[] QueryPendingSets(string[] items, TfsRecursionType recursionType, string queryWorkspaceName, string queryUserName) 
+        {
+
+            Trace.WriteLine($"Getting pending changes for \n\t{string.Join("\n\t",items)}\n, Workspace: {queryWorkspaceName ?? "<null>"}, UserName: {queryUserName ?? "<null>"}");
+
+            var pendingSets = VersionControl.QueryPendingSets(
+                items,
+                _bridge.Convert<RecursionType>(recursionType),
+                queryWorkspaceName,
+                queryUserName
+            );
+
+            return _bridge.Wrap<WrapperForPendingSet, PendingSet>(pendingSets);
+        }
+
+
     }
 
     public class ItemDownloadStrategy : IItemDownloadStrategy

--- a/GitTfs.VsCommon/TfsHelper.Common.cs
+++ b/GitTfs.VsCommon/TfsHelper.Common.cs
@@ -1452,7 +1452,7 @@ namespace Sep.Git.Tfs.VsCommon
         public IPendingSet[] QueryPendingSets(string[] items, TfsRecursionType recursionType, string queryWorkspaceName, string queryUserName) 
         {
 
-            Trace.WriteLine($"Getting pending changes for \n\t{string.Join("\n\t",items)}\n, Workspace: {queryWorkspaceName ?? "<null>"}, UserName: {queryUserName ?? "<null>"}");
+            Trace.WriteLine(string.Format("Getting pending changes for \n\t{0}\n, Workspace: {1}, UserName: {2}", string.Join("\n\t", items), queryWorkspaceName ?? "<null>", queryUserName ?? "<null>"));
 
             var pendingSets = VersionControl.QueryPendingSets(
                 items,

--- a/GitTfs.VsCommon/Wrappers.cs
+++ b/GitTfs.VsCommon/Wrappers.cs
@@ -252,8 +252,84 @@ namespace Sep.Git.Tfs.VsCommon
 
     public class WrapperForPendingChange : WrapperFor<PendingChange>, IPendingChange
     {
-        public WrapperForPendingChange(PendingChange pendingChange) : base(pendingChange)
+        private readonly TfsApiBridge _bridge;
+        private readonly PendingChange _pendingChange;
+
+        public WrapperForPendingChange(TfsApiBridge bridge, PendingChange pendingChange) : base(pendingChange)
         {
+            this._bridge = bridge;
+            this._pendingChange = pendingChange;
+        }
+
+        public string FileName {
+            get {
+                return _pendingChange.FileName;
+            }
+        }
+
+        public bool IsLock {
+            get {
+                return _pendingChange.IsLock;
+            }
+        }
+
+        public TfsLockLevel LockLevel {
+            get {
+                return _bridge.Convert<TfsLockLevel>(_pendingChange.LockLevel);
+            }
+        }
+
+        public string LocalItem {
+            get {
+                return _pendingChange.LocalItem;
+            }
+        }
+
+        public string ServerItem {
+            get {
+                return _pendingChange.ServerItem;
+            }
+        }
+    }
+
+    public class WrapperForPendingSet : WrapperFor<PendingSet>, IPendingSet {
+        private readonly TfsApiBridge _bridge;
+        private readonly PendingSet _pendingSet;
+
+        public WrapperForPendingSet(TfsApiBridge bridge, PendingSet pendingSet) : base(pendingSet)
+        {
+            this._bridge = bridge;
+            this._pendingSet = pendingSet;
+        }
+
+        public IPendingChange[] PendingChanges {
+            get {
+                return _bridge.Wrap<WrapperForPendingChange, PendingChange>(_pendingSet.PendingChanges);
+            }
+        }
+
+        public string Computer {
+            get {
+                return _pendingSet.Computer;
+            }
+        }
+
+        public string Name {
+            get {
+                return _pendingSet.Name;
+            }
+        }
+
+        public string OwnerDisplayName {
+            get {
+                return _pendingSet.OwnerDisplayName;
+            }
+        }
+
+        public string OwnerName {
+            get {
+                return _pendingSet.OwnerName;
+            }
         }
     }
 

--- a/GitTfs.VsFake/TfsHelper.VsFake.cs
+++ b/GitTfs.VsFake/TfsHelper.VsFake.cs
@@ -530,6 +530,11 @@ namespace Sep.Git.Tfs.VsFake
             throw new NotImplementedException();
         }
 
+        public IPendingSet[] QueryPendingSets(string[] items, TfsRecursionType recursionType, string queryWorkspace, string queryUser) 
+        {
+            throw new NotImplementedException();
+        }
+
         #endregion
 
         private class FakeVersionControlServer : IVersionControlServer

--- a/GitTfs/Commands/Rcheckin.cs
+++ b/GitTfs/Commands/Rcheckin.cs
@@ -146,12 +146,12 @@ namespace Sep.Git.Tfs.Commands
             var lockedChanges = pendingSets
                 .SelectMany( set => set.PendingChanges, (set, change) => Tuple.Create(set, change))
                 .Where( change => change.Item2.LockLevel != Core.TfsInterop.TfsLockLevel.None)
-                .Select( change => $"{change.Item2.ServerItem} has been locked ({change.Item2.LockLevel.ToString()}) by {change.Item1.OwnerDisplayName};{change.Item1.Computer}")
+                .Select( change => string.Format("{0} has been locked ({1}) by {2};{3}", change.Item2.ServerItem, change.Item2.LockLevel.ToString(), change.Item1.OwnerDisplayName, change.Item1.Computer))
                 .ToArray();
             
             if (lockedChanges.Length > 0) 
             {
-                throw new GitTfsException($"error: Some files are exclusive locked.\n{String.Join("\n", lockedChanges)}");
+                throw new GitTfsException(string.Format("error: Some files are exclusive locked.\n{0}", String.Join("\n", lockedChanges)));
             }
 
             

--- a/GitTfs/Core/DerivedGitTfsRemote.cs
+++ b/GitTfs/Core/DerivedGitTfsRemote.cs
@@ -309,6 +309,11 @@ namespace Sep.Git.Tfs.Core
         {
             throw DerivedRemoteException;
         }
+
+        public IPendingSet[] QueryPendingSets(TfsChangesetInfo parentChangeset, string[] items, TfsRecursionType recursionType, string queryWorkspace, string queryUser) 
+        {
+            throw DerivedRemoteException;
+        }
         #endregion
     }
 }

--- a/GitTfs/Core/GitTfsRemote.cs
+++ b/GitTfs/Core/GitTfsRemote.cs
@@ -224,7 +224,7 @@ namespace Sep.Git.Tfs.Core
 
         public void CleanupWorkspace()
         {
-            Tfs.CleanupWorkspaces(WorkingDirectory);
+            Tfs.CleanupWorkspaces(WorkingDirectory);            
         }
 
         public void CleanupWorkspaceDirectory()
@@ -1041,6 +1041,22 @@ namespace Sep.Git.Tfs.Core
             }
             Trace.WriteLine("Remote created!");
             return tfsRemote;
+        }
+
+        public IPendingSet[] QueryPendingSets(TfsChangesetInfo parentChangeset, string[] items, TfsRecursionType recursionType, string queryWorkspace, string queryUser) 
+        {
+            IPendingSet[] ret = null;
+
+            WithWorkspace(parentChangeset, workspace => 
+            {
+                var workspaceItems = items
+                .Select(x => workspace.GetLocalPath(x))
+                .ToArray();
+
+                ret = Tfs.QueryPendingSets(workspaceItems, recursionType, queryWorkspace, queryUser);
+            });
+
+            return ret;
         }
     }
 }

--- a/GitTfs/Core/IGitTfsRemote.cs
+++ b/GitTfs/Core/IGitTfsRemote.cs
@@ -80,6 +80,8 @@ namespace Sep.Git.Tfs.Core
         void EnsureTfsAuthenticated();
         bool MatchesUrlAndRepositoryPath(string tfsUrl, string tfsRepositoryPath);
         void DeleteShelveset(string shelvesetName);
+
+        IPendingSet[] QueryPendingSets(TfsChangesetInfo parentChangeset, string[] items, TfsRecursionType recursionType, string queryWorkspace, string queryUser);
     }
 
     public static class IGitTfsRemoteExt

--- a/GitTfs/Core/TfsInterop/IPendingChange.cs
+++ b/GitTfs/Core/TfsInterop/IPendingChange.cs
@@ -3,5 +3,18 @@ namespace Sep.Git.Tfs.Core.TfsInterop
 {
     public interface IPendingChange
     {
+        string FileName { get; }
+        bool IsLock { get; }
+        TfsLockLevel LockLevel { get; }
+        string LocalItem { get; }
+        string ServerItem { get; }
+    }
+
+    public enum TfsLockLevel 
+    {
+        None = 0,
+        Checkin = 1,
+        CheckOut = 2,
+        Unchanged = 3
     }
 }

--- a/GitTfs/Core/TfsInterop/IPendingSet.cs
+++ b/GitTfs/Core/TfsInterop/IPendingSet.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Sep.Git.Tfs.Core.TfsInterop 
+{
+    public interface IPendingSet 
+    {
+
+        string Computer { get; }
+        string Name { get; }
+        string OwnerDisplayName { get; }
+        string OwnerName { get; }
+
+        IPendingChange[] PendingChanges { get; }
+    }
+}

--- a/GitTfs/Core/TfsInterop/ITfsHelper.cs
+++ b/GitTfs/Core/TfsInterop/ITfsHelper.cs
@@ -49,5 +49,7 @@ namespace Sep.Git.Tfs.Core.TfsInterop
         void WithWorkspace(string localDirectory, IGitTfsRemote remote, IEnumerable<Tuple<string, string>> mappings, TfsChangesetInfo versionToFetch, Action<ITfsWorkspace> action);
         int QueueGatedCheckinBuild(Uri value, string buildDefinitionName, string shelvesetName, string checkInTicket);
         void DeleteShelveset(IWorkspace workspace, string shelvesetName);
+
+        IPendingSet[] QueryPendingSets(string[] items, TfsRecursionType recursionType, string queryWorkspace, string queryUser);
     }
 }

--- a/GitTfs/GitTfs.csproj
+++ b/GitTfs/GitTfs.csproj
@@ -154,6 +154,7 @@
     <Compile Include="Core\Changes\Git\Modify.cs" />
     <Compile Include="Core\Changes\Git\RenameEdit.cs" />
     <Compile Include="Core\CheckinPolicyEvaluator.cs" />
+    <Compile Include="Core\TfsInterop\IPendingSet.cs" />
     <Compile Include="Core\TfsInterop\RootBranch.cs" />
     <Compile Include="Core\TfsLabel.cs" />
     <Compile Include="Core\DerivedGitTfsRemote.cs" />

--- a/doc/commands/rcheckin.md
+++ b/doc/commands/rcheckin.md
@@ -22,6 +22,9 @@ rcheckin differs from [checkin](checkin.md) in that the latter squashes the comm
 
         -A, --authors=VALUE        Path to an Authors file to map TFS users to Git users
 
+        --check-lock               Checks if there is no lock on any file before
+                                     checkin
+
         -d, --debug
             (Type: Flag, Value Type:[Boolean])
             Show lots of output.
@@ -34,7 +37,7 @@ rcheckin differs from [checkin](checkin.md) in that the latter squashes the comm
 
 ### Simple
 
-Suppose you have 
+Suppose you have
 
     A [tfs/default, C1] <- B <- C [master, HEAD]
 
@@ -103,7 +106,7 @@ You could check in commits of other users in TFS. To be able to do that, you mus
 
     git tfs rcheckin --authors="c:\path\to\authors.txt"
 
-Note : To be able to check in commits of other users, you should have a special right defined in TFS. To activate, Right click on the TFS project, then "Security..." and select "Allow" to the "Check in other user's changes" permission (CheckinOther). 
+Note : To be able to check in commits of other users, you should have a special right defined in TFS. To activate, Right click on the TFS project, then "Security..." and select "Allow" to the "Check in other user's changes" permission (CheckinOther).
 
 ## Internals
 

--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -6,3 +6,4 @@
 * Allow using both "--changeset" and "--up-to" options at the same time (#1057) to fetch a specific range of TFS changesets
 * Added a TraceWarning message when the authors file fails to copy to the cache location (#1071)
 * Prevent infinite loop when parent changeset cannot be found
+* Added a `--check-lock` option for `rcheckin` command


### PR DESCRIPTION
See #1088

I've added a new `--check-lock` option to `rcheckin`. This option checks all changed files if there is an exclusive (checkout) lock in tfs

Example output:
```
> git-tfs rcheckin --check-lock
Working with tfs remote: default => $/TFS/PATH
Fetching changes from TFS to minimize possibility of late conflict...
error: Some files are exclusive locked.
$/TFS/PATH/.gitignore has been locked (CheckOut) by DOMAIN\USER;WORKSTATION
All the logs could be found in the log file: C:\Users\USER\AppData\Local\git-tfs\git-tfs_log.txt
```

---Please read and delete this text before creating this pull request---
Thanks a lot for the pull request you are going to do!
Please verify that you validate these points:

- [x] indentation is made with 4 spaces
- [x] your pull request contains only changes intended (no refactoring, line return added, ... that could make code review harder. Make another one if you think it is needed...)
- [ ] run and verify that existing tests pass. Add some new units tests, if needed.
- [x] update the documentation, if needed.
- [x] update the [release notes file](../tree/master/doc/release-notes/NEXT.md)

------------------------------------------------------------------------