### PR TITLE
Use --rebase-merges for rebase instead of the deprecated --preserve-merges

### DIFF
--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -1,0 +1,5 @@
+* Replace usage of the deprecated `git rebase --preserve-merges` with its sucessor `git rebase --rebase-merges`.  
+  `git rebase --preserve-merges` was introduced in git v2.18.0. Using any older git version won't work.  
+  HINT: Rebasing actual merge commits is nevertheless not something recommended by the git project itself,
+  as it will lose any conflict resolution of the merge commit when it is rebased. 
+  This is independent on the used commandline switch.

--- a/src/GitTfs/Commands/Pull.cs
+++ b/src/GitTfs/Commands/Pull.cs
@@ -50,7 +50,7 @@ namespace GitTfs.Commands
                         throw new GitTfsException("error: You have local changes; rebase-workflow only possible with clean working directory.")
                             .WithRecommendation("Try 'git stash' to stash your local changes and pull again.");
                     }
-                    _globals.Repository.CommandNoisy("rebase", "--preserve-merges", remote.RemoteRef);
+                    _globals.Repository.CommandNoisy("rebase", "--rebase-merges", remote.RemoteRef);
                 }
                 else
                     _globals.Repository.Merge(remote.RemoteRef);

--- a/src/GitTfs/Commands/Rcheckin.cs
+++ b/src/GitTfs/Commands/Rcheckin.cs
@@ -85,7 +85,7 @@ namespace GitTfs.Commands
             {
                 if (AutoRebase)
                 {
-                    _globals.Repository.CommandNoisy("rebase", "--preserve-merges", parentChangeset.Remote.RemoteRef);
+                    _globals.Repository.CommandNoisy("rebase", "--rebase-merges", parentChangeset.Remote.RemoteRef);
                     parentChangeset = _globals.Repository.GetTfsCommit(parentChangeset.Remote.MaxCommitHash);
                 }
                 else
@@ -142,7 +142,7 @@ namespace GitTfs.Commands
                         var lastCommit = _globals.Repository.FindCommitHashByChangesetId(newChangesetId);
                         RebaseOnto(lastCommit, target);
                         if (AutoRebase)
-                            tfsRemote.Repository.CommandNoisy("rebase", "--preserve-merges", tfsRemote.RemoteRef);
+                            tfsRemote.Repository.CommandNoisy("rebase", "--rebase-merges", tfsRemote.RemoteRef);
                         else
                             throw new GitTfsException("error: New TFS changesets were found. Rcheckin was not finished.");
                     }
@@ -214,7 +214,7 @@ namespace GitTfs.Commands
 
         public void RebaseOnto(string newBaseCommit, string oldBaseCommit)
         {
-            _globals.Repository.CommandNoisy("rebase", "--preserve-merges", "--onto", newBaseCommit, oldBaseCommit);
+            _globals.Repository.CommandNoisy("rebase", "--rebase-merges", "--onto", newBaseCommit, oldBaseCommit);
         }
     }
 }


### PR DESCRIPTION
git rebase --rebase-merges commandline switch was introduced in Git
version v2.18.0 (released on 2018-06-21) to replace the --preserve-merges
commandline switch to git rebase. Since v2.22.0 the old --preserve-merges
is offically deprecated.

Replace the deprecated usage of --preserve-merges with the newer --rebase-merges
option on all occurences.

The decision was made that the git version v2.18.0 as the minimum required version
is reasonably old enough to assume that the user has it (or a newer version)
installed on his machine. Therefore no version dependend logic on which
switch to select was implemented here.