### PR TITLE
Added addtional masks to support Property changes

### DIFF
--- a/src/GitTfs/Core/TfsInterop/TfsChangeType.cs
+++ b/src/GitTfs/Core/TfsInterop/TfsChangeType.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace GitTfs.Core.TfsInterop
 {
@@ -6,18 +6,22 @@ namespace GitTfs.Core.TfsInterop
     [Flags]
     public enum TfsChangeType
     {
-        None = 0x0001,
-        Add = 0x0002,
-        Edit = 0x0004,
-        Encoding = 0x0008,
-        Rename = 0x0010,
-        Delete = 0x0020,
-        Undelete = 0x0040,
-        Content = 0x007F, // Rollup of the preceding change types
+        None        = 0x0001,
+        Add         = 0x0002,
+        Edit        = 0x0004,
+        Encoding    = 0x0008,
+        Rename      = 0x0010,
+        Delete      = 0x0020,
+        Undelete    = 0x0040, // Unused
+        Content     = 0x207F, // Rollup of the preceding change types - and Property Changes
 
-        Branch = 0x0080,
-        Merge = 0x0100,
+        Branch      = 0x0080,
+        Merge       = 0x0100,
 
-        Lock = 0x0200
+        Lock        = 0x0200,
+        Rollback    = 0x0400,
+        SourceRename= 0x0800,
+        TargetRename= 0x1000, // Unused?
+        Property    = 0x2000  // Adding to handle softlinks (ie MKLINK) and executable bit (for Team Explorer Everywhere)
     }
 }


### PR DESCRIPTION
Added additional masks to support key/value pair changes to Property used to indicate:
 * executable via "Microsoft.TeamFoundation.VersionControl.Executable" for Team Foundation Everywhere use on Linux/Unix/MacOS
 * soft-links via "Microsoft.TeamFoundation.VersionControl.SymbolicLink" natively supported with TFvc

This is incomplete but enables work to be done for #1245 and #242 to be achievable.
 
---Please read and delete this text before creating this pull request---
Thanks a lot for the pull request you are going to do!
Please verify that you validate these points:

- [x] indentation is made with 4 spaces
- [x] your pull request contains only changes intended (no refactoring, line return added, ... that could make code review harder. Make another one if you think it is needed...)
- [x] run and verify that existing tests pass. Add some new units tests, if needed.
- [x] update the documentation, if needed.
- [x] update the [release notes file](../tree/master/doc/release-notes/NEXT.md)

------------------------------------------------------------------------