### PR TITLE
Ignore not init branches

### DIFF
--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -1,1 +1,2 @@
 * Pick up labels that don't have the branch folder specifically listed (#1125)
+* ignore-not-init-branches value is not longer case sensitive

--- a/src/GitTfs/Core/GitTfsRemote.cs
+++ b/src/GitTfs/Core/GitTfsRemote.cs
@@ -631,7 +631,8 @@ namespace GitTfs.Core
                     }
                 }
 
-                if (mergeChangeset && tfsBranch != null && Repository.GetConfig(GitTfsConstants.IgnoreNotInitBranches) == true.ToString())
+                if (mergeChangeset && tfsBranch != null &&
+                    string.Equals(Repository.GetConfig(GitTfsConstants.IgnoreNotInitBranches), true.ToString(), StringComparison.InvariantCultureIgnoreCase))
                 {
                     Trace.TraceInformation("warning: skip not initialized branch for path " + tfsBranch.Path);
                     tfsRemote = null;


### PR DESCRIPTION
ignore-not-init-branches's value is not longer case sensitive.
True, true, False, False etc are all valid.