### PR TITLE
rcheckin with --check-lock option

### DIFF
--- a/doc/commands/rcheckin.md
+++ b/doc/commands/rcheckin.md
@@ -24,6 +24,8 @@ rcheckin differs from [checkin](checkin.md) in that the latter squashes the comm
       -a, --autorebase           Continue and rebase if new TFS changesets found
           --ignore-merge         Force check in ignoring parent tfs branches in
                                    merge commits
+      --check-lock               Checks if there is no lock on any file before
+                                   checkin
       -m, --comment=VALUE        A comment for the changeset
           --no-build-default-comment
                                  Do not concatenate commit comments for the
@@ -66,7 +68,7 @@ rcheckin differs from [checkin](checkin.md) in that the latter squashes the comm
 
 ### Simple
 
-Suppose you have 
+Suppose you have
 
     A [tfs/default, C1] <- B <- C [master, HEAD]
 
@@ -135,7 +137,7 @@ You could check in commits of other users in TFS. To be able to do that, you mus
 
     git tfs rcheckin --authors="c:\path\to\authors.txt"
 
-Note : To be able to check in commits of other users, you should have a special right defined in TFS. To activate, Right click on the TFS project, then "Security..." and select "Allow" to the "Check in other user's changes" permission (CheckinOther). 
+Note : To be able to check in commits of other users, you should have a special right defined in TFS. To activate, Right click on the TFS project, then "Security..." and select "Allow" to the "Check in other user's changes" permission (CheckinOther).
 
 ## Internals
 

--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -1,1 +1,2 @@
 * Maintain export flag when resuming a clone for non-trunk branches (#1123)
+* Added a `--check-lock` option for `rcheckin` command

--- a/src/GitTfs.VsCommon/TfsHelper.Common.cs
+++ b/src/GitTfs.VsCommon/TfsHelper.Common.cs
@@ -20,6 +20,7 @@ using StructureMap.Attributes;
 using ChangeType = Microsoft.TeamFoundation.VersionControl.Client.ChangeType;
 using IdentityNotFoundException = Microsoft.TeamFoundation.VersionControl.Client.IdentityNotFoundException;
 using Microsoft.TeamFoundation.Build.Client;
+using Sep.Git.Tfs.Core.TfsInterop;
 
 namespace GitTfs.VsCommon
 {
@@ -1448,6 +1449,28 @@ namespace GitTfs.VsCommon
         {
             return queuedBuild.Build;
         }
+
+        public IPendingSet[] QueryPendingSets(string[] items, TfsRecursionType recursionType, string queryWorkspaceName, string queryUserName) 
+        {
+
+            Trace.WriteLine(String.Format("Getting pending changes for \n\t{0}\n, Workspace: {1}, UserName: {2}", 
+                                            string.Join("\n\t", items), 
+                                            queryWorkspaceName ?? "<null>", 
+                                            queryUserName ?? "<null>"
+                           )
+            );
+
+            var pendingSets = VersionControl.QueryPendingSets(
+                items,
+                _bridge.Convert<RecursionType>(recursionType),
+                queryWorkspaceName,
+                queryUserName
+            );
+
+            return _bridge.Wrap<WrapperForPendingSet, PendingSet>(pendingSets);
+        }
+
+
     }
 
     public class ItemDownloadStrategy : IItemDownloadStrategy

--- a/src/GitTfs.VsCommon/Wrappers.cs
+++ b/src/GitTfs.VsCommon/Wrappers.cs
@@ -9,6 +9,7 @@ using GitTfs.Core;
 using GitTfs.Core.TfsInterop;
 using GitTfs.Util;
 using Microsoft.TeamFoundation.VersionControl.Common;
+using Sep.Git.Tfs.Core.TfsInterop;
 
 namespace GitTfs.VsCommon
 {
@@ -252,8 +253,84 @@ namespace GitTfs.VsCommon
 
     public class WrapperForPendingChange : WrapperFor<PendingChange>, IPendingChange
     {
-        public WrapperForPendingChange(PendingChange pendingChange) : base(pendingChange)
+        private readonly TfsApiBridge _bridge;
+        private readonly PendingChange _pendingChange;
+
+        public WrapperForPendingChange(TfsApiBridge bridge, PendingChange pendingChange) : base(pendingChange)
         {
+            this._bridge = bridge;
+            this._pendingChange = pendingChange;
+        }
+
+        public string FileName {
+            get {
+                return _pendingChange.FileName;
+            }
+        }
+
+        public bool IsLock {
+            get {
+                return _pendingChange.IsLock;
+            }
+        }
+
+        public TfsLockLevel LockLevel {
+            get {
+                return _bridge.Convert<TfsLockLevel>(_pendingChange.LockLevel);
+            }
+        }
+
+        public string LocalItem {
+            get {
+                return _pendingChange.LocalItem;
+            }
+        }
+
+        public string ServerItem {
+            get {
+                return _pendingChange.ServerItem;
+            }
+        }
+    }
+
+    public class WrapperForPendingSet : WrapperFor<PendingSet>, IPendingSet {
+        private readonly TfsApiBridge _bridge;
+        private readonly PendingSet _pendingSet;
+
+        public WrapperForPendingSet(TfsApiBridge bridge, PendingSet pendingSet) : base(pendingSet)
+        {
+            this._bridge = bridge;
+            this._pendingSet = pendingSet;
+        }
+
+        public IPendingChange[] PendingChanges {
+            get {
+                return _bridge.Wrap<WrapperForPendingChange, PendingChange>(_pendingSet.PendingChanges);
+            }
+        }
+
+        public string Computer {
+            get {
+                return _pendingSet.Computer;
+            }
+        }
+
+        public string Name {
+            get {
+                return _pendingSet.Name;
+            }
+        }
+
+        public string OwnerDisplayName {
+            get {
+                return _pendingSet.OwnerDisplayName;
+            }
+        }
+
+        public string OwnerName {
+            get {
+                return _pendingSet.OwnerName;
+            }
         }
     }
 

--- a/src/GitTfs.VsFake/TfsHelper.VsFake.cs
+++ b/src/GitTfs.VsFake/TfsHelper.VsFake.cs
@@ -7,6 +7,7 @@ using GitTfs.Commands;
 using GitTfs.Core;
 using GitTfs.Core.TfsInterop;
 using GitTfs.Util;
+using Sep.Git.Tfs.Core.TfsInterop;
 using StructureMap;
 
 namespace GitTfs.VsFake
@@ -526,6 +527,11 @@ namespace GitTfs.VsFake
         }
 
         public void DeleteShelveset(IWorkspace workspace, string shelvesetName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IPendingSet[] QueryPendingSets(string[] items, TfsRecursionType recursionType, string queryWorkspace, string queryUser) 
         {
             throw new NotImplementedException();
         }

--- a/src/GitTfs/Commands/Rcheckin.cs
+++ b/src/GitTfs/Commands/Rcheckin.cs
@@ -21,6 +21,7 @@ namespace GitTfs.Commands
 
         private bool AutoRebase { get; set; }
         private bool ForceCheckin { get; set; }
+        private bool CheckLock { get; set; }
 
         public Rcheckin(CheckinOptions checkinOptions, TfsWriter writer, Globals globals, AuthorsFile authors)
         {
@@ -39,6 +40,7 @@ namespace GitTfs.Commands
                     {
                         {"a|autorebase", "Continue and rebase if new TFS changesets found", v => AutoRebase = v != null},
                         {"ignore-merge", "Force check in ignoring parent tfs branches in merge commits", v => ForceCheckin = v != null},
+                        {"check-lock", "Checks if there is no lock on any file before checkin ", v => CheckLock = v != null }
                     }.Merge(_checkinOptions.OptionSet);
             }
         }
@@ -103,9 +105,63 @@ namespace GitTfs.Commands
             if (!commitsToCheckin.Any())
                 throw new GitTfsException("error: latest TFS commit should be parent of commits being checked in");
 
+            Trace.WriteLine("Checking locks");
+            if (CheckLock) 
+            {
+                CheckLocks(parentChangeset, refToCheckin);
+            }
+
             SetupMetadataExport(parentChangeset.Remote);
 
             return _PerformRCheckinQuick(parentChangeset, refToCheckin, commitsToCheckin);
+        }
+
+        private void CheckLocks(TfsChangesetInfo parentChangeset, string refToCheckin) 
+        {
+            string[] changedFiles = _globals.Repository.GetChangedFiles(parentChangeset.GitCommit, refToCheckin)
+                .Select( x=> {
+                    if (x is Core.Changes.Git.Modify) {
+                        return ((Core.Changes.Git.Modify)x).Path;
+                    } else if (x is Core.Changes.Git.RenameEdit) {
+                        return ((Core.Changes.Git.RenameEdit)x).Path;
+                    } else {
+                        return null;
+                    }
+                })
+                .Where(x => !String.IsNullOrEmpty(x))
+                .ToArray()
+            ;
+
+
+            if (changedFiles.Length == 0) { return; }
+
+            var pendingSets = parentChangeset.Remote.QueryPendingSets(
+                    parentChangeset,
+                    changedFiles,
+                    Core.TfsInterop.TfsRecursionType.None,
+                    queryWorkspace: null,
+                    queryUser: null
+                );
+
+            var lockedChanges = pendingSets
+                .SelectMany( set => set.PendingChanges, (set, change) => Tuple.Create(set, change))
+                .Where( change => change.Item2.LockLevel != Core.TfsInterop.TfsLockLevel.None)
+                .Select( change => String.Format(
+                                            "{0} has been locked ({1}) by {2};{3}", 
+                                            change.Item2.ServerItem, 
+                                            change.Item2.LockLevel.ToString(), 
+                                            change.Item1.OwnerDisplayName, 
+                                            change.Item1.Computer
+                                   )
+                )
+                .ToArray();
+            
+            if (lockedChanges.Length > 0) 
+            {
+                throw new GitTfsException(String.Format("error: Some files are exclusive locked.\n{0}", String.Join("\n", lockedChanges)));
+            }
+
+            
         }
 
         private void SetupMetadataExport(IGitTfsRemote remote)

--- a/src/GitTfs/Core/DerivedGitTfsRemote.cs
+++ b/src/GitTfs/Core/DerivedGitTfsRemote.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using GitTfs.Core.TfsInterop;
 using GitTfs.Commands;
+using Sep.Git.Tfs.Core.TfsInterop;
 
 namespace GitTfs.Core
 {
@@ -306,6 +307,11 @@ namespace GitTfs.Core
         }
 
         public void Merge(string sourceTfsPath, string targetTfsPath)
+        {
+            throw DerivedRemoteException;
+        }
+
+        public IPendingSet[] QueryPendingSets(TfsChangesetInfo parentChangeset, string[] items, TfsRecursionType recursionType, string queryWorkspace, string queryUser) 
         {
             throw DerivedRemoteException;
         }

--- a/src/GitTfs/Core/GitTfsRemote.cs
+++ b/src/GitTfs/Core/GitTfsRemote.cs
@@ -8,6 +8,7 @@ using System.Text.RegularExpressions;
 using GitTfs.Commands;
 using GitTfs.Core.TfsInterop;
 using GitTfs.Util;
+using Sep.Git.Tfs.Core.TfsInterop;
 
 namespace GitTfs.Core
 {
@@ -224,7 +225,7 @@ namespace GitTfs.Core
 
         public void CleanupWorkspace()
         {
-            Tfs.CleanupWorkspaces(WorkingDirectory);
+            Tfs.CleanupWorkspaces(WorkingDirectory);            
         }
 
         public void CleanupWorkspaceDirectory()
@@ -1043,6 +1044,22 @@ namespace GitTfs.Core
             }
             Trace.WriteLine("Remote created!");
             return tfsRemote;
+        }
+
+        public IPendingSet[] QueryPendingSets(TfsChangesetInfo parentChangeset, string[] items, TfsRecursionType recursionType, string queryWorkspace, string queryUser) 
+        {
+            IPendingSet[] ret = null;
+
+            WithWorkspace(parentChangeset, workspace => 
+            {
+                var workspaceItems = items
+                .Select(x => workspace.GetLocalPath(x))
+                .ToArray();
+
+                ret = Tfs.QueryPendingSets(workspaceItems, recursionType, queryWorkspace, queryUser);
+            });
+
+            return ret;
         }
     }
 }

--- a/src/GitTfs/Core/IGitTfsRemote.cs
+++ b/src/GitTfs/Core/IGitTfsRemote.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using GitTfs.Core.TfsInterop;
 using GitTfs.Commands;
+using Sep.Git.Tfs.Core.TfsInterop;
 
 namespace GitTfs.Core
 {
@@ -80,6 +81,8 @@ namespace GitTfs.Core
         void EnsureTfsAuthenticated();
         bool MatchesUrlAndRepositoryPath(string tfsUrl, string tfsRepositoryPath);
         void DeleteShelveset(string shelvesetName);
+
+        IPendingSet[] QueryPendingSets(TfsChangesetInfo parentChangeset, string[] items, TfsRecursionType recursionType, string queryWorkspace, string queryUser);
     }
 
     public static class IGitTfsRemoteExt

--- a/src/GitTfs/Core/TfsInterop/IPendingChange.cs
+++ b/src/GitTfs/Core/TfsInterop/IPendingChange.cs
@@ -3,5 +3,18 @@ namespace GitTfs.Core.TfsInterop
 {
     public interface IPendingChange
     {
+        string FileName { get; }
+        bool IsLock { get; }
+        TfsLockLevel LockLevel { get; }
+        string LocalItem { get; }
+        string ServerItem { get; }
+    }
+
+    public enum TfsLockLevel 
+    {
+        None = 0,
+        Checkin = 1,
+        CheckOut = 2,
+        Unchanged = 3
     }
 }

--- a/src/GitTfs/Core/TfsInterop/IPendingSet.cs
+++ b/src/GitTfs/Core/TfsInterop/IPendingSet.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using GitTfs.Core.TfsInterop;
+
+namespace Sep.Git.Tfs.Core.TfsInterop 
+{
+    public interface IPendingSet 
+    {
+
+        string Computer { get; }
+        string Name { get; }
+        string OwnerDisplayName { get; }
+        string OwnerName { get; }
+
+        IPendingChange[] PendingChanges { get; }
+    }
+}

--- a/src/GitTfs/Core/TfsInterop/ITfsHelper.cs
+++ b/src/GitTfs/Core/TfsInterop/ITfsHelper.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using GitTfs.Commands;
+using Sep.Git.Tfs.Core.TfsInterop;
 
 namespace GitTfs.Core.TfsInterop
 {
@@ -49,5 +50,7 @@ namespace GitTfs.Core.TfsInterop
         void WithWorkspace(string localDirectory, IGitTfsRemote remote, IEnumerable<Tuple<string, string>> mappings, TfsChangesetInfo versionToFetch, Action<ITfsWorkspace> action);
         int QueueGatedCheckinBuild(Uri value, string buildDefinitionName, string shelvesetName, string checkInTicket);
         void DeleteShelveset(IWorkspace workspace, string shelvesetName);
+
+        IPendingSet[] QueryPendingSets(string[] items, TfsRecursionType recursionType, string queryWorkspace, string queryUser);
     }
 }

--- a/src/GitTfs/GitTfs.csproj
+++ b/src/GitTfs/GitTfs.csproj
@@ -151,6 +151,7 @@
     <Compile Include="Core\Changes\Git\Modify.cs" />
     <Compile Include="Core\Changes\Git\RenameEdit.cs" />
     <Compile Include="Core\CheckinPolicyEvaluator.cs" />
+    <Compile Include="Core\TfsInterop\IPendingSet.cs" />
     <Compile Include="Core\TfsInterop\RootBranch.cs" />
     <Compile Include="Core\TfsLabel.cs" />
     <Compile Include="Core\DerivedGitTfsRemote.cs" />


### PR DESCRIPTION
See #1088

I've added a new `--check-lock` option to `rcheckin`. This option checks all changed files if there is an exclusive (checkout) lock in tfs

Example output:
```
> git-tfs rcheckin --check-lock
Working with tfs remote: default => $/TFS/PATH
Fetching changes from TFS to minimize possibility of late conflict...
error: Some files are exclusive locked.
$/TFS/PATH/.gitignore has been locked (CheckOut) by DOMAIN\USER;WORKSTATION
All the logs could be found in the log file: C:\Users\USER\AppData\Local\git-tfs\git-tfs_log.txt
```

---Please read and delete this text before creating this pull request---
Thanks a lot for the pull request you are going to do!
Please verify that you validate these points:

- [x] indentation is made with 4 spaces
- [x] your pull request contains only changes intended (no refactoring, line return added, ... that could make code review harder. Make another one if you think it is needed...)
- [ ] run and verify that existing tests pass. Add some new units tests, if needed.
- [x] update the documentation, if needed.
- [x] update the [release notes file](../tree/master/doc/release-notes/NEXT.md)

------------------------------------------------------------------------