### PR TITLE
external repository detection fix and usability improvements to exclude branches during clone/fetch

### DIFF
--- a/doc/commands/clone.md
+++ b/doc/commands/clone.md
@@ -41,6 +41,10 @@ a TFS source tree and fetch all the changesets
 								 initialize the merged branches
 								 * all: Manage merged changesets and initialize
 								 all the branches during the clone
+		  --ignore-branches-regex=VALUE
+								 Don't initialize branches that match given regex
+		  --ignore-not-init-branches
+								 Don't initialize additional branches (only use what already was initialized)
 		  --batch-size=VALUE     Size of the batch of tfs changesets fetched (-1 for all in one batch)
       -c, --changeset=VALUE      The changeset to clone from (must be a number)
       -t, --up-to=VALUE          up-to changeset # (optional, -1 for up to 

--- a/doc/commands/fetch.md
+++ b/doc/commands/fetch.md
@@ -27,6 +27,10 @@ The fetch command fetch all the new changesets from a TFS remote
                                    messages
                                    Use this when you're exporting from TFS and
                                    don't need to put data back into TFS.
+		  --ignore-branches-regex=VALUE 
+								 Don't initialize branches that match given regex
+		  --ignore-not-init-branches
+								 Don't initialize additional branches (only use what already was initialized)
       -u, --username=VALUE       TFS user name
       -p, --password=VALUE       TFS password
 ## Examples

--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -1,2 +1,5 @@
 * Pick up labels that don't have the branch folder specifically listed (#1125)
 * ignore-not-init-branches value is not longer case sensitive
+* ignore-not-init-branches now configurable via commandline flag
+* ignore-branches-regex to configure a filter regex to exclude branches during cloning or fetching with branches
+* fixed bug in detecting of external repositories from the default repository

--- a/src/GitTfs/Commands/Fetch.cs
+++ b/src/GitTfs/Commands/Fetch.cs
@@ -131,7 +131,8 @@ namespace GitTfs.Commands
             if (!FetchAll && BranchStrategy == BranchStrategy.None)
                 _globals.Repository.SetConfig(GitTfsConstants.IgnoreBranches, true);
 
-            _globals.Repository.SetConfig(GitTfsConstants.IgnoreBranchesRegex, IgnoreBranchesRegex);
+            if(!string.IsNullOrEmpty(IgnoreBranchesRegex))
+                _globals.Repository.SetConfig(GitTfsConstants.IgnoreBranchesRegex, IgnoreBranchesRegex);
             _globals.Repository.SetConfig(GitTfsConstants.IgnoreNotInitBranches, IgnoreNotInitBranches);
 
             var remotesToFetch = GetRemotesToFetch(args).ToList();

--- a/src/GitTfs/Commands/Fetch.cs
+++ b/src/GitTfs/Commands/Fetch.cs
@@ -38,6 +38,8 @@ namespace GitTfs.Commands
         private bool ExportMetadatas { get; set; }
         private string ExportMetadatasFile { get; set; }
         public BranchStrategy BranchStrategy { get; set; }
+        private string IgnoreBranchesRegex { get; set; }
+        private bool IgnoreNotInitBranches { get; set; }
         public string BatchSizeOption
         {
             set
@@ -100,7 +102,11 @@ namespace GitTfs.Commands
                     { "c|changeset|from=", "The changeset to clone from (must be a number)",
                         v => InitialChangeset = Convert.ToInt32(v) },
                     { "t|up-to|to=", "up-to changeset # (optional, -1 for up to maximum, must be a number, not prefixed with 'C')",
-                        v => UpToChangeSetOption = v }
+                        v => UpToChangeSetOption = v },
+                    { "ignore-branches-regex=", "Don't initialize branches that match given regex",
+                        v => IgnoreBranchesRegex = v  },
+                    { "ignore-not-init-branches", "Ignore not-initialized branches",
+                        v => IgnoreNotInitBranches = v != null },
                 }.Merge(_remoteOptions.OptionSet);
             }
         }
@@ -124,6 +130,9 @@ namespace GitTfs.Commands
         {
             if (!FetchAll && BranchStrategy == BranchStrategy.None)
                 _globals.Repository.SetConfig(GitTfsConstants.IgnoreBranches, true);
+
+            _globals.Repository.SetConfig(GitTfsConstants.IgnoreBranchesRegex, IgnoreBranchesRegex);
+            _globals.Repository.SetConfig(GitTfsConstants.IgnoreNotInitBranches, IgnoreNotInitBranches);
 
             var remotesToFetch = GetRemotesToFetch(args).ToList();
             foreach (var remote in remotesToFetch)

--- a/src/GitTfs/Commands/Init.cs
+++ b/src/GitTfs/Commands/Init.cs
@@ -150,6 +150,7 @@ namespace GitTfs.Commands
             }
 
             _globals.Repository.SetConfig(GitTfsConstants.IgnoreBranches, false);
+            _globals.Repository.SetConfig(GitTfsConstants.IgnoreNotInitBranches, false);
         }
 
         private string[] BuildInitCommand()

--- a/src/GitTfs/Core/GitRepository.cs
+++ b/src/GitTfs/Core/GitRepository.cs
@@ -304,7 +304,8 @@ namespace GitTfs.Core
 
             var teamProjectPath = defaultRepository.TfsRepositoryPath.ToTfsTeamProjectRepositoryPath();
 
-            return tfsRepositoryPath.StartsWith(teamProjectPath);
+            //add ending '/' because there can be overlapping names ($/myproject/ and $/myproject other/)
+            return tfsRepositoryPath.StartsWith(teamProjectPath + "/");
         }
 
         public bool HasRef(string gitRef)

--- a/src/GitTfs/Core/GitTfsRemote.cs
+++ b/src/GitTfs/Core/GitTfsRemote.cs
@@ -630,8 +630,15 @@ namespace GitTfs.Core
                         break;
                     }
                 }
-
-                if (mergeChangeset && tfsBranch != null &&
+                var filterRegex = Repository.GetConfig(GitTfsConstants.IgnoreBranchesRegex);
+                if (mergeChangeset && tfsBranch != null && filterRegex != null
+                    && Regex.IsMatch(tfsBranch.Path, filterRegex, RegexOptions.IgnoreCase))
+                {
+                    Trace.TraceInformation("warning: skip filtered branch for path " + tfsBranch.Path + " (regex:" + filterRegex + ")");
+                    tfsRemote = null;
+                    omittedParentBranch = tfsBranch.Path + ";C" + parentChangesetId;
+                }
+                else if (mergeChangeset && tfsBranch != null &&
                     string.Equals(Repository.GetConfig(GitTfsConstants.IgnoreNotInitBranches), true.ToString(), StringComparison.InvariantCultureIgnoreCase))
                 {
                     Trace.TraceInformation("warning: skip not initialized branch for path " + tfsBranch.Path);

--- a/src/GitTfs/Core/GitTfsRemote.cs
+++ b/src/GitTfs/Core/GitTfsRemote.cs
@@ -631,7 +631,7 @@ namespace GitTfs.Core
                     }
                 }
                 var filterRegex = Repository.GetConfig(GitTfsConstants.IgnoreBranchesRegex);
-                if (mergeChangeset && tfsBranch != null && filterRegex != null
+                if (mergeChangeset && tfsBranch != null && !string.IsNullOrEmpty(filterRegex)
                     && Regex.IsMatch(tfsBranch.Path, filterRegex, RegexOptions.IgnoreCase))
                 {
                     Trace.TraceInformation("warning: skip filtered branch for path " + tfsBranch.Path + " (regex:" + filterRegex + ")");

--- a/src/GitTfs/GitTfsConstants.cs
+++ b/src/GitTfs/GitTfsConstants.cs
@@ -68,6 +68,7 @@ namespace GitTfs
         public const string IgnoreBranches = GitTfsPrefix + ".ignore-branches";
 
         public const string IgnoreNotInitBranches = GitTfsPrefix + ".ignore-not-init-branches";
+        public const string IgnoreBranchesRegex = GitTfsPrefix + ".ignore-branches-regex";
 
         public const string BatchSize = GitTfsPrefix + ".batch-size";
         public static string InitialChangeset = GitTfsPrefix + ".initial-changeset";


### PR DESCRIPTION
fixed bug in external repository detection
improved usability by
- exposing ignore-not-init-branches to commandline
- added ignore-branches-regex to more granularly control which branches to initialize during fetching and cloning