### PR TITLE
Not store first commit in global property

### DIFF
--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -4,4 +4,6 @@
 * Add .net462 and windows10 long path support. See [doc to enable it](../blob/master/doc/Set-custom-workspace.md). (#1221 by @pmiossec)
 * Fix bug where checkin attempts to remove a non-empty directory. (#1249 by @m-akinc)
 * Line endings are now properly normalized when pushing changes to TFS if core.autocrlf is set to true (#1210 by @JeffCyr)
-* Fix merge commits connecting to wrong parent
+* Fix merge commits connecting to wrong parent (#1264 by DotNetSparky)
+* Now possible to clone a deleted branch (#1263 by magol)
+* Fix a issue that commits in a branch are lost if they are older then the first commit in a branch that are merging from this branch. (#1263 by magol)

--- a/src/GitTfs.VsCommon/TfsHelper.Common.cs
+++ b/src/GitTfs.VsCommon/TfsHelper.Common.cs
@@ -1335,7 +1335,7 @@ namespace GitTfs.VsCommon
 
         public bool IsExistingInTfs(string path)
         {
-            return VersionControl.ServerItemExists(path, ItemType.Any);
+            return VersionControl.ServerItemExists(path, VersionSpec.Latest, DeletedState.Any, ItemType.Any);
         }
 
         protected void ConvertFolderIntoBranch(string tfsRepositoryPath)

--- a/src/GitTfs/Commands/InitBranch.cs
+++ b/src/GitTfs/Commands/InitBranch.cs
@@ -149,7 +149,7 @@ namespace GitTfs.Commands
                 // If this branch's branch point is past the first commit, indicate this so Fetch can start from that point
                 if (rootBranch.TargetBranchChangesetId > -1)
                 {
-                    branchTfsRemote.SetInitialChangeset(rootBranch.TargetBranchChangesetId);
+                    branchTfsRemote.SetFirstChangeset(rootBranch.TargetBranchChangesetId);
                 }
 
                 if (rootBranch.IsRenamedBranch || !NoFetch)

--- a/src/GitTfs/Core/DerivedGitTfsRemote.cs
+++ b/src/GitTfs/Core/DerivedGitTfsRemote.cs
@@ -190,12 +190,12 @@ namespace GitTfs.Core
         public bool ExportMetadatas { get; set; }
         public Dictionary<string, IExportWorkItem> ExportWorkitemsMapping { get; set; }
 
-        public int? GetInitialChangeset()
+        public int? GetFirstChangeset()
         {
             throw DerivedRemoteException;
         }
 
-        public void SetInitialChangeset(int? changesetId)
+        public void SetFirstChangeset(int? changesetId)
         {
             throw DerivedRemoteException;
         }

--- a/src/GitTfs/Core/IGitTfsRemote.cs
+++ b/src/GitTfs/Core/IGitTfsRemote.cs
@@ -54,8 +54,8 @@ namespace GitTfs.Core
         string Prefix { get; }
         bool ExportMetadatas { get; set; }
         Dictionary<string, IExportWorkItem> ExportWorkitemsMapping { get; set; }
-        int? GetInitialChangeset();
-        void SetInitialChangeset(int? changesetId);
+        int? GetFirstChangeset();
+        void SetFirstChangeset(int? changesetId);
         bool ShouldSkip(string path);
         IGitTfsRemote InitBranch(RemoteOptions remoteOptions, string tfsRepositoryPath, int rootChangesetId = -1, bool fetchParentBranch = false, string gitBranchNameExpected = null, IRenameResult renameResult = null);
         string GetPathInGitRepo(string tfsPath);

--- a/src/GitTfs/Core/TfsInterop/IBranch.cs
+++ b/src/GitTfs/Core/TfsInterop/IBranch.cs
@@ -48,9 +48,23 @@ namespace GitTfs.Core.TfsInterop
 
     public static class BranchExtensions
     {
+        /// <summary>Find the root branch that match the path given in <paramref name="remoteTfsPath" />.</summary>
+        /// <param name="tfs">The <see cref="ITfsHelper" /> to use.</param>
+        /// <param name="remoteTfsPath">The TFS path to search for.</param>
+        /// <param name="searchExactPath">If <paramref name="remoteTfsPath" /> must match exact, or if it is ok if
+        ///     <paramref name="remoteTfsPath" /> is a part of the path.</param>
+        /// <returns>The root branch that match the search criteria or null if nothing was found.</returns>
+        /// <remarks>
+        ///     If the root branch matching the search criteria was not found, it try to search by all deleted branches to.
+        ///     This can usable if the user want to clone a deleted branch.
+        /// </remarks>
         public static BranchTree GetRootTfsBranchForRemotePath(this ITfsHelper tfs, string remoteTfsPath, bool searchExactPath = true)
+            => GetRootTfsBranchForRemotePath(tfs, remoteTfsPath, searchExactPath, false) ??
+               GetRootTfsBranchForRemotePath(tfs, remoteTfsPath, searchExactPath, true);
+
+        private static BranchTree GetRootTfsBranchForRemotePath(this ITfsHelper tfs, string remoteTfsPath, bool searchExactPath, bool searchDeletedBranches)
         {
-            var branches = tfs.GetBranches();
+            var branches = tfs.GetBranches(searchDeletedBranches);
             var branchTrees = branches.Aggregate(new Dictionary<string, BranchTree>(StringComparer.OrdinalIgnoreCase), (dict, branch) => dict.Tap(d => d.Add(branch.Path, new BranchTree(branch))));
             foreach (var branch in branchTrees.Values)
             {

--- a/src/GitTfsTest/Commands/InitBranchTest.cs
+++ b/src/GitTfsTest/Commands/InitBranchTest.cs
@@ -237,7 +237,7 @@ namespace GitTfs.Test.Commands
             mocks.ClassUnderTest.CloneAllBranches = true;
             var tfsPathBranch1 = "$/MyProject/MyBranch1";
             var tfsPathBranch2 = "$/MyProject/MyBranch2";
-            tfsHelperMock.Setup(t => t.GetBranches(false)).Returns(new IBranchObject[] {
+            tfsHelperMock.Setup(t => t.GetBranches(true)).Returns(new IBranchObject[] {
                 new MockBranchObject() { IsRoot = true, Path = trunkGitTfsRemote.Object.TfsRepositoryPath },
                 new MockBranchObject() { ParentPath = trunkGitTfsRemote.Object.TfsRepositoryPath, Path = tfsPathBranch1 },
                 new MockBranchObject() { ParentPath = trunkGitTfsRemote.Object.TfsRepositoryPath, Path = tfsPathBranch2 },
@@ -296,7 +296,7 @@ namespace GitTfs.Test.Commands
             var tfsPathBranch1 = "$/MyProject/MyBranch1";
             var tfsPathBranch2 = "$/MyProject/MyBranch2";
             var tfsPathBranch3 = "$/MyProject/MyBranch3";
-            tfsHelperMock.Setup(t => t.GetBranches(false)).Returns(new IBranchObject[] {
+            tfsHelperMock.Setup(t => t.GetBranches(true)).Returns(new IBranchObject[] {
                 new MockBranchObject() { IsRoot = true, Path = "$/MyProject/ParentOfTrunk" },
                 new MockBranchObject() { ParentPath = "$/MyProject/ParentOfTrunk", Path = trunkGitTfsRemote.Object.TfsRepositoryPath },
                 new MockBranchObject() { ParentPath = trunkGitTfsRemote.Object.TfsRepositoryPath, Path = tfsPathBranch1 },


### PR DESCRIPTION
Fix a issue that commits in a branch are lost if they are older then the first commit in a branch that are merging from this branch.


The global property "initial-changeset" is used to store the first changeset the use want to clone from.

But this is allso in some situations used to store the first changeset in a branch. This give a problem as this property is global and will be applied on all branches. If initial-changeset is set for a branch, the next cloned branch can not get the changesets before the changeset given in initial-changeset if it is not updated for that branch to.

It is problematic to use a property for different information.