### PR TITLE
[Fix] Add GitTfs.VS2019 to the cake.build

### DIFF
--- a/src/build.cake
+++ b/src/build.cake
@@ -218,6 +218,7 @@ Task("Build").Description("Build git-tfs")
 			.SetMaxCpuCount(4);
 		settings.WithTarget("GitTfs_Vs2015")
 			.WithTarget("GitTfs_Vs2017")
+			.WithTarget("GitTfs_Vs2019")
 			.WithTarget(TestProjectName);
 	});
 });


### PR DESCRIPTION
In f2f6da15 ("Add support for VS2019", 2020-08-03) the support for VS2019
was added, but it was not added to the cake.build script, meaning that
the VS2019 support isn't build/packaged.

Correct this oversight by adding the GitTfs.Vs2019 to the cake.build file.