### PR TITLE
Check if the necessary libraries are available before opening checkin tool

### DIFF
--- a/src/GitTfs.VsCommon/TfsHelper.Common.cs
+++ b/src/GitTfs.VsCommon/TfsHelper.Common.cs
@@ -880,8 +880,20 @@ namespace GitTfs.VsCommon
             return VersionControl.AuthorizedUser;
         }
 
-        public bool CanShowCheckinDialog { get { return true; } }
-
+        public bool CanShowCheckinDialog
+        {
+            get
+            {
+                try
+                {
+                    return GetCheckinDialogType() != null;
+                }
+                catch (Exception)
+                {
+                    return false;
+                }
+            }
+        }
         public ITfsChangeset GetShelvesetData(IGitTfsRemote remote, string shelvesetOwner, string shelvesetName)
         {
             shelvesetOwner = shelvesetOwner == "all" ? null : (shelvesetOwner ?? GetAuthenticatedUser());

--- a/src/GitTfs/Commands/CheckinTool.cs
+++ b/src/GitTfs/Commands/CheckinTool.cs
@@ -18,7 +18,10 @@ namespace GitTfs.Commands
             if (!changeset.Remote.Tfs.CanShowCheckinDialog)
                 throw new GitTfsException(
                     "checkintool does not work with this TFS version (" + changeset.Remote.Tfs.TfsClientLibraryVersion + ").",
-                    new[] { "Try installing the VS2010 edition of Team Explorer." });
+                    new[] {
+                        "Try installing the Team Explorer matching the TFS client libraries",
+                        "Alternatively, set the GIT_TFS_CLIENT environment variable to a supported/installed Visual Studio version",
+                        });
 
             return changeset.Remote.CheckinTool(refToCheckin, changeset);
         }


### PR DESCRIPTION
When trying to run `git tfs checkintool` the code actually calls into
`CanShowDialog`, but that method has an implementation of `return true`.

In situations where the matching Visual Studio version wasn't installed
this implementation it obviously wrong.

Implement `CanShowDialog` for real and only return true when we actually
have the necessary type available to instantiate the dialog.
All other (error) cases return false, meaning "No, we don't support the
checkin dialog".

Furthermore, improve the error message to give the user a better chance
to figure out what is missing to make the command work.

Fixes #1312