### PR TITLE
Don't attempt to delete a directory that had a new file added in a subdirectory

### DIFF
--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -2,3 +2,4 @@
 * FindMergeChangesetParent now also takes into account the path of the changes. This should avoid detection of incorrect parent when a changeset has merges in different branches at once. (#1204 by @Laibalion)
 * Provide way to delete all remotes in a single call (#1204 by @Laibalion)
 * Add .net462 and windows10 long path support. See [doc to enable it](../blob/master/doc/Set-custom-workspace.md). (#1221 by @pmiossec)
+* Fix bug where checkin attempts to remove a non-empty directory. (#1249 by @m-akinc)

--- a/src/GitTfs/Core/DirectoryTidier.cs
+++ b/src/GitTfs/Core/DirectoryTidier.cs
@@ -46,6 +46,8 @@ namespace GitTfs.Core
             {
                 if (fileAndOperation.Value == FileOperation.Remove)
                     _filesInTfs.Remove(fileAndOperation.Key.ToLowerInvariant());
+                else if (fileAndOperation.Value == FileOperation.Add || fileAndOperation.Value == FileOperation.RenameTo)
+                    _filesInTfs.Add(fileAndOperation.Key.ToLowerInvariant());
             }
 
             var deletedDirs = new List<string>();
@@ -133,24 +135,16 @@ namespace GitTfs.Core
         private IEnumerable<string> CalculateCandidateDirectories()
         {
             var directoriesWithRemovedFiles = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
-            var directoriesBlockedForRemoval = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
 
-            foreach (var fileAndOperation in _fileOperations)
+            foreach (var removedFilePath in _fileOperations.Where(x => x.Value == FileOperation.Remove).Select(x => x.Key))
             {
-                var directory = GetDirectoryName(fileAndOperation.Key);
-                switch (fileAndOperation.Value)
+                var directory = GetDirectoryName(removedFilePath);
+                if (directory != null)
                 {
-                    case FileOperation.Remove:
-                        directoriesWithRemovedFiles.Add(directory);
-                        break;
-                    default:
-                        directoriesBlockedForRemoval.Add(directory);
-                        break;
+                    directoriesWithRemovedFiles.Add(directory);
                 }
             }
 
-            directoriesBlockedForRemoval.Add(null);
-            directoriesWithRemovedFiles.ExceptWith(directoriesBlockedForRemoval);
             return directoriesWithRemovedFiles;
         }
     }

--- a/src/GitTfsTest/Core/DirectoryTidierTests.cs
+++ b/src/GitTfsTest/Core/DirectoryTidierTests.cs
@@ -71,6 +71,7 @@ namespace GitTfs.Test.Core
         public void NoChangesMeansNoChanges()
         {
             // nothing!
+            Mock.Get(mockWorkspace).VerifyNoOtherCalls();
         }
 
         [Fact]
@@ -81,6 +82,7 @@ namespace GitTfs.Test.Core
             TidyDisposeToProcess();
 
             Mock.Get(mockWorkspace).Verify(x => x.Add("topDir/midDir/bottomDir/newFile.txt"));
+            Mock.Get(mockWorkspace).VerifyNoOtherCalls();
         }
 
         [Fact]
@@ -91,6 +93,7 @@ namespace GitTfs.Test.Core
             TidyDisposeToProcess();
 
             Mock.Get(mockWorkspace).Verify(x => x.Delete("topDir/midDir/bottomDir/file1.txt"));
+            Mock.Get(mockWorkspace).VerifyNoOtherCalls();
         }
 
         [Fact]
@@ -104,6 +107,7 @@ namespace GitTfs.Test.Core
             Mock.Get(mockWorkspace).Verify(x => x.Delete("topDir/midDir/bottomDir/file1.txt"));
             Mock.Get(mockWorkspace).Verify(x => x.Delete("topDir/midDir/bottomDir/file2.txt"));
             Mock.Get(mockWorkspace).Verify(x => x.Delete("topDir/midDir/bottomDir"));
+            Mock.Get(mockWorkspace).VerifyNoOtherCalls();
         }
 
         [Fact]
@@ -117,6 +121,7 @@ namespace GitTfs.Test.Core
             Mock.Get(mockWorkspace).Verify(x => x.Delete("topDir/midDir/bottomDir/file1.txt"));
             Mock.Get(mockWorkspace).Verify(x => x.Delete("topDir/midDir/bottomDir/file2.txt"));
             Mock.Get(mockWorkspace).Verify(x => x.Delete("topDir/midDir/bottomDir"));
+            Mock.Get(mockWorkspace).VerifyNoOtherCalls();
         }
 
         [Fact]
@@ -128,6 +133,7 @@ namespace GitTfs.Test.Core
 
             Mock.Get(mockWorkspace).Verify(x => x.Delete("dir1/dir2/dir3/lonelyFile.txt"));
             Mock.Get(mockWorkspace).Verify(x => x.Delete("dir1"));
+            Mock.Get(mockWorkspace).VerifyNoOtherCalls();
         }
 
 
@@ -145,6 +151,7 @@ namespace GitTfs.Test.Core
 
             Mock.Get(mockWorkspace).Verify(x => x.Delete("topDir/midDir/bottomDir/file1.txt"));
             Mock.Get(mockWorkspace).Verify(x => x.Rename("topDir/midDir/bottomDir/file2.txt", "file2.txt", ScoreIsIrrelevant));
+            Mock.Get(mockWorkspace).VerifyNoOtherCalls();
             // "topDir/midDir/bottomDir/" becomes empty but is not deleted
         }
 
@@ -156,6 +163,7 @@ namespace GitTfs.Test.Core
             TidyDisposeToProcess();
 
             Mock.Get(mockWorkspace).Verify(x => x.Rename("dir1/dir2/dir3/lonelyFile.txt", "otherdir/otherdir2/newName.txt", ScoreIsIrrelevant));
+            Mock.Get(mockWorkspace).VerifyNoOtherCalls();
         }
 
         [Fact]
@@ -169,6 +177,7 @@ namespace GitTfs.Test.Core
             Mock.Get(mockWorkspace).Verify(x => x.Delete("dirA/file.txt"));
             Mock.Get(mockWorkspace).Verify(x => x.Delete("dirA/dirB/file.txt"));
             Mock.Get(mockWorkspace).Verify(x => x.Delete("dirA"));
+            Mock.Get(mockWorkspace).VerifyNoOtherCalls();
         }
 
         [Fact]
@@ -181,6 +190,7 @@ namespace GitTfs.Test.Core
 
             Mock.Get(mockWorkspace).Verify(x => x.Rename("dir1/dir2/dir3/lonelyFile.txt", "otherdir/otherdir2/newName.txt", ScoreIsIrrelevant));
             Mock.Get(mockWorkspace).Verify(x => x.Rename("topDir/topFile.txt", "dir1/dir2/dir3/replacement.txt", ScoreIsIrrelevant));
+            Mock.Get(mockWorkspace).VerifyNoOtherCalls();
         }
 
         [Fact]
@@ -193,6 +203,7 @@ namespace GitTfs.Test.Core
 
             Mock.Get(mockWorkspace).Verify(x => x.Delete("dir1/dir2/dir3/lonelyFile.txt"));
             Mock.Get(mockWorkspace).Verify(x => x.Add("dir1/dir2/dir3/newFile.txt"));
+            Mock.Get(mockWorkspace).VerifyNoOtherCalls();
         }
 
         [Fact]
@@ -212,6 +223,7 @@ namespace GitTfs.Test.Core
             Mock.Get(mockWorkspace).Verify(x => x.Delete("topDir/topFile.txt"));
             Mock.Get(mockWorkspace).Verify(x => x.Delete("rootFile.txt"));
             Mock.Get(mockWorkspace).Verify(x => x.Delete("topDir"));
+            Mock.Get(mockWorkspace).VerifyNoOtherCalls();
         }
 
         [Fact]
@@ -229,6 +241,7 @@ namespace GitTfs.Test.Core
             Mock.Get(mockWorkspace).Verify(x => x.Delete("TOPDIR/MIDDIR/MIDFILE.TXT"));
             Mock.Get(mockWorkspace).Verify(x => x.Delete("TOPDIR/TOPFILE.TXT"));
             Mock.Get(mockWorkspace).Verify(x => x.Delete("TOPDIR"));
+            Mock.Get(mockWorkspace).VerifyNoOtherCalls();
         }
 
         [Fact]
@@ -241,6 +254,7 @@ namespace GitTfs.Test.Core
 
             Mock.Get(mockWorkspace).Verify(x => x.Edit("topDir/midDir/bottomDir/file1.txt"));
             Mock.Get(mockWorkspace).Verify(x => x.Rename("topDir/midDir/bottomDir/file1.txt", "topDir/midDir/bottomDir/file1renamed.txt", ScoreIsIrrelevant));
+            Mock.Get(mockWorkspace).VerifyNoOtherCalls();
         }
 
         [Fact]

--- a/src/GitTfsTest/Core/DirectoryTidierTests.cs
+++ b/src/GitTfsTest/Core/DirectoryTidierTests.cs
@@ -207,6 +207,46 @@ namespace GitTfs.Test.Core
         }
 
         [Fact]
+        public void DeletingAFileAndAddingAnotherInANewSubdirectoryLeavesParents()
+        {
+            Tidy.Delete("top/file.txt");
+            Tidy.Add("top/sub/file.txt");
+
+            TidyDisposeToProcess();
+
+            Mock.Get(mockWorkspace).Verify(x => x.Delete("top/file.txt"));
+            Mock.Get(mockWorkspace).Verify(x => x.Add("top/sub/file.txt"));
+            Mock.Get(mockWorkspace).VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public void DeletingAFileAndAddingAnotherInANewSiblingDirectoryLeavesParent()
+        {
+            Tidy.Delete("top/sub1/file.txt");
+            Tidy.Add("top/sub2/file.txt");
+
+            TidyDisposeToProcess();
+
+            Mock.Get(mockWorkspace).Verify(x => x.Delete("top/sub1/file.txt"));
+            Mock.Get(mockWorkspace).Verify(x => x.Add("top/sub2/file.txt"));
+            Mock.Get(mockWorkspace).Verify(x => x.Delete("top/sub1")); // but NOT "top"
+            Mock.Get(mockWorkspace).VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public void DeletingAFileAndMovingAnotherInLeavesTheDirectory()
+        {
+            Tidy.Delete("dir/file1.txt");
+            Tidy.Rename("file2.txt", "dir/file2.txt", ScoreIsIrrelevant);
+
+            TidyDisposeToProcess();
+
+            Mock.Get(mockWorkspace).Verify(x => x.Delete("dir/file1.txt"));
+            Mock.Get(mockWorkspace).Verify(x => x.Rename("file2.txt", "dir/file2.txt", ScoreIsIrrelevant));
+            Mock.Get(mockWorkspace).VerifyNoOtherCalls();
+        }
+
+        [Fact]
         public void RemovingAllFilesRemovesAllParents()
         {
             Tidy.Delete("topDir/midDir/bottomDir/file1.txt");


### PR DESCRIPTION
The DirectoryTidier determines if a directory is empty based on what files were in it _before_ the new operations are applied (i.e. `_filesInTfs`). There is also some logic that attempt to handle files being added by the operations (in `CalculateCandidateDirectories`), but it isn't sufficient. It only prevents deletion of a directory if a file was added and removed _directly_ to it. I.e. if the directory had a file added in a new subdirectory, the logic doesn't prevent deletion.

Because of how `DeleteEmptyDir` recursively checks for empty containing directories, it's cleanest to fix this by updating `_filesInTfs` with the paths for new files. We have to include both added paths, and renamed-to paths. Renamed-from paths should already be in `_filesInTfs`. Handling it this way makes the existing (incomplete) logic in `CalculateCandidateDirectories` redundant, so I removed it.

Also, most of the DirectoryTidier tests should have been calling `VerifyNoOtherCalls()` to catch unwanted deletes, so I added those calls.

Fixes #1248