### PR TITLE
Interpret authors file path relative to the current directory at the time the command was executed

### DIFF
--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -2,3 +2,5 @@
   and the official distribution channel for binaries is a ZIP file or a chocolatey package.
 
 * Added a new command to create a mapping file of changet ids and commit ids. 
+
+* Fixed authors file not being found for the copy to .git/git-tfs_authors due to git-tfs changing the current directory before initiating the copy.

--- a/src/GitTfs/Globals.cs
+++ b/src/GitTfs/Globals.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.IO;
 using NDesk.Options;
 using GitTfs.Core;
 using GitTfs.Util;
@@ -26,7 +27,7 @@ namespace GitTfs
                     { "i|tfs-remote|remote|id=", "The remote ID of the TFS to interact with\ndefault: default",
                         v => UserSpecifiedRemoteId = v },
                     { "A|authors=", "Path to an Authors file to map TFS users to Git users (will be kept in cache and used for all the following commands)",
-                        v => AuthorsFilePath = v },
+                        v => AuthorsFilePath = Path.GetFullPath(v) },
                 };
             }
         }


### PR DESCRIPTION
This fixes the warning always seen when using `--authors` with a path that is not fully qualified:

> Failed to copy authors file from "..\authors.txt" to ".git\git-tfs_authors".

I tried to set up a test but the existing fixtures don't seem to exercise a code path that copies the authors file. Let me know what to do if a test is needed.