### PR TITLE
Safer gitignore support

### DIFF
--- a/src/GitTfs/Commands/Clone.cs
+++ b/src/GitTfs/Commands/Clone.cs
@@ -129,7 +129,6 @@ namespace GitTfs.Commands
 
                     retVal = _initBranch.Run();
                 }
-                _globals.Repository.SetConfig(GitTfsConstants.DisableGitignoreSupport, true);
             }
             catch (GitTfsException)
             {

--- a/src/GitTfs/Commands/Fetch.cs
+++ b/src/GitTfs/Commands/Fetch.cs
@@ -131,6 +131,8 @@ namespace GitTfs.Commands
 
         private int Run(bool stopOnFailMergeCommit, params string[] args)
         {
+            UseTheGitIgnoreFile(_remoteOptions.GitIgnorePath);
+
             if (!FetchAll && BranchStrategy == BranchStrategy.None)
                 _globals.Repository.SetConfig(GitTfsConstants.IgnoreBranches, true);
 
@@ -144,6 +146,16 @@ namespace GitTfs.Commands
                 FetchRemote(stopOnFailMergeCommit, remote);
             }
             return 0;
+        }
+
+        private void UseTheGitIgnoreFile(string pathToGitIgnoreFile)
+        {
+            if (string.IsNullOrWhiteSpace(pathToGitIgnoreFile))
+            {
+                Trace.WriteLine("No .gitignore file specified to use...");
+                return;
+            }
+            _globals.Repository.UseGitIgnore(pathToGitIgnoreFile);
         }
 
         private void FetchRemote(bool stopOnFailMergeCommit, IGitTfsRemote remote)

--- a/src/GitTfs/Commands/Init.cs
+++ b/src/GitTfs/Commands/Init.cs
@@ -52,6 +52,7 @@ namespace GitTfs.Commands
             VerifyGitUserConfig();
             SaveAuthorFileInRepository();
             CommitTheGitIgnoreFile(_remoteOptions.GitIgnorePath);
+            UseTheGitIgnoreFile(_remoteOptions.GitIgnorePath);
             GitTfsInit(tfsUrl, tfsRepositoryPath);
             return 0;
         }
@@ -80,10 +81,20 @@ namespace GitTfs.Commands
         {
             if (string.IsNullOrWhiteSpace(pathToGitIgnoreFile))
             {
-                Trace.WriteLine("No .gitignore file specified...");
+                Trace.WriteLine("No .gitignore file specified to commit...");
                 return;
             }
             _globals.Repository.CommitGitIgnore(pathToGitIgnoreFile);
+        }
+
+        private void UseTheGitIgnoreFile(string pathToGitIgnoreFile)
+        {
+            if (string.IsNullOrWhiteSpace(pathToGitIgnoreFile))
+            {
+                Trace.WriteLine("No .gitignore file specified to use...");
+                return;
+            }
+            _globals.Repository.UseGitIgnore(pathToGitIgnoreFile);
         }
 
         public int Run(string tfsUrl, string tfsRepositoryPath, string gitRepositoryPath)

--- a/src/GitTfs/Commands/Init.cs
+++ b/src/GitTfs/Commands/Init.cs
@@ -51,7 +51,7 @@ namespace GitTfs.Commands
             DoGitInitDb();
             VerifyGitUserConfig();
             SaveAuthorFileInRepository();
-            CommitTheGitIgnoreFile(_initOptions.GitIgnorePath);
+            CommitTheGitIgnoreFile(_remoteOptions.GitIgnorePath);
             GitTfsInit(tfsUrl, tfsRepositoryPath);
             return 0;
         }

--- a/src/GitTfs/Commands/InitOptions.cs
+++ b/src/GitTfs/Commands/InitOptions.cs
@@ -27,7 +27,6 @@ namespace GitTfs.Commands
                         v => GitInitIgnoreCase = ValidateIgnoreCaseValue(v) },
                     {"bare", "Clone the TFS repository in a bare git repository", v => IsBare = v != null},
                     {"workspace=", "Set tfs workspace to a specific folder (a shorter path is better!)", v => WorkspacePath = v},
-                    {"gitignore=", "Path toward the .gitignore file which be committed and used to ignore files", v => GitIgnorePath = v},
                 };
             }
         }
@@ -55,6 +54,5 @@ namespace GitTfs.Commands
         public object GitInitShared { get; set; }
         public string GitInitAutoCrlf { get; set; }
         public string GitInitIgnoreCase { get; set; }
-        public string GitIgnorePath { get; set; }
     }
 }

--- a/src/GitTfs/Commands/RemoteOptions.cs
+++ b/src/GitTfs/Commands/RemoteOptions.cs
@@ -16,8 +16,8 @@ namespace GitTfs.Commands
                         v => IgnoreRegex = v },
                     { "except-regex=", "A regex of exceptions to '--ignore-regex'",
                         v => ExceptRegex = v},
-                    { "gitignore=", "Path toward the .gitignore file which will be used to ignore files",
-                        v => GitIgnorePath = v },
+                    { "gitignore:", "Use .gitignore to ignore files on download from TFS. Alternatively, provide path toward the .gitignore file which will be used to ignore files",
+                        v => { GitIgnorePath = v; UseGitIgnore = true; } },
                     { "u|username=", "TFS username",
                         v => Username = v },
                     { "p|password=", "TFS password",
@@ -31,6 +31,7 @@ namespace GitTfs.Commands
         public string IgnoreRegex { get; set; }
         public string ExceptRegex { get; set; }
         public string GitIgnorePath { get; set; }
+        public bool UseGitIgnore { get; set; }
         public string Username { get; set; }
         public string Password { get; set; }
         public bool NoParallel { get; set; }

--- a/src/GitTfs/Commands/RemoteOptions.cs
+++ b/src/GitTfs/Commands/RemoteOptions.cs
@@ -16,6 +16,8 @@ namespace GitTfs.Commands
                         v => IgnoreRegex = v },
                     { "except-regex=", "A regex of exceptions to '--ignore-regex'",
                         v => ExceptRegex = v},
+                    { "gitignore=", "Path toward the .gitignore file which will be used to ignore files",
+                        v => GitIgnorePath = v },
                     { "u|username=", "TFS username",
                         v => Username = v },
                     { "p|password=", "TFS password",
@@ -28,6 +30,7 @@ namespace GitTfs.Commands
 
         public string IgnoreRegex { get; set; }
         public string ExceptRegex { get; set; }
+        public string GitIgnorePath { get; set; }
         public string Username { get; set; }
         public string Password { get; set; }
         public bool NoParallel { get; set; }

--- a/src/GitTfs/Commands/RemoteOptions.cs
+++ b/src/GitTfs/Commands/RemoteOptions.cs
@@ -18,6 +18,8 @@ namespace GitTfs.Commands
                         v => ExceptRegex = v},
                     { "gitignore:", "Use .gitignore to ignore files on download from TFS. Alternatively, provide path toward the .gitignore file which will be used to ignore files",
                         v => { GitIgnorePath = v; UseGitIgnore = true; } },
+                    { "no-gitignore", "Do not use .gitignore to ignore files on download from TFS",
+                        v => NoGitIgnore = v != null },
                     { "u|username=", "TFS username",
                         v => Username = v },
                     { "p|password=", "TFS password",
@@ -32,6 +34,7 @@ namespace GitTfs.Commands
         public string ExceptRegex { get; set; }
         public string GitIgnorePath { get; set; }
         public bool UseGitIgnore { get; set; }
+        public bool NoGitIgnore { get; set; }
         public string Username { get; set; }
         public string Password { get; set; }
         public bool NoParallel { get; set; }

--- a/src/GitTfs/Commands/Verify.cs
+++ b/src/GitTfs/Commands/Verify.cs
@@ -15,15 +15,17 @@ namespace GitTfs.Commands
     [Description("verify [options] [commitish]\n   ex: git-tfs verify\n       git-tfs verify 889ad74c162\n       git-tfs verify tfs/mybranch\n       git-tfs verify --all")]
     public class Verify : GitTfsCommand
     {
+        private readonly RemoteOptions _remoteOptions;
         private readonly Help _helper;
         private readonly Globals _globals;
         private readonly TreeVerifier _verifier;
 
-        public Verify(Globals globals, TreeVerifier verifier, Help helper)
+        public Verify(Globals globals, TreeVerifier verifier, Help helper, RemoteOptions remoteOptions)
         {
             _globals = globals;
             _verifier = verifier;
             _helper = helper;
+            _remoteOptions = remoteOptions;
         }
 
         public OptionSet OptionSet
@@ -31,12 +33,12 @@ namespace GitTfs.Commands
             get
             {
                 return new OptionSet()
-            {
+                {
                     { "ignore-path-case-mismatch", "Ignore the case mismatch in the path when comparing the files.",
                         v => IgnorePathCaseMismatch = v != null },
                     { "all", "Verify all the tfs remotes",
                         v => VerifyAllRemotes = v != null },
-            };
+                }.Merge(_remoteOptions.OptionSet);
             }
         }
 

--- a/src/GitTfs/Core/DerivedGitTfsRemote.cs
+++ b/src/GitTfs/Core/DerivedGitTfsRemote.cs
@@ -211,6 +211,16 @@ namespace GitTfs.Core
             throw DerivedRemoteException;
         }
 
+        public bool IsIgnored(string path)
+        {
+            throw DerivedRemoteException;
+        }
+
+        public bool IsInDotGit(string path)
+        {
+            throw DerivedRemoteException;
+        }
+
         public IGitTfsRemote InitBranch(RemoteOptions remoteOptions, string tfsRepositoryPath, int shaRootChangesetId, bool fetchParentBranch, string gitBranchNameExpected = null, IRenameResult renameResult = null)
         {
             throw new NotImplementedException();

--- a/src/GitTfs/Core/DerivedGitTfsRemote.cs
+++ b/src/GitTfs/Core/DerivedGitTfsRemote.cs
@@ -138,6 +138,12 @@ namespace GitTfs.Core
             set { throw DerivedRemoteException; }
         }
 
+        public string GitIgnorePath
+        {
+            get { throw DerivedRemoteException; }
+            set { throw DerivedRemoteException; }
+        }
+
         public IGitRepository Repository
         {
             get { throw DerivedRemoteException; }

--- a/src/GitTfs/Core/GitRepository.cs
+++ b/src/GitTfs/Core/GitRepository.cs
@@ -789,11 +789,15 @@ namespace GitTfs.Core
 
             _repository.Refs.Add(ShortToTfsRemoteName("default"), new ObjectId(sha));
             _repository.Refs.Add(ShortToLocalName("master"), new ObjectId(sha));
+
+            return sha;
+        }
+
+        public void UseGitIgnore(string pathToGitIgnoreFile)
+        {
             //Should add ourself the rules to the temporary rules because committing directly to the git database
             //prevent libgit2sharp to detect the new .gitignore file
             _repository.Ignore.AddTemporaryRules(File.ReadLines(pathToGitIgnoreFile));
-
-            return sha;
         }
 
         public IDictionary<int, string> GetCommitChangeSetPairs()

--- a/src/GitTfs/Core/GitRepository.cs
+++ b/src/GitTfs/Core/GitRepository.cs
@@ -19,7 +19,6 @@ namespace GitTfs.Core
         private IDictionary<string, IGitTfsRemote> _cachedRemotes;
         private readonly Repository _repository;
         private readonly RemoteConfigConverter _remoteConfigReader;
-        private readonly bool _disableGitignoreSupport;
 
         public GitRepository(string gitDir, IContainer container, Globals globals, RemoteConfigConverter remoteConfigReader)
             : base(container)
@@ -29,12 +28,6 @@ namespace GitTfs.Core
             GitDir = gitDir;
             _repository = new Repository(GitDir);
             _remoteConfigReader = remoteConfigReader;
-
-            var value = GetConfig<string>(GitTfsConstants.DisableGitignoreSupport, null);
-            bool disableGitignoreSupport;
-            if (value != null && bool.TryParse(value, out disableGitignoreSupport))
-                _disableGitignoreSupport = disableGitignoreSupport;
-
         }
 
         ~GitRepository()
@@ -778,7 +771,7 @@ namespace GitTfs.Core
 
         public bool IsPathIgnored(string relativePath)
         {
-            return !_disableGitignoreSupport && _repository.Ignore.IsPathIgnored(relativePath);
+            return _repository.Ignore.IsPathIgnored(relativePath);
         }
 
         public string CommitGitIgnore(string pathToGitIgnoreFile)

--- a/src/GitTfs/Core/GitTfsRemote.cs
+++ b/src/GitTfs/Core/GitTfsRemote.cs
@@ -56,6 +56,8 @@ namespace GitTfs.Core
             }
             else
             {
+                _disableGitignoreSupport = true;
+
                 var value = Repository.GetConfig<string>(GitTfsConstants.DisableGitignoreSupport, null);
                 bool disableGitignoreSupport;
                 if (value != null && bool.TryParse(value, out disableGitignoreSupport))

--- a/src/GitTfs/Core/GitTfsRemote.cs
+++ b/src/GitTfs/Core/GitTfsRemote.cs
@@ -44,7 +44,7 @@ namespace GitTfs.Core
             IgnoreRegexExpression = info.IgnoreRegex;
             IgnoreExceptRegexExpression = info.IgnoreExceptRegex;
             GitIgnorePath = _remoteOptions.GitIgnorePath ?? info.GitIgnorePath;
-            UseGitIgnore = _remoteOptions.UseGitIgnore || IsGitIgnoreSupportEnabled();
+            UseGitIgnore = !_remoteOptions.NoGitIgnore && (_remoteOptions.UseGitIgnore || IsGitIgnoreSupportEnabled());
 
             Autotag = info.Autotag;
 

--- a/src/GitTfs/Core/GitTfsRemote.cs
+++ b/src/GitTfs/Core/GitTfsRemote.cs
@@ -265,7 +265,7 @@ namespace GitTfs.Core
             return IsInDotGit(path) || IsIgnored(path);
         }
 
-        private bool IsIgnored(string path)
+        public bool IsIgnored(string path)
         {
             return Ignorance.IsIncluded(path) || IsPathIgnored(path);
         }
@@ -292,7 +292,7 @@ namespace GitTfs.Core
             }
         }
 
-        private bool IsInDotGit(string path)
+        public bool IsInDotGit(string path)
         {
             return isInDotGit.IsMatch(path);
         }

--- a/src/GitTfs/Core/GitTfsRemote.cs
+++ b/src/GitTfs/Core/GitTfsRemote.cs
@@ -44,29 +44,23 @@ namespace GitTfs.Core
             IgnoreRegexExpression = info.IgnoreRegex;
             IgnoreExceptRegexExpression = info.IgnoreExceptRegex;
             GitIgnorePath = _remoteOptions.GitIgnorePath ?? info.GitIgnorePath;
-
-            if (_remoteOptions.UseGitIgnore)
-            {
-                // To provide expected single run effect of explicitly provided
-                // `--gitignore` option, even in situation where .gitignore
-                // support would otherwise be disabled through configuration,
-                // allow overriding `disable-gitignore-support` setting,
-                // forcing enabled .gitignore support for the command duration
-                _disableGitignoreSupport = false;
-            }
-            else
-            {
-                _disableGitignoreSupport = true;
-
-                var value = Repository.GetConfig<string>(GitTfsConstants.DisableGitignoreSupport, null);
-                bool disableGitignoreSupport;
-                if (value != null && bool.TryParse(value, out disableGitignoreSupport))
-                    _disableGitignoreSupport = disableGitignoreSupport;
-            }
+            UseGitIgnore = _remoteOptions.UseGitIgnore || IsGitIgnoreSupportEnabled();
 
             Autotag = info.Autotag;
 
             IsSubtree = CheckSubtree();
+        }
+
+        private bool IsGitIgnoreSupportEnabled()
+        {
+            var isGitIgnoreSupportDisabled = true;
+
+            var value = Repository.GetConfig<string>(GitTfsConstants.DisableGitignoreSupport, null);
+            bool disableGitignoreSupport;
+            if (value != null && bool.TryParse(value, out disableGitignoreSupport))
+                isGitIgnoreSupportDisabled = disableGitignoreSupport;
+
+            return !isGitIgnoreSupportDisabled;
         }
 
         private bool CheckSubtree()
@@ -161,6 +155,7 @@ namespace GitTfs.Core
         public string IgnoreRegexExpression { get; set; }
         public string IgnoreExceptRegexExpression { get; set; }
         public string GitIgnorePath { get; set; }
+        public bool UseGitIgnore { get; set; }
         public IGitRepository Repository { get; set; }
         public ITfsHelper Tfs { get; set; }
 
@@ -277,7 +272,7 @@ namespace GitTfs.Core
 
         private bool IsPathIgnored(string path)
         {
-            return !_disableGitignoreSupport && Repository.IsPathIgnored(path);
+            return UseGitIgnore && Repository.IsPathIgnored(path);
         }
 
         private Bouncer _ignorance;

--- a/src/GitTfs/Core/GitTfsRemote.cs
+++ b/src/GitTfs/Core/GitTfsRemote.cs
@@ -45,10 +45,22 @@ namespace GitTfs.Core
             IgnoreExceptRegexExpression = info.IgnoreExceptRegex;
             GitIgnorePath = _remoteOptions.GitIgnorePath ?? info.GitIgnorePath;
 
-            var value = Repository.GetConfig<string>(GitTfsConstants.DisableGitignoreSupport, null);
-            bool disableGitignoreSupport;
-            if (value != null && bool.TryParse(value, out disableGitignoreSupport))
-                _disableGitignoreSupport = disableGitignoreSupport;
+            if (!string.IsNullOrEmpty(_remoteOptions.GitIgnorePath))
+            {
+                // To provide expected single run effect of explicitly provided
+                // `--gitignore` option, even in situation where .gitignore
+                // support would otherwise be disabled through configuration,
+                // allow overriding `disable-gitignore-support` setting,
+                // forcing enabled .gitignore support for the command duration
+                _disableGitignoreSupport = false;
+            }
+            else
+            {
+                var value = Repository.GetConfig<string>(GitTfsConstants.DisableGitignoreSupport, null);
+                bool disableGitignoreSupport;
+                if (value != null && bool.TryParse(value, out disableGitignoreSupport))
+                    _disableGitignoreSupport = disableGitignoreSupport;
+            }
 
             Autotag = info.Autotag;
 

--- a/src/GitTfs/Core/GitTfsRemote.cs
+++ b/src/GitTfs/Core/GitTfsRemote.cs
@@ -42,6 +42,7 @@ namespace GitTfs.Core
             Aliases = (info.Aliases ?? Enumerable.Empty<string>()).ToArray();
             IgnoreRegexExpression = info.IgnoreRegex;
             IgnoreExceptRegexExpression = info.IgnoreExceptRegex;
+            GitIgnorePath = _remoteOptions.GitIgnorePath ?? info.GitIgnorePath;
 
             Autotag = info.Autotag;
 
@@ -139,6 +140,7 @@ namespace GitTfs.Core
 
         public string IgnoreRegexExpression { get; set; }
         public string IgnoreExceptRegexExpression { get; set; }
+        public string GitIgnorePath { get; set; }
         public IGitRepository Repository { get; set; }
         public ITfsHelper Tfs { get; set; }
 

--- a/src/GitTfs/Core/GitTfsRemote.cs
+++ b/src/GitTfs/Core/GitTfsRemote.cs
@@ -45,7 +45,7 @@ namespace GitTfs.Core
             IgnoreExceptRegexExpression = info.IgnoreExceptRegex;
             GitIgnorePath = _remoteOptions.GitIgnorePath ?? info.GitIgnorePath;
 
-            if (!string.IsNullOrEmpty(_remoteOptions.GitIgnorePath))
+            if (_remoteOptions.UseGitIgnore)
             {
                 // To provide expected single run effect of explicitly provided
                 // `--gitignore` option, even in situation where .gitignore

--- a/src/GitTfs/Core/GitTfsRemote.cs
+++ b/src/GitTfs/Core/GitTfsRemote.cs
@@ -250,13 +250,7 @@ namespace GitTfs.Core
 
         private bool IsIgnored(string path)
         {
-            var isIgnored = Ignorance.IsIncluded(path) || Repository.IsPathIgnored(path);
-            if (isIgnored)
-            {
-                Trace.TraceWarning("The file '{0}' is ignored due to `.gitignore` or ignore regex defined.", path);
-            }
-
-            return isIgnored;
+            return Ignorance.IsIncluded(path) || Repository.IsPathIgnored(path);
         }
 
         private Bouncer _ignorance;

--- a/src/GitTfs/Core/IGitRepository.cs
+++ b/src/GitTfs/Core/IGitRepository.cs
@@ -62,6 +62,7 @@ namespace GitTfs.Core
         IEnumerable<GitCommit> FindParentCommits(string fromCommit, string toCommit);
         bool IsPathIgnored(string relativePath);
         string CommitGitIgnore(string pathToGitIgnoreFile);
+        void UseGitIgnore(string pathToGitIgnoreFile);
         IDictionary<int, string> GetCommitChangeSetPairs();
     }
 }

--- a/src/GitTfs/Core/IGitTfsRemote.cs
+++ b/src/GitTfs/Core/IGitTfsRemote.cs
@@ -58,6 +58,8 @@ namespace GitTfs.Core
         int? GetFirstChangeset();
         void SetFirstChangeset(int? changesetId);
         bool ShouldSkip(string path);
+        bool IsIgnored(string path);
+        bool IsInDotGit(string path);
         IGitTfsRemote InitBranch(RemoteOptions remoteOptions, string tfsRepositoryPath, int rootChangesetId = -1, bool fetchParentBranch = false, string gitBranchNameExpected = null, IRenameResult renameResult = null);
         string GetPathInGitRepo(string tfsPath);
         IFetchResult Fetch(bool stopOnFailMergeCommit = false, int lastChangesetIdToFetch = -1, IRenameResult renameResult = null);

--- a/src/GitTfs/Core/IGitTfsRemote.cs
+++ b/src/GitTfs/Core/IGitTfsRemote.cs
@@ -40,6 +40,7 @@ namespace GitTfs.Core
         string[] TfsSubtreePaths { get; }
         string IgnoreRegexExpression { get; set; }
         string IgnoreExceptRegexExpression { get; set; }
+        string GitIgnorePath { get; set; }
         bool Autotag { get; set; }
         string TfsUsername { get; set; }
         string TfsPassword { get; set; }

--- a/src/GitTfs/Core/RemoteConfigConverter.cs
+++ b/src/GitTfs/Core/RemoteConfigConverter.cs
@@ -31,6 +31,8 @@ namespace GitTfs.Core
                         remote.IgnoreRegex = entry.Value;
                     else if (key == "ignore-except")
                         remote.IgnoreExceptRegex = entry.Value;
+                    else if (key == "gitignore-path")
+                        remote.GitIgnorePath = entry.Value;
                     else if (key == "legacy-urls")
                         remote.Aliases = entry.Value.Split(',');
                     else if (key == "autotag")
@@ -53,6 +55,7 @@ namespace GitTfs.Core
                 yield return c(prefix + "password", remote.Password);
                 yield return c(prefix + "ignore-paths", remote.IgnoreRegex);
                 yield return c(prefix + "ignore-except", remote.IgnoreExceptRegex);
+                yield return c(prefix + "gitignore-path", remote.GitIgnorePath);
                 yield return c(prefix + "legacy-urls", remote.Aliases == null ? null : string.Join(",", remote.Aliases));
                 yield return c(prefix + "autotag", remote.Autotag ? "true" : null);
                 yield return c(prefix + "noparallel", remote.NoParallel ? "true" : null);

--- a/src/GitTfs/Core/RemoteInfo.cs
+++ b/src/GitTfs/Core/RemoteInfo.cs
@@ -12,14 +12,15 @@ namespace GitTfs.Core
         public string Password { get; set; }
         public string IgnoreRegex { get; set; }
         public string IgnoreExceptRegex { get; set; }
+        public string GitIgnorePath { get; set; }
         public IEnumerable<string> Aliases { get; set; }
         public bool Autotag { get; set; }
         public bool NoParallel { get; set; }
 
         public RemoteOptions RemoteOptions
         {
-            get { return new RemoteOptions { IgnoreRegex = IgnoreRegex, ExceptRegex = IgnoreExceptRegex, Username = Username, Password = Password, NoParallel = NoParallel }; }
-            set { IgnoreRegex = value.IgnoreRegex; IgnoreExceptRegex = value.ExceptRegex; Username = value.Username; Password = value.Password; NoParallel = value.NoParallel; }
+            get { return new RemoteOptions { IgnoreRegex = IgnoreRegex, ExceptRegex = IgnoreExceptRegex, GitIgnorePath = GitIgnorePath, Username = Username, Password = Password, NoParallel = NoParallel }; }
+            set { IgnoreRegex = value.IgnoreRegex; IgnoreExceptRegex = value.ExceptRegex; GitIgnorePath = value.GitIgnorePath; Username = value.Username; Password = value.Password; NoParallel = value.NoParallel; }
         }
     }
 }

--- a/src/GitTfs/Core/TfsChangeset.cs
+++ b/src/GitTfs/Core/TfsChangeset.cs
@@ -56,6 +56,9 @@ namespace GitTfs.Core
                 case ChangeType.Delete:
                     Delete(change.GitPath, treeBuilder, initialTree);
                     break;
+                case ChangeType.Ignore:
+                    Ignore(change.GitPath);
+                    break;
                 default:
                     throw new NotImplementedException("Unsupported change type: " + change.Type);
             }
@@ -72,6 +75,11 @@ namespace GitTfs.Core
             {
                 Trace.TraceInformation("Cannot checkout file '{0}' from TFS. Skip it", change.GitPath);
             }
+        }
+
+        private void Ignore(string pathInGitRepo)
+        {
+            Trace.TraceInformation(string.Format("C{0} ! No changes applied to '{1}', file ignored", _changeset.ChangesetId, pathInGitRepo));
         }
 
         public IEnumerable<TfsTreeEntry> GetTree()

--- a/src/GitTfs/Core/TfsChangeset.cs
+++ b/src/GitTfs/Core/TfsChangeset.cs
@@ -36,8 +36,7 @@ namespace GitTfs.Core
                 IsRenameChangeset = true;
             }
             _changeset.Get(workspace, sieve.GetChangesToFetch(), ignorableErrorHandler);
-            var forceGetChanges = lastCommit == null;
-            foreach (var change in sieve.GetChangesToApply(forceGetChanges))
+            foreach (var change in sieve.GetChangesToApply())
             {
                 ignorableErrorHandler.Catch(() =>
                 {

--- a/src/GitTfs/Util/ChangeSieve.cs
+++ b/src/GitTfs/Util/ChangeSieve.cs
@@ -171,6 +171,26 @@ namespace GitTfs.Util
             return isBranchOrMerge && !isContentChange;
         }
 
+        private bool IsGitPathInDotGit(NamedChange change)
+        {
+            return IsInDotGit(change.GitPath);
+        }
+
+        private bool IsInDotGit(string path)
+        {
+            return _resolver.IsInDotGit(path);
+        }
+
+        private bool IsGitPathIgnored(NamedChange change)
+        {
+            return IsIgnored(change.GitPath);
+        }
+
+        private bool IsIgnored(string path)
+        {
+            return _resolver.IsIgnored(path);
+        }
+
         private bool IncludeInApply(NamedChange change)
         {
             return IncludeInFetch(change) && change.Change.Item.DeletionId == 0;

--- a/src/GitTfs/Util/ChangeSieve.cs
+++ b/src/GitTfs/Util/ChangeSieve.cs
@@ -98,22 +98,24 @@ namespace GitTfs.Util
                     if (change.GitPath != null)
                         compartments.Deleted.Add(ApplicableChange.Delete(change.GitPath));
                 }
-                else if (change.Change.ChangeType.IncludesOneOf(TfsChangeType.Rename))
-                {
-                    var oldInfo = _resolver.GetGitObject(GetPathBeforeRename(change.Change.Item));
-                    if (oldInfo != null)
-                        compartments.Deleted.Add(ApplicableChange.Delete(oldInfo.Path));
-                    if (IncludeInApply(change))
-                    {
-                        compartments.Updated.Add(ApplicableChange.Update(change.GitPath,
-                            oldInfo != null ? oldInfo.Mode : Mode.NonExecutableFile));
-                    }
-                }
                 else
                 {
+                    var mode = change.Info != null ? change.Info.Mode : Mode.NonExecutableFile;
+
+                    if (change.Change.ChangeType.IncludesOneOf(TfsChangeType.Rename))
+                    {
+                        var oldInfo = _resolver.GetGitObject(GetPathBeforeRename(change.Change.Item));
+                        if (oldInfo != null)
+                        {
+                            compartments.Deleted.Add(ApplicableChange.Delete(oldInfo.Path));
+
+                            mode = oldInfo.Mode;
+                        }
+                    }
+
                     if (IncludeInApply(change))
                     {
-                        compartments.Updated.Add(ApplicableChange.Update(change.GitPath, change.Info.Mode));
+                        compartments.Updated.Add(ApplicableChange.Update(change.GitPath, mode));
                     }
                 }
             }

--- a/src/GitTfs/Util/ChangeSieve.cs
+++ b/src/GitTfs/Util/ChangeSieve.cs
@@ -95,7 +95,7 @@ namespace GitTfs.Util
 
                 if (change.Change.ChangeType.IncludesOneOf(TfsChangeType.Delete))
                 {
-                    if (change.GitPath != null)
+                    if (!IsGitPathMissing(change))
                         compartments.Deleted.Add(ApplicableChange.Delete(change.GitPath));
                 }
                 else
@@ -161,7 +161,9 @@ namespace GitTfs.Util
                 return false;
             }
 
-            return _resolver.ShouldIncludeGitItem(change.GitPath);
+            return !IsGitPathMissing(change)
+                && !IsGitPathInDotGit(change)
+                && !IsGitPathIgnored(change);
         }
 
         private bool IgnorableChangeType(TfsChangeType changeType)
@@ -169,6 +171,11 @@ namespace GitTfs.Util
             var isBranchOrMerge = (changeType & (TfsChangeType.Branch | TfsChangeType.Merge)) != 0;
             var isContentChange = (changeType & TfsChangeType.Content) != 0;
             return isBranchOrMerge && !isContentChange;
+        }
+
+        private bool IsGitPathMissing(NamedChange change)
+        {
+            return string.IsNullOrEmpty(change.GitPath);
         }
 
         private bool IsGitPathInDotGit(NamedChange change)

--- a/src/GitTfs/Util/ChangeSieve.cs
+++ b/src/GitTfs/Util/ChangeSieve.cs
@@ -113,7 +113,11 @@ namespace GitTfs.Util
                         }
                     }
 
-                    if (IncludeInApply(change))
+                    if (!IsItemDeleted(change)
+                        && !IsGitPathMissing(change)
+                        && !IsGitPathInDotGit(change)
+                        && !IsGitPathIgnored(change)
+                        && !IsIgnorable(change))
                     {
                         compartments.Updated.Add(ApplicableChange.Update(change.GitPath, mode));
                     }
@@ -197,11 +201,6 @@ namespace GitTfs.Util
         private bool IsIgnored(string path)
         {
             return _resolver.IsIgnored(path);
-        }
-
-        private bool IncludeInApply(NamedChange change)
-        {
-            return !IsItemDeleted(change) && IncludeInFetch(change);
         }
 
         private bool IsItemDeleted(NamedChange change)

--- a/src/GitTfs/Util/ChangeSieve.cs
+++ b/src/GitTfs/Util/ChangeSieve.cs
@@ -201,7 +201,17 @@ namespace GitTfs.Util
 
         private bool IncludeInApply(NamedChange change)
         {
-            return IncludeInFetch(change) && change.Change.Item.DeletionId == 0;
+            return !IsItemDeleted(change) && IncludeInFetch(change);
+        }
+
+        private bool IsItemDeleted(NamedChange change)
+        {
+            return IsDeleted(change.Change.Item);
+        }
+
+        private bool IsDeleted(IItem item)
+        {
+            return item.DeletionId != 0;
         }
 
         private string GetPathBeforeRename(IItem item)

--- a/src/GitTfs/Util/ChangeSieve.cs
+++ b/src/GitTfs/Util/ChangeSieve.cs
@@ -76,8 +76,7 @@ namespace GitTfs.Util
         /// <summary>
         /// Get all the changes of a changeset to apply
         /// </summary>
-        /// <param name="forceGetChanges">true - force get changes ignoring check what should be applied. </param>
-        public IEnumerable<ApplicableChange> GetChangesToApply(bool forceGetChanges = false)
+        public IEnumerable<ApplicableChange> GetChangesToApply()
         {
             if (DeletesProject)
                 return Enumerable.Empty<ApplicableChange>();
@@ -112,11 +111,8 @@ namespace GitTfs.Util
                 }
                 else
                 {
-                    if (forceGetChanges || IncludeInApply(change))
+                    if (IncludeInApply(change))
                     {
-                        // for get changes only on first change set
-                        forceGetChanges = false;
-
                         compartments.Updated.Add(ApplicableChange.Update(change.GitPath, change.Info.Mode));
                     }
                 }

--- a/src/GitTfs/Util/ChangeSieve.cs
+++ b/src/GitTfs/Util/ChangeSieve.cs
@@ -156,15 +156,16 @@ namespace GitTfs.Util
 
         private bool IncludeInFetch(NamedChange change)
         {
-            if (IgnorableChangeType(change.Change.ChangeType) && _resolver.Contains(change.GitPath))
-            {
-                return false;
-            }
-
-            return !IsGitPathMissing(change)
+            return !IsIgnorable(change)
+                && !IsGitPathMissing(change)
                 && !IsGitPathInDotGit(change)
                 && !IsGitPathIgnored(change);
         }
+
+        private bool IsIgnorable(NamedChange change)
+        {
+            return IgnorableChangeType(change.Change.ChangeType) && _resolver.Contains(change.GitPath);
+         }
 
         private bool IgnorableChangeType(TfsChangeType changeType)
         {

--- a/src/GitTfs/Util/PathResolver.cs
+++ b/src/GitTfs/Util/PathResolver.cs
@@ -35,7 +35,7 @@ namespace GitTfs.Util
 
         public bool ShouldIncludeGitItem(string gitPath)
         {
-            return !string.IsNullOrEmpty(gitPath) && !_remote.ShouldSkip(gitPath);
+            return !string.IsNullOrEmpty(gitPath) && !IsInDotGit(gitPath) && !IsIgnored(gitPath);
         }
 
         public bool IsIgnored(string path)

--- a/src/GitTfs/Util/PathResolver.cs
+++ b/src/GitTfs/Util/PathResolver.cs
@@ -33,11 +33,6 @@ namespace GitTfs.Util
             return Lookup(pathInGitRepo);
         }
 
-        public bool ShouldIncludeGitItem(string gitPath)
-        {
-            return !string.IsNullOrEmpty(gitPath) && !IsInDotGit(gitPath) && !IsIgnored(gitPath);
-        }
-
         public bool IsIgnored(string path)
         {
             return _remote.IsIgnored(path);

--- a/src/GitTfs/Util/PathResolver.cs
+++ b/src/GitTfs/Util/PathResolver.cs
@@ -38,6 +38,16 @@ namespace GitTfs.Util
             return !string.IsNullOrEmpty(gitPath) && !_remote.ShouldSkip(gitPath);
         }
 
+        public bool IsIgnored(string path)
+        {
+            return _remote.IsIgnored(path);
+        }
+
+        public bool IsInDotGit(string path)
+        {
+            return _remote.IsInDotGit(path);
+        }
+
         public bool Contains(string pathInGitRepo)
         {
             if (pathInGitRepo != null)

--- a/src/GitTfsTest/Core/ChangeSieveTests.cs
+++ b/src/GitTfsTest/Core/ChangeSieveTests.cs
@@ -351,7 +351,10 @@ namespace GitTfs.Test.Core
                     ApplicableChange.Delete("5-wasincluded.txt"),
                     ApplicableChange.Delete("6-wasignored.txt"),
                     ApplicableChange.Update("2-included.txt"),
-                    ApplicableChange.Update("6-included.txt"));
+                    ApplicableChange.Update("6-included.txt"),
+                    ApplicableChange.Ignore("0-ignored.txt"),
+                    ApplicableChange.Ignore("4-ignored.txt"),
+                    ApplicableChange.Ignore("5-ignored.txt"));
             }
         }
 

--- a/src/GitTfsTest/Core/ChangeSieveTests.cs
+++ b/src/GitTfsTest/Core/ChangeSieveTests.cs
@@ -24,8 +24,6 @@ namespace GitTfs.Test.Core
                 RemoteMock.Setup(r => r.GetPathInGitRepo(It.IsAny<string>()))
                     .Returns(new Func<string, string>(path => path != null && path.StartsWith("$/Project/") ? path.Replace("$/Project/", "") : null));
                 // Make this remote ignore any path that includes "ignored".
-                RemoteMock.Setup(r => r.ShouldSkip(It.IsAny<string>()))
-                    .Returns(new Func<string, bool>(s => s.Contains("ignored")));
                 RemoteMock.Setup(r => r.IsIgnored(It.IsAny<string>()))
                     .Returns(new Func<string, bool>(s => !string.IsNullOrEmpty(s) && s.Contains("ignored")));
                 RemoteMock.Setup(r => r.IsInDotGit(It.IsAny<string>()))
@@ -84,9 +82,8 @@ namespace GitTfs.Test.Core
             public void Dispose()
             {
                 BaseFixture.RemoteMock.Verify(r => r.GetPathInGitRepo(It.IsAny<string>()), Times.AtLeastOnce);
-                BaseFixture.RemoteMock.Verify(r => r.ShouldSkip(It.IsAny<string>()), Times.AtLeastOnce);
-                BaseFixture.RemoteMock.Verify(r => r.IsIgnored(It.IsAny<string>()), Times.Never);
-                BaseFixture.RemoteMock.Verify(r => r.IsInDotGit(It.IsAny<string>()), Times.Never);
+                BaseFixture.RemoteMock.Verify(r => r.ShouldSkip(It.IsAny<string>()), Times.Never);
+                BaseFixture.RemoteMock.Verify(r => r.IsInDotGit(It.IsAny<string>()), Times.AtLeastOnce);
             }
 
             protected void AssertChanges(IEnumerable<ApplicableChange> actualChanges, params ApplicableChange[] expectedChanges)

--- a/src/GitTfsTest/Core/ChangeSieveTests.cs
+++ b/src/GitTfsTest/Core/ChangeSieveTests.cs
@@ -26,6 +26,10 @@ namespace GitTfs.Test.Core
                 // Make this remote ignore any path that includes "ignored".
                 RemoteMock.Setup(r => r.ShouldSkip(It.IsAny<string>()))
                     .Returns(new Func<string, bool>(s => s.Contains("ignored")));
+                RemoteMock.Setup(r => r.IsIgnored(It.IsAny<string>()))
+                    .Returns(new Func<string, bool>(s => !string.IsNullOrEmpty(s) && s.Contains("ignored")));
+                RemoteMock.Setup(r => r.IsInDotGit(It.IsAny<string>()))
+                    .Returns(new Func<string, bool>(s => !string.IsNullOrEmpty(s) && s.Contains("\\.git\\")));
             }
 
             private ChangeSieve _changeSieve;
@@ -81,6 +85,8 @@ namespace GitTfs.Test.Core
             {
                 BaseFixture.RemoteMock.Verify(r => r.GetPathInGitRepo(It.IsAny<string>()), Times.AtLeastOnce);
                 BaseFixture.RemoteMock.Verify(r => r.ShouldSkip(It.IsAny<string>()), Times.AtLeastOnce);
+                BaseFixture.RemoteMock.Verify(r => r.IsIgnored(It.IsAny<string>()), Times.Never);
+                BaseFixture.RemoteMock.Verify(r => r.IsInDotGit(It.IsAny<string>()), Times.Never);
             }
 
             protected void AssertChanges(IEnumerable<ApplicableChange> actualChanges, params ApplicableChange[] expectedChanges)
@@ -265,6 +271,8 @@ namespace GitTfs.Test.Core
             {
                 BaseFixture.RemoteMock.Verify(r => r.GetPathInGitRepo(It.IsAny<string>()), Times.Never);
                 BaseFixture.RemoteMock.Verify(r => r.ShouldSkip(It.IsAny<string>()), Times.Never);
+                BaseFixture.RemoteMock.Verify(r => r.IsIgnored(It.IsAny<string>()), Times.Never);
+                BaseFixture.RemoteMock.Verify(r => r.IsInDotGit(It.IsAny<string>()), Times.Never);
             }
         }
 
@@ -558,6 +566,8 @@ namespace GitTfs.Test.Core
             {
                 BaseFixture.RemoteMock.Verify(r => r.GetPathInGitRepo(It.IsAny<string>()), Times.Exactly(4));
                 BaseFixture.RemoteMock.Verify(r => r.ShouldSkip(It.IsAny<string>()), Times.Never);
+                BaseFixture.RemoteMock.Verify(r => r.IsIgnored(It.IsAny<string>()), Times.Never);
+                BaseFixture.RemoteMock.Verify(r => r.IsInDotGit(It.IsAny<string>()), Times.Never);
             }
         }
 

--- a/src/GitTfsTest/Core/ChangeSieveTests.cs
+++ b/src/GitTfsTest/Core/ChangeSieveTests.cs
@@ -83,7 +83,6 @@ namespace GitTfs.Test.Core
             {
                 BaseFixture.RemoteMock.Verify(r => r.GetPathInGitRepo(It.IsAny<string>()), Times.AtLeastOnce);
                 BaseFixture.RemoteMock.Verify(r => r.ShouldSkip(It.IsAny<string>()), Times.Never);
-                BaseFixture.RemoteMock.Verify(r => r.IsInDotGit(It.IsAny<string>()), Times.AtLeastOnce);
             }
 
             protected void AssertChanges(IEnumerable<ApplicableChange> actualChanges, params ApplicableChange[] expectedChanges)

--- a/src/GitTfsTest/Core/RemoteConfigConverterTests.cs
+++ b/src/GitTfsTest/Core/RemoteConfigConverterTests.cs
@@ -54,6 +54,7 @@ namespace GitTfs.Test.Core
                     Password = "pass",
                     IgnoreRegex = "abc",
                     IgnoreExceptRegex = "def",
+                    GitIgnorePath = ".gitignore",
                     Autotag = true,
                     Aliases = new string[] { "http://abc", "http://def" },
                     NoParallel = true,
@@ -65,6 +66,7 @@ namespace GitTfs.Test.Core
                 AssertContainsConfig("tfs-remote.default.password", "pass", config);
                 AssertContainsConfig("tfs-remote.default.ignore-paths", "abc", config);
                 AssertContainsConfig("tfs-remote.default.ignore-except", "def", config);
+                AssertContainsConfig("tfs-remote.default.gitignore-path", ".gitignore", config);
                 AssertContainsConfig("tfs-remote.default.legacy-urls", "http://abc,http://def", config);
                 AssertContainsConfig("tfs-remote.default.autotag", "true", config);
                 AssertContainsConfig("tfs-remote.default.noparallel", "true", config);
@@ -87,6 +89,7 @@ namespace GitTfs.Test.Core
                         Password = "pass",
                         IgnoreRegex = "abc",
                         ExceptRegex = "def",
+                        GitIgnorePath = ".gitignore",
                         NoParallel = true
                     },
                     Autotag = true,
@@ -99,6 +102,7 @@ namespace GitTfs.Test.Core
                 AssertContainsConfig("tfs-remote.default.password", "pass", config);
                 AssertContainsConfig("tfs-remote.default.ignore-paths", "abc", config);
                 AssertContainsConfig("tfs-remote.default.ignore-except", "def", config);
+                AssertContainsConfig("tfs-remote.default.gitignore-path", ".gitignore", config);
                 AssertContainsConfig("tfs-remote.default.legacy-urls", "http://abc,http://def", config);
                 AssertContainsConfig("tfs-remote.default.autotag", "true", config);
                 AssertContainsConfig("tfs-remote.default.noparallel", "true", config);
@@ -119,6 +123,7 @@ namespace GitTfs.Test.Core
                     Password = "pass",
                     IgnoreRegex = "abc",
                     IgnoreExceptRegex = "def",
+                    GitIgnorePath = ".gitignore",
                     Autotag = true,
                     Aliases = new[] { "http://abc", "http://def" },
                     NoParallel = true
@@ -129,6 +134,7 @@ namespace GitTfs.Test.Core
                 Assert.Equal("pass", remoteOptions.Password);
                 Assert.Equal("abc", remoteOptions.IgnoreRegex);
                 Assert.Equal("def", remoteOptions.ExceptRegex);
+                Assert.Equal(".gitignore", remoteOptions.GitIgnorePath);
                 Assert.True(remoteOptions.NoParallel);
             }
 
@@ -189,6 +195,7 @@ namespace GitTfs.Test.Core
                     c("tfs-remote.default.password", "thepassword"),
                     c("tfs-remote.default.ignore-paths", "ignorethis.zip"),
                     c("tfs-remote.default.ignore-except", "dontignorethis.zip"),
+                    c("tfs-remote.default.gitignore-path", ".gitignore"),
                     c("tfs-remote.default.legacy-urls", "http://old:8080/,http://other/"),
                     c("tfs-remote.default.autotag", "true"),
                     c("tfs-remote.default.noparallel", "true"));
@@ -201,6 +208,7 @@ namespace GitTfs.Test.Core
                 Assert.Equal("thepassword", remote.Password);
                 Assert.Equal("ignorethis.zip", remote.IgnoreRegex);
                 Assert.Equal("dontignorethis.zip", remote.IgnoreExceptRegex);
+                Assert.Equal(".gitignore", remote.GitIgnorePath);
                 Assert.Equal(new string[] { "http://old:8080/", "http://other/" }, remote.Aliases);
                 Assert.True(remote.Autotag);
                 Assert.True(remote.NoParallel);


### PR DESCRIPTION
Patch series trying to improve "git-tfs" .gitignore file handling support, making it both safer and more clear, but more useful at the same time, too.

Attempt to address issues #1121, #1140, #1208 and #1212.

Work in progress (to be rebased/rewritten), but pretty much settling down now, some important documentation updates and improvements still missing, but otherwise open for comments and discussion, feedback and testing appreciated :)

p.s. Please note that, due to how GitHub handles [pull request rebasing][1], commits listed here may appear in the wrong order, so not to get confused with what get's applied first, being important for providing context for following commits.

[1]: https://help.github.com/articles/why-are-my-commits-in-the-wrong-order