### PR TITLE
RFC: handle "TF14098: Access Denied" exceptions

### DIFF
--- a/doc/commands/fetch.md
+++ b/doc/commands/fetch.md
@@ -31,6 +31,8 @@ The fetch command fetch all the new changesets from a TFS remote
 								 Don't initialize branches that match given regex
 		  --ignore-not-init-branches
 								 Don't initialize additional branches (only use what already was initialized)
+      --ignore-restricted-changesets
+                 Ignore changesets that the TFS user has no read access to
       -u, --username=VALUE       TFS user name
       -p, --password=VALUE       TFS password
 ## Examples

--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -3,3 +3,4 @@
 * ignore-not-init-branches now configurable via commandline flag
 * ignore-branches-regex to configure a filter regex to exclude branches during cloning or fetching with branches
 * fixed bug in detecting of external repositories from the default repository
+* ignore changesets that the TFS user has no read access to with the `--ignore-restricted-changesets` option

--- a/src/GitTfs/Commands/Fetch.cs
+++ b/src/GitTfs/Commands/Fetch.cs
@@ -33,6 +33,7 @@ namespace GitTfs.Commands
         private bool FetchAll { get; set; }
         private bool FetchLabels { get; set; }
         private bool FetchParents { get; set; }
+        private bool IgnoreRestrictedChangesets { get; set; }
         private string BareBranch { get; set; }
         private bool ForceFetch { get; set; }
         private bool ExportMetadatas { get; set; }
@@ -107,6 +108,8 @@ namespace GitTfs.Commands
                         v => IgnoreBranchesRegex = v  },
                     { "ignore-not-init-branches", "Ignore not-initialized branches",
                         v => IgnoreNotInitBranches = v != null },
+                    { "ignore-restricted-changesets", "Ignore restricted changesets",
+                        v => IgnoreRestrictedChangesets = v != null }
                 }.Merge(_remoteOptions.OptionSet);
             }
         }
@@ -199,7 +202,7 @@ namespace GitTfs.Commands
                 {
                     _properties.InitialChangeset = InitialChangeset.Value;
                     _properties.PersistAllOverrides();
-                    remote.QuickFetch(InitialChangeset.Value);
+                    remote.QuickFetch(InitialChangeset.Value, IgnoreRestrictedChangesets);
                     remote.Fetch(stopOnFailMergeCommit, upToChangeSet);
                 }
                 else

--- a/src/GitTfs/Commands/QuickFetch.cs
+++ b/src/GitTfs/Commands/QuickFetch.cs
@@ -21,9 +21,9 @@ namespace GitTfs.Commands
         protected override void DoFetch(IGitTfsRemote remote, bool stopOnFailMergeCommit)
         {
             if (InitialChangeset.HasValue)
-                remote.QuickFetch(InitialChangeset.Value);
+                remote.QuickFetch(InitialChangeset.Value, false, false);
             else
-                remote.QuickFetch();
+                remote.QuickFetch(-1, false, false);
             _properties.InitialChangeset = remote.MaxChangesetId;
             _properties.PersistAllOverrides();
         }

--- a/src/GitTfs/Core/DerivedGitTfsRemote.cs
+++ b/src/GitTfs/Core/DerivedGitTfsRemote.cs
@@ -225,12 +225,7 @@ namespace GitTfs.Core
             throw DerivedRemoteException;
         }
 
-        public void QuickFetch()
-        {
-            throw DerivedRemoteException;
-        }
-
-        public void QuickFetch(int changesetId)
+        public void QuickFetch(int changesetId, bool ignoreRestricted, bool printRestrictionHint)
         {
             throw DerivedRemoteException;
         }

--- a/src/GitTfs/Core/IGitTfsRemote.cs
+++ b/src/GitTfs/Core/IGitTfsRemote.cs
@@ -61,8 +61,7 @@ namespace GitTfs.Core
         string GetPathInGitRepo(string tfsPath);
         IFetchResult Fetch(bool stopOnFailMergeCommit = false, int lastChangesetIdToFetch = -1, IRenameResult renameResult = null);
         IFetchResult FetchWithMerge(int mergeChangesetId, bool stopOnFailMergeCommit = false, IRenameResult renameResult = null, params string[] parentCommitsHashes);
-        void QuickFetch();
-        void QuickFetch(int changesetId);
+        void QuickFetch(int changesetId, bool ignoreRestricted, bool printRestrictionHint = true);
         void Unshelve(string shelvesetOwner, string shelvesetName, string destinationBranch, Action<Exception> ignorableErrorHandler, bool force);
         void Shelve(string shelvesetName, string treeish, TfsChangesetInfo parentChangeset, CheckinOptions options, bool evaluateCheckinPolicies);
         bool HasShelveset(string shelvesetName);


### PR DESCRIPTION
I am working with a TFS repo that I don't have full access to. I am not interested in the parts that I don't have access to and I just want `git-tfs` to ignore these parts. Therefore, I implemented this very basic workaround here. I wonder what you think about the approach? Do you see problems with it? Would that be something you would be willing to merge? Maybe I could mask the workaround behind an option `--ignore-restricted-content` or something?

See also #1033