### PR TITLE
Correct error message shown when `git tfs clone` fails

### DIFF
--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -5,3 +5,4 @@
   This is independent on the used commandline switch. (#1342)
 * Improve performance by caching branch objects instead of looking them up over and over (#1286)
 * Upgrade to .NET Framework 4.7.2 and upgrade NuGet dependencies (#1344 by @siprbaum)
+* Correct error message shown when `git tfs clone` has an error (#1347 by @siprbaum)

--- a/src/GitTfs/Commands/Clone.cs
+++ b/src/GitTfs/Commands/Clone.cs
@@ -139,7 +139,7 @@ namespace GitTfs.Commands
             {
                 errorOccurs = true;
                 throw new GitTfsException("error: a problem occurred when trying to clone the repository. Try to solve the problem described below.\nIn any case, after, try to continue using command `git tfs "
-                    + (_fetch.BranchStrategy == BranchStrategy.All ? "branch init --all" : "fetch") + "`\n", ex);
+                    + (_fetch.BranchStrategy == BranchStrategy.All ? "branch --init --all" : "fetch") + "`\n", ex);
             }
             finally
             {


### PR DESCRIPTION
git tfs branch has an option `--init`, not another subcommand `init`.

Fixes #1135