### PR TITLE
Move [options] to right place

### DIFF
--- a/doc/usecases/migrate_tfs_to_git.md
+++ b/doc/usecases/migrate_tfs_to_git.md
@@ -12,7 +12,7 @@ If you are not interested by all the history (because it could be very long), yo
 #### Fetch all the history, for all branches
 First fetch all the source history (with all branches) in a local git repository:
 
-    git tfs clone https://tfs.codeplex.com:443/tfs/Collection $/project/trunk . --branches=all
+    git tfs clone --branches=all https://tfs.codeplex.com:443/tfs/Collection $/project/trunk .
 
 See [clone](../commands/clone.md) command if you should use a password or an author file
  (recommended if you want an email address instead of a windows login in commit messages), ...
@@ -26,7 +26,7 @@ of the main branch and only the branches merged into it.
 
 To do that, do not specify the `--branches` or use the default value of the option `--branches=auto`, like that:
 
-    git tfs clone https://tfs.codeplex.com:443/tfs/Collection $/project/trunk . --branches=auto
+    git tfs clone --branches=auto https://tfs.codeplex.com:443/tfs/Collection $/project/trunk .
 
 #### Fetch all the history, for just the main branch (ignoring all the other branches)
 
@@ -37,7 +37,7 @@ all the other branches and the merge changesets.
 
 To do that, use the option `--branches=none`, like that:
 
-    git tfs clone https://tfs.codeplex.com:443/tfs/Collection $/project/trunk . --branches=none
+    git tfs clone --branches=none https://tfs.codeplex.com:443/tfs/Collection $/project/trunk .
 
 #### Ignoring history before a specific changeset
 
@@ -46,7 +46,7 @@ In this case, you could try to retrieve less history by passing to git-tfs, the 
 
 To do that, use the option `--changeset=3245`, and run:
 
-    git tfs clone https://tfs.codeplex.com:443/tfs/Collection $/project/trunk . --changeset=3245
+    git tfs clone --changeset=3245 https://tfs.codeplex.com:443/tfs/Collection $/project/trunk .
 
 #### Fetch only the last changeset
 
@@ -128,7 +128,7 @@ Extract the data to create a file with each line formatted following: OldWorkIte
 
 First fetch all the source history (with all branches) in a local git repository exporting work-items metadatas (using the mapping file obtained in the previous step):
 
-    git tfs clone https://tfs.codeplex.com:443/tfs/Collection $/project/trunk . --branches=all --export --export-work-item-mapping="c:\workitems\mapping\file.txt"
+    git tfs clone --branches=all --export --export-work-item-mapping="c:\workitems\mapping\file.txt" https://tfs.codeplex.com:443/tfs/Collection $/project/trunk .
 
 See [clone](../commands/clone.md) command if you should use a password or an author file
  (recommended if you want an mail address instead of a windows login in commit messages), ...


### PR DESCRIPTION
From the [`clone`](https://github.com/git-tfs/git-tfs/blob/master/doc/commands/clone.md) help I see the `[options]` comes right after the `clone` keyword.

Also, right now, running the `git tfs clone https://tfs.codeplex.com:443/tfs/Collection $/project/trunk . --branches=all` returns me:
> warning: you are going to clone a subdirectory of a branch and won't be able to manage branches :(
   => If you want to manage branches with git-tfs, clone $/Enterprise/Utils with '--branches=all' option instead...)

---Please read and delete this text before creating this pull request---
Thanks a lot for the pull request you are going to do!
Please verify that you validate these points:

- [ ] indentation is made with 4 spaces
- [ ] your pull request contains only changes intended (no refactoring, line return added, ... that could make code review harder. Make another one if you think it is needed...)
- [ ] run and verify that existing tests pass. Add some new units tests, if needed.
- [ ] update the documentation, if needed.
- [ ] update the [release notes file](../tree/master/doc/release-notes/NEXT.md)

------------------------------------------------------------------------