### PR TITLE
GitTfsRemote: remove unused variable to silence build warning

### DIFF
--- a/src/GitTfs/Core/GitTfsRemote.cs
+++ b/src/GitTfs/Core/GitTfsRemote.cs
@@ -18,7 +18,6 @@ namespace GitTfs.Core
         private readonly Globals _globals;
         private readonly RemoteOptions _remoteOptions;
         private readonly ConfigProperties _properties;
-        private readonly bool _disableGitignoreSupport;
         private int? firstChangesetId;
         private int? maxChangesetId;
         private string maxCommitHash;


### PR DESCRIPTION
In 8eca32f (GitTfsRemote: Cleanup gitignore support configuration handling,
2018-08-11) the last remaining user of the _disableGitingoreSupport variable
was removed, but the member variable was not. Remove it now to silence
a build warning.