### PR TITLE
Improve HideUserCredentials function

### DIFF
--- a/src/GitTfs/Commands/Init.cs
+++ b/src/GitTfs/Commands/Init.cs
@@ -112,9 +112,9 @@ namespace GitTfs.Commands
 
         public static string HideUserCredentials(string commandLineRun)
         {
-            Regex rgx = new Regex("(--username|-u)[= ][^ ]+");
+            Regex rgx = new Regex("((--|/)username|[/-]u)(=| +)[^ ]+");
             commandLineRun = rgx.Replace(commandLineRun, "--username=xxx");
-            rgx = new Regex("(--password|-p)[= ][^ ]+");
+            rgx = new Regex("((--|/)password|[/-]p)(=| +)[^ ]+");
             return rgx.Replace(commandLineRun, "--password=xxx");
         }
 

--- a/src/GitTfsTest/Commands/CloneTest.cs
+++ b/src/GitTfsTest/Commands/CloneTest.cs
@@ -1,4 +1,4 @@
-﻿using GitTfs.Commands;
+using GitTfs.Commands;
 using Xunit;
 
 namespace GitTfs.Test.Commands
@@ -8,13 +8,29 @@ namespace GitTfs.Test.Commands
         [Theory]
         [InlineData("-u=login", "--username=xxx")]
         [InlineData("-u login", "--username=xxx")]
+        [InlineData("-u  login", "--username=xxx")]
         [InlineData("--username=login", "--username=xxx")]
         [InlineData("--username login", "--username=xxx")]
+        [InlineData("--username  login", "--username=xxx")]
+        [InlineData("/u=login", "--username=xxx")]
+        [InlineData("/u login", "--username=xxx")]
+        [InlineData("/u  login", "--username=xxx")]
+        [InlineData("/username=login", "--username=xxx")]
+        [InlineData("/username login", "--username=xxx")]
+        [InlineData("/username  login", "--username=xxx")]
 
         [InlineData("-p=mypassword", "--password=xxx")]
         [InlineData("-p mypassword", "--password=xxx")]
+        [InlineData("-p  mypassword", "--password=xxx")]
         [InlineData("--password=mypassword", "--password=xxx")]
         [InlineData("--password mypassword", "--password=xxx")]
+        [InlineData("--password  mypassword", "--password=xxx")]
+        [InlineData("/p=mypassword", "--password=xxx")]
+        [InlineData("/p mypassword", "--password=xxx")]
+        [InlineData("/p  mypassword", "--password=xxx")]
+        [InlineData("/password=mypassword", "--password=xxx")]
+        [InlineData("/password mypassword", "--password=xxx")]
+        [InlineData("/password  mypassword", "--password=xxx")]
 
         [InlineData("git tfs clone https://tfs/tfs $/repo/branch . --branches=all --username=me --password=ExtraHardPassword",
             "git tfs clone https://tfs/tfs $/repo/branch . --branches=all --username=xxx --password=xxx")]


### PR DESCRIPTION
In this fix I added replacing cmd-style arguments (`/username`, `/u`, `/password`, `/p`) and ability to handle any number of spaces between username/password key and value