### PR TITLE
Normalize line endings on checkout/tfs push if autocrlf=true

### DIFF
--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -1,4 +1,6 @@
+
 * When cloning a whole TFS Project Collection (``$/``) without specifying a local repository name, clone into "tfs-collection" instead of erroring with "Invalid Path". (#1202 by @0x53A)
 * FindMergeChangesetParent now also takes into account the path of the changes. This should avoid detection of incorrect parent when a changeset has merges in different branches at once. (#1204 by @Laibalion)
 * Provide way to delete all remotes in a single call (#1204 by @Laibalion)
 * Add .net462 and windows10 long path support. See [doc to enable it](../blob/master/doc/Set-custom-workspace.md). (#1221 by @pmiossec)
+* Line endings are now properly normalized when pushing changes to TFS if core.autocrlf is set to true (#1210 by @JeffCyr)

--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -1,4 +1,3 @@
-
 * When cloning a whole TFS Project Collection (``$/``) without specifying a local repository name, clone into "tfs-collection" instead of erroring with "Invalid Path". (#1202 by @0x53A)
 * FindMergeChangesetParent now also takes into account the path of the changes. This should avoid detection of incorrect parent when a changeset has merges in different branches at once. (#1204 by @Laibalion)
 * Provide way to delete all remotes in a single call (#1204 by @Laibalion)

--- a/src/GitTfs/Core/GitRepository.cs
+++ b/src/GitTfs/Core/GitRepository.cs
@@ -542,7 +542,7 @@ namespace GitTfs.Core
             if (!destination.Directory.Exists)
                 destination.Directory.Create();
             if ((blob = _repository.Lookup<Blob>(sha)) != null)
-                using (Stream stream = blob.GetContentStream())
+                using (Stream stream = blob.GetContentStream(new FilteringOptions(string.Empty)))
                 using (var outstream = File.Create(destination.FullName))
                     stream.CopyTo(outstream);
         }

--- a/src/GitTfsTest/Integration/CloneTests.cs
+++ b/src/GitTfsTest/Integration/CloneTests.cs
@@ -307,6 +307,37 @@ namespace GitTfs.Test.Integration
         }
 
         [FactExceptOnUnix]
+        public void LineEndingsNormalizedWhenAutocrlf()
+        {
+            h.SetupFake(r =>
+            {
+                r.Changeset(1, "Project created from template", DateTime.Parse("2012-01-01 12:12:12 -05:00"))
+                    .Change(TfsChangeType.Add, TfsItemType.Folder, "$/MyProject");
+                r.Changeset(2, "Add some files", DateTime.Parse("2012-01-02 12:12:12 -05:00"))
+                 .Change(TfsChangeType.Add, TfsItemType.File, "$/MyProject/README", "tld \r\n another line \r\n");
+            });
+            h.Run("clone", h.TfsUrl, "$/MyProject", "MyProject","--autocrlf=true");
+            
+            h.AssertFileInWorkspace("MyProject", "README", "tld \r\n another line \r\n");
+            h.AssertFileInIndex("MyProject", "README", "tld \n another line \n");
+        }
+        
+        [FactExceptOnUnix]
+        public void LineNotNormalizedWhenAutocrlfFalse()
+        {
+            h.SetupFake(r =>
+            {
+                r.Changeset(1, "Project created from template", DateTime.Parse("2012-01-01 12:12:12 -05:00"))
+                    .Change(TfsChangeType.Add, TfsItemType.Folder, "$/MyProject");
+                r.Changeset(2, "Add some files", DateTime.Parse("2012-01-02 12:12:12 -05:00"))
+                 .Change(TfsChangeType.Add, TfsItemType.File, "$/MyProject/README", "tld \r\n another line \r\n");
+            });
+            h.Run("clone", h.TfsUrl, "$/MyProject", "MyProject", "--autocrlf=false");
+            h.AssertFileInWorkspace("MyProject", "README", "tld \r\n another line \r\n");
+            h.AssertFileInIndex("MyProject", "README", "tld \r\n another line \r\n");
+        }
+
+        [FactExceptOnUnix]
         public void HandlesIgnoredFilesParticipatingInRenames()
         {
             h.SetupFake(r =>

--- a/src/GitTfsTest/Integration/IntegrationHelper.cs
+++ b/src/GitTfsTest/Integration/IntegrationHelper.cs
@@ -367,6 +367,15 @@ namespace GitTfs.Test.Integration
             AssertEqual(contents, actual, "Contents of " + path);
         }
 
+        public void AssertFileInIndex(string repodir, string file, string contents)
+        {
+            var repo = Repository(repodir);
+            var indexEntry = repo.Index.FirstOrDefault(x => x.Path == file);
+            var blob = repo.Lookup<Blob>(indexEntry.Id);
+            var actual = blob.GetContentText();
+            Assert.Equal(contents, actual);
+        }
+
         public void AssertNoFileInWorkspace(string repodir, string file)
         {
             var path = Path.Combine(Workdir, repodir, file);


### PR DESCRIPTION
Fixes #528 
- ~~Default autocrlf is now set to the global core.autocrlf value instead of false~~
- Line endings are now correctly normalized when pushing changes to TFS if autocrlf=true

(Original commit by @sopolenius)
