### PR TITLE
Updated v0.30.0.md for long path support doc link

### DIFF
--- a/doc/release-notes/v0.30.0.md
+++ b/doc/release-notes/v0.30.0.md
@@ -1,7 +1,7 @@
 * When cloning a whole TFS Project Collection (``$/``) without specifying a local repository name, clone into "tfs-collection" instead of erroring with "Invalid Path". (#1202 by @0x53A)
 * FindMergeChangesetParent now also takes into account the path of the changes. This should avoid detection of incorrect parent when a changeset has merges in different branches at once. (#1204 by @Laibalion)
 * Provide way to delete all remotes in a single call (#1204 by @Laibalion)
-* Add .net462 and windows10 long path support. See [doc to enable it](../blob/master/doc/Set-custom-workspace.md). (#1221 by @pmiossec)
+* Add .net462 and windows10 long path support. See [doc to enable it](/doc/Set-custom-workspace.md). (#1221 by @pmiossec)
 * Fix bug where checkin attempts to remove a non-empty directory. (#1249 by @m-akinc)
 * Line endings are now properly normalized when pushing changes to TFS if core.autocrlf is set to true (#1210 by @JeffCyr)
 * Fix merge commits connecting to wrong parent (#1264 by DotNetSparky)


### PR DESCRIPTION
.Net462 and windows10 long path support documentation link was broken, this should fix the problem.