### PR TITLE
Example method to use Server location for the workspace.

### DIFF
--- a/src/GitTfs.VsCommon/TfsHelper.Common.cs
+++ b/src/GitTfs.VsCommon/TfsHelper.Common.cs
@@ -723,7 +723,11 @@ namespace GitTfs.VsCommon
 
         private Workspace GetWorkspace(params WorkingFolder[] folders)
         {
-            var workspace = VersionControl.CreateWorkspace(GenerateWorkspaceName());
+            var workspaceParameters = new CreateWorkspaceParameters(GenerateWorkspaceName())
+            {
+                Location = Microsoft.TeamFoundation.VersionControl.Common.WorkspaceLocation.Server
+            };
+            var workspace = VersionControl.CreateWorkspace(workspaceParameters);
             try
             {
                 SetWorkspaceMappingFolders(workspace, folders);


### PR DESCRIPTION
This is only an example.

Example method to use Server location for the workspace. This is not an ideal way to do this and instead of being hardcoded as one way or the other, should ideally be an option that the caller can specify.