### PR TITLE
Improve performance by caching workspaces during the clone operation 

### DIFF
--- a/doc/release-notes/Next.md
+++ b/doc/release-notes/Next.md
@@ -1,0 +1,1 @@
+* Improve performance by caching workspaces during the clone operation so that each checkin doesn't require a full workspace setup/teardown

--- a/src/GitTfs.VsCommon/TfsHelper.Common.cs
+++ b/src/GitTfs.VsCommon/TfsHelper.Common.cs
@@ -676,7 +676,7 @@ namespace GitTfs.VsCommon
             return result != null && result.Length > 0;
         }
 
-        private readonly Dictionary<string, Workspace> _workspaces = new Dictionary<string, Workspace>();
+        private static readonly Dictionary<string, Workspace> _workspaces = new Dictionary<string, Workspace>();
 
         public void WithWorkspace(string localDirectory, IGitTfsRemote remote, IEnumerable<Tuple<string, string>> mappings, TfsChangesetInfo versionToFetch, Action<ITfsWorkspace> action)
         {
@@ -703,22 +703,21 @@ namespace GitTfs.VsCommon
 
         public void WithWorkspace(string localDirectory, IGitTfsRemote remote, TfsChangesetInfo versionToFetch, Action<ITfsWorkspace> action)
         {
-            Trace.WriteLine("Setting up a TFS workspace at " + localDirectory);
-            var workspace = Retry.Do(() => GetWorkspace(new WorkingFolder(remote.TfsRepositoryPath, localDirectory)));
-            try
+            Workspace workspace;
+            if (!_workspaces.TryGetValue(remote.Id, out workspace))
             {
-                var tfsWorkspace = _container.With("localDirectory").EqualTo(localDirectory)
-                    .With("remote").EqualTo(remote)
-                    .With("contextVersion").EqualTo(versionToFetch)
-                    .With("workspace").EqualTo(_bridge.Wrap<WrapperForWorkspace, Workspace>(workspace))
-                    .With("tfsHelper").EqualTo(this)
-                    .GetInstance<TfsWorkspace>();
-                action(tfsWorkspace);
+                Trace.WriteLine("Setting up a TFS workspace with subtrees at " + localDirectory);
+                _workspaces.Add(remote.Id, workspace = Retry.Do(() => GetWorkspace(new WorkingFolder(remote.TfsRepositoryPath, localDirectory))));
+                Janitor.CleanThisUpWhenWeClose(() => TryToDeleteWorkspace(workspace));
             }
-            finally
-            {
-                TryToDeleteWorkspace(workspace);
-            }
+
+            var tfsWorkspace = _container.With("localDirectory").EqualTo(localDirectory)
+                .With("remote").EqualTo(remote)
+                .With("contextVersion").EqualTo(versionToFetch)
+                .With("workspace").EqualTo(_bridge.Wrap<WrapperForWorkspace, Workspace>(workspace))
+                .With("tfsHelper").EqualTo(this)
+                .GetInstance<TfsWorkspace>();
+            action(tfsWorkspace);
         }
 
         private Workspace GetWorkspace(params WorkingFolder[] folders)
@@ -820,7 +819,15 @@ namespace GitTfs.VsCommon
                     // Normally, the workspace will have one mapping, mapped to the git-tfs
                     // workspace folder. In that case, we just delete the workspace.
                     Trace.TraceInformation("Removing workspace \"" + workspace.DisplayName + "\".");
+
+                    foreach (var keyValuePair in _workspaces.ToList())
+                    {
+                        if (string.Equals(keyValuePair.Value.DisambiguatedDisplayName,
+                            workspace.DisambiguatedDisplayName))
+                            _workspaces.Remove(keyValuePair.Key);
+                    }
                     workspace.Delete();
+
                 }
                 else
                 {

--- a/src/GitTfs/Core/GitTfsRemote.cs
+++ b/src/GitTfs/Core/GitTfsRemote.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
 using GitTfs.Commands;
 using GitTfs.Core.TfsInterop;
 using GitTfs.Util;
@@ -23,6 +24,13 @@ namespace GitTfs.Core
         private string maxCommitHash;
         private bool isTfsAuthenticated;
         public RemoteInfo RemoteInfo { get; private set; }
+
+        private static int remoteCounter = 0;
+
+        /// <summary>
+        ///    Holds the subdirectory path for this remote so that each remote doesn't conflict with each other and doesn't cause the worskspaces to get created and destroyed over and over
+        /// </summary>
+        private readonly string _workingSubDirectory;
 
         public GitTfsRemote(RemoteInfo info, IGitRepository repository, RemoteOptions remoteOptions, Globals globals,
             ITfsHelper tfsHelper, ConfigProperties properties)
@@ -46,6 +54,9 @@ namespace GitTfs.Core
             Autotag = info.Autotag;
 
             IsSubtree = CheckSubtree();
+
+            var value = Interlocked.Increment(ref remoteCounter);
+            _workingSubDirectory =  value.ToString("X4");
         }
 
         private bool CheckSubtree()
@@ -220,7 +231,7 @@ namespace GitTfs.Core
         {
             get
             {
-                return Path.Combine(_globals.GitDir, WorkspaceDirectory);
+                return Path.Combine(_globals.GitDir, WorkspaceDirectory, _workingSubDirectory);
             }
         }
 


### PR DESCRIPTION
I sped up the clone process by having it not create/tear down the workspace for every commit in the process.

It also moves each remote into a separate subfolder in the working directory so there are no conflicts by not removing the workspace.

On my machine, this workspace setup/tear down was adding 600-800ms per commit.

I was now able to clone my repository with ~17,000 commits across 7 branches in right at 3 hours.

I don't have the exact timing from before, but I believe this removed at least 2-4 hours from the process

