### PR TITLE
To work for --branches=all option

### DIFF
--- a/src/GitTfs.VsCommon/TfsHelper.Common.cs
+++ b/src/GitTfs.VsCommon/TfsHelper.Common.cs
@@ -445,7 +445,7 @@ namespace GitTfs.VsCommon
                 _allTfsBranches = VersionControl.QueryRootBranchObjects(RecursionType.Full)
                     .ToDictionary(b => b.Properties.RootItem.Item,
                         b => b.Properties.ParentBranch != null ? b.Properties.ParentBranch.Item : null,
-                        (StringComparer.InvariantCultureIgnoreCase));
+                        (StringComparer.OrdinalIgnoreCase));
                 return _allTfsBranches;
             }
         }


### PR DESCRIPTION
With StringComparer.**InvariantCultureIgnoreCase** the fetching of changes with clone command works fine for --branches=none, however not for complex branching.

With StringComparer.**OrdinalIgnoreCase**, even for complex branching the tool is able to fetch changes across branches.

Compiled with VS 2015 Enterprise and it passed. The compiled tool worked fine in TFS 2017.3.