### PR TITLE
Allow git 2.x dependency in Chocolatey package

### DIFF
--- a/src/build/ChocolateyTemplates/gittfs.nuspec
+++ b/src/build/ChocolateyTemplates/gittfs.nuspec
@@ -21,7 +21,7 @@ ${ReleaseNotesContents}
     <licenseUrl>https://github.com/git-tfs/git-tfs/blob/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <dependencies>
-      <dependency id="git" version="1.9.5.20150320" />
+      <dependency id="git" version="[1.9.5.20150320,3)" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
The Chocolatey package currently requires Git version 1.9.5.20150320 installed.  This means that when I have the latest version of Git installed (2.14.2.20170927), Chocolatey will revert back to Git 1.9.5.20150320 when upgrading GitTfs.  This commit changes the dependency to a range which accepts 1.9.5.x but also allows any 2.x versions.