### PR TITLE
Improve detection of merge parent

### DIFF
--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -4,3 +4,4 @@
 * Add .net462 and windows10 long path support. See [doc to enable it](../blob/master/doc/Set-custom-workspace.md). (#1221 by @pmiossec)
 * Fix bug where checkin attempts to remove a non-empty directory. (#1249 by @m-akinc)
 * Line endings are now properly normalized when pushing changes to TFS if core.autocrlf is set to true (#1210 by @JeffCyr)
+* Fix merge commits connecting to wrong parent

--- a/src/GitTfs.VsCommon/TfsHelper.Common.cs
+++ b/src/GitTfs.VsCommon/TfsHelper.Common.cs
@@ -230,9 +230,10 @@ namespace GitTfs.VsCommon
             //  2. figuring out up to which changeset the merge source branch needs to be fetched
             return changes.Max(change =>
             {
-                if (change.MergeSources.Empty())
+                var mergeSources = change.MergeSources.Where(mergeSource => mergeSource.VersionTo < targetChangeset);
+                if (mergeSources.Empty())
                     return -1;
-                return change.MergeSources.Max(mergeSource => mergeSource.VersionFrom);
+                return mergeSources.Max(mergeSource => mergeSource.VersionTo);
             });
         }
 


### PR DESCRIPTION
Fixes issue where the wrong parent is selected for a merge if the
correct parent consists entirely of files that were modified in earlier
changesets in the merge (it was selecting the highest "version FROM"
instead of "version TO").

I believe this could resolve #974 (it did in my specific case).

I'm having a hard time creating a unit test with a faked repository that demonstrates the original problem. If I can do that, I'll include the tests.

Tested against TFS 2017 and 2019.