### PR TITLE
Update ProGit2 links, as the TFS content is removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ Have a look to more detailed git-tfs use cases:
 * [Manage TFS branches with git-tfs](doc/usecases/manage_tfs_branches.md)
 * [Migrate your history from TFSVC to a git repository](doc/usecases/migrate_tfs_to_git.md)
 * [Working with shelvesets](doc/usecases/working_with_shelvesets.md)
-* [Git and Tfs (ProGit v2 Book)](https://git-scm.com/book/en/v2/Git-and-Other-Systems-Git-as-a-Client#_git_and_tfs)
-* [Migrate from Tfs to Git (ProGit v2 Book)](https://git-scm.com/book/en/v2/Git-and-Other-Systems-Migrating-to-Git#_git_tfs)
+* [Git (ProGit v2 book)](https://git-scm.com/book/en/v2)
+* [Last ProGit2 release to cover Git Tfs and migration](https://github.com/progit/progit2/releases/tag/2.1.245)
 
 ## Available commands / options
 


### PR DESCRIPTION
**Changes this pull request makes:**

- Update both links to the ProGit 2 book
- Ensure that readers can still find the last release that covers TFS and the migration towards Git

**Context:**

I made the last push to remove the TFS content from the Pro Git book, seeing as the content was getting badly out of date, and that the TFS project is end of life. This removal was done after discussing with the Pro Git 2 author on this move, and after people have had ample time to complain about the proposed removal at https://github.com/progit/progit2/issues/1326. Nobody has complained since Oct 29,2019, so the decision was made to remove the content.

The old content can still be found in html, epub, pdf and mobi formats though, so it's not totally gone!

Prior discussion that happened before deciding to remove the TFS content:
https://github.com/progit/progit2/pull/1322
https://github.com/progit/progit2/issues/1323
https://github.com/progit/progit2/issues/1326

Pull request that removes the TFS content:
https://github.com/progit/progit2/pull/1480