### PR TITLE
Incorporate review comments for the release notes

### DIFF
--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -6,14 +6,14 @@
 * Improve performance by caching branch objects instead of looking them up over and over (#1286)
 * Upgrade to .NET Framework 4.7.2 and upgrade NuGet dependencies (#1344 by @siprbaum)
 * Correct error message shown when `git tfs clone` has an error (#1347 by @siprbaum)
-* Add support for Visual Studio 2017 (no checkin pocicies yet). To use it set the
-  environment variable `GIT_TFS_CLIENT` to `2017`. Multiple versions of VS2017 installed side by side,
-  either as different editions like VS2017 Enterprise  and Premium or different VS2017 minor versions are
-  not offically supported yet. The current implementation will simply use the first version found. (#1348 by siprbaum)
-* Add support for Visual Studio 2019 (no checkin pocicies yet). To use it set the
-  environment variable `GIT_TFS_CLIENT` to `2019`. Them same restrictions as for VS2017 apply, e.g.
-  multiple versions of VS2019 installed side by side,  either as different editions like VS2019 Enterprise
-  and Premium or different VS2019 minor versions are not offically supported yet. The current implementation
-  will simply use the first version found. (#1355 by siprbaum)
+* Add support for Visual Studio 2017. To use it set the environment variable `GIT_TFS_CLIENT` to `2017`.
+  Multiple versions of VS2017 installed side by side, either as different editions like VS2017 Enterprise
+  and Premium or different VS2017 minor versions are not offically supported yet.
+  The current implementation will simply use the first version found. (#1348 by siprbaum)
+* Add support for Visual Studio 2019. To use it set the environment variable `GIT_TFS_CLIENT` to `2019`.
+  The same restrictions as for VS2017 apply, e.g. multiple versions of VS2019 installed side by side,
+  either as different editions like VS2019 Enterprise and Premium or different VS2019 minor
+  versions are not offically supported yet. The current implementation will simply use
+  the first version found. (#1355 by siprbaum)
 * Add support for checkin policies for Visual Studio 2017 and Visual Studio 2019 (#1356 by siprbaum)
 


### PR DESCRIPTION
This makes it clearer that checkin policies are supported now, as before
we mentioned them explicitely as "not supported yet" in the entries where
VS 2017 and VS 2019 were introduced.

I reflowed the paragraphs, so this is best reviewed with
`git diff --word-diff`