### PR TITLE
Allow specifying custom shelveset base for shelve command

### DIFF
--- a/doc/commands/shelve.md
+++ b/doc/commands/shelve.md
@@ -6,7 +6,7 @@ Creates a TFS shelveset from a Git branch.
 
 ## Synopsis
 
-    Usage: git-tfs shelve [options] shelveset-name [ref-to-shelve]
+    Usage: git-tfs shelve [options] shelveset-name [ref-to-shelve | (shelveset-base ref-to-shelve)]
     where options are:
 
         -i, --id, --remote, --tfs-remote
@@ -59,6 +59,10 @@ Creates a TFS shelveset from a Git branch.
 ### Shelve another branch
 
 `git tfs shelve MyShlevesetName MyBranch`
+
+### Shelve a branch with a custom base
+
+`git tfs shelve MyShlevesetName BranchBase MyBranch`
 
 ### Shelve a branch from a different remote
 

--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -1,3 +1,4 @@
 * When cloning a whole TFS Project Collection (``$/``) without specifying a local repository name, clone into "tfs-collection" instead of erroring with "Invalid Path". (#1202 by @0x53A)
 * FindMergeChangesetParent now also takes into account the path of the changes. This should avoid detection of incorrect parent when a changeset has merges in different branches at once. (#1204 by @Laibalion)
 * Provide way to delete all remotes in a single call (#1204 by @Laibalion)
+* Provide way to specify custom base when creating a shelveset, e.g. `git shelve ShelveSetName experiments experiment-1`

--- a/src/GitTfs/Commands/Shelve.cs
+++ b/src/GitTfs/Commands/Shelve.cs
@@ -8,7 +8,7 @@ using System.Diagnostics;
 namespace GitTfs.Commands
 {
     [Pluggable("shelve")]
-    [Description("shelve [options] shelveset-name [ref-to-shelve]")]
+    [Description("shelve [options] shelveset-name [ref-to-shelve | (shelveset-base ref-to-shelve)]")]
     [RequiresValidGitRepository]
     public class Shelve : GitTfsCommand
     {
@@ -48,6 +48,11 @@ namespace GitTfs.Commands
 
         public int Run(string shelvesetName, string refToShelve)
         {
+            return Run(shelvesetName, null, refToShelve);
+        }
+
+        public int Run(string shelvesetName, string shelvesetBase, string refToShelve)
+        {
             return _writer.Write(refToShelve, (changeset, referenceToShelve) =>
             {
                 if (!_checkinOptions.Force && changeset.Remote.HasShelveset(shelvesetName))
@@ -64,7 +69,7 @@ namespace GitTfs.Commands
 
                 var shelveSpecificCheckinOptions = _checkinOptionsFactory.BuildShelveSetSpecificCheckinOptions(_checkinOptions, message);
 
-                changeset.Remote.Shelve(shelvesetName, referenceToShelve, changeset, shelveSpecificCheckinOptions, EvaluateCheckinPolicies);
+                changeset.Remote.Shelve(shelvesetName, referenceToShelve, changeset, shelveSpecificCheckinOptions, EvaluateCheckinPolicies, shelvesetBase);
                 return GitTfsExitCodes.OK;
             });
         }

--- a/src/GitTfs/Core/DerivedGitTfsRemote.cs
+++ b/src/GitTfs/Core/DerivedGitTfsRemote.cs
@@ -235,7 +235,7 @@ namespace GitTfs.Core
             throw DerivedRemoteException;
         }
 
-        public void Shelve(string shelvesetName, string treeish, TfsChangesetInfo parentChangeset, CheckinOptions options, bool evaluateCheckinPolicies)
+        public void Shelve(string shelvesetName, string treeish, TfsChangesetInfo parentChangeset, CheckinOptions options, bool evaluateCheckinPolicies, string shelvesetBase = null)
         {
             throw DerivedRemoteException;
         }

--- a/src/GitTfs/Core/GitTfsRemote.cs
+++ b/src/GitTfs/Core/GitTfsRemote.cs
@@ -893,9 +893,9 @@ namespace GitTfs.Core
             Repository.UpdateRef(destinationRef, commit, "Shelveset " + shelvesetName + " from " + shelvesetOwner);
         }
 
-        public void Shelve(string shelvesetName, string head, TfsChangesetInfo parentChangeset, CheckinOptions options, bool evaluateCheckinPolicies)
+        public void Shelve(string shelvesetName, string head, TfsChangesetInfo parentChangeset, CheckinOptions options, bool evaluateCheckinPolicies, string shelvesetBase = null)
         {
-            WithWorkspace(parentChangeset, workspace => Shelve(shelvesetName, head, parentChangeset, options, evaluateCheckinPolicies, workspace));
+            WithWorkspace(parentChangeset, workspace => Shelve(shelvesetName, head, parentChangeset, options, evaluateCheckinPolicies, shelvesetBase, workspace));
         }
 
         public bool HasShelveset(string shelvesetName)
@@ -903,9 +903,9 @@ namespace GitTfs.Core
             return Tfs.HasShelveset(shelvesetName);
         }
 
-        private void Shelve(string shelvesetName, string head, TfsChangesetInfo parentChangeset, CheckinOptions options, bool evaluateCheckinPolicies, ITfsWorkspace workspace)
+        private void Shelve(string shelvesetName, string head, TfsChangesetInfo parentChangeset, CheckinOptions options, bool evaluateCheckinPolicies, string shelvesetBase, ITfsWorkspace workspace)
         {
-            PendChangesToWorkspace(head, parentChangeset.GitCommit, workspace);
+            PendChangesToWorkspace(head, shelvesetBase ?? parentChangeset.GitCommit, workspace);
             workspace.Shelve(shelvesetName, evaluateCheckinPolicies, options, () => Repository.GetCommitMessage(head, parentChangeset.GitCommit));
         }
 

--- a/src/GitTfs/Core/IGitTfsRemote.cs
+++ b/src/GitTfs/Core/IGitTfsRemote.cs
@@ -63,7 +63,7 @@ namespace GitTfs.Core
         IFetchResult FetchWithMerge(int mergeChangesetId, bool stopOnFailMergeCommit = false, IRenameResult renameResult = null, params string[] parentCommitsHashes);
         void QuickFetch(int changesetId, bool ignoreRestricted, bool printRestrictionHint = true);
         void Unshelve(string shelvesetOwner, string shelvesetName, string destinationBranch, Action<Exception> ignorableErrorHandler, bool force);
-        void Shelve(string shelvesetName, string treeish, TfsChangesetInfo parentChangeset, CheckinOptions options, bool evaluateCheckinPolicies);
+        void Shelve(string shelvesetName, string treeish, TfsChangesetInfo parentChangeset, CheckinOptions options, bool evaluateCheckinPolicies, string shelvesetBase = null);
         bool HasShelveset(string shelvesetName);
         int CheckinTool(string head, TfsChangesetInfo parentChangeset);
         int Checkin(string treeish, TfsChangesetInfo parentChangeset, CheckinOptions options, string sourceTfsPath = null);


### PR DESCRIPTION
For example:

     git-tfs shelve "Experiment v1" experiments experiment-1

  This will populate changes starting from experiments ref, rather than
  last TFS check-in ref.

NOTE: While existing tests pass, I did not add any new tests, the reason being is that I have no idea how to Mock two refs, still I have tested it in real-life scenario and it works fine for me.