### PR TITLE
ProcessCheckinNoteCommand: don't trim the commit message unconditionally 

### DIFF
--- a/src/GitTfs/Util/CheckinOptionsExtensions.cs
+++ b/src/GitTfs/Util/CheckinOptionsExtensions.cs
@@ -43,8 +43,8 @@ namespace GitTfs.Util
 
         public static void ProcessWorkItemCommands(this CheckinOptions checkinOptions, bool isResolvable = true)
         {
-            MatchCollection workitemMatches;
-            if ((workitemMatches = GitTfsConstants.TfsWorkItemRegex.Matches(checkinOptions.CheckinComment)).Count > 0)
+            MatchCollection workitemMatches = GitTfsConstants.TfsWorkItemRegex.Matches(checkinOptions.CheckinComment);
+            if (workitemMatches.Count > 0)
             {
                 foreach (Match match in workitemMatches)
                 {

--- a/src/GitTfs/Util/CheckinOptionsExtensions.cs
+++ b/src/GitTfs/Util/CheckinOptionsExtensions.cs
@@ -82,7 +82,11 @@ namespace GitTfs.Util
 
         public static void ProcessCheckinNoteCommands(this CheckinOptions checkinOptions)
         {
-            foreach (Match match in GitTfsConstants.TfsReviewerRegex.Matches(checkinOptions.CheckinComment))
+            MatchCollection matches = GitTfsConstants.TfsReviewerRegex.Matches(checkinOptions.CheckinComment);
+            if (matches.Count == 0)
+                return;
+
+            foreach (Match match in matches)
             {
                 string reviewer = match.Groups["reviewer"].Value;
                 if (!string.IsNullOrWhiteSpace(reviewer))

--- a/src/GitTfs/Util/CheckinOptionsExtensions.cs
+++ b/src/GitTfs/Util/CheckinOptionsExtensions.cs
@@ -107,26 +107,21 @@ namespace GitTfs.Util
             checkinOptions.CheckinComment = GitTfsConstants.TfsReviewerRegex.Replace(checkinOptions.CheckinComment, "").Trim(' ', '\r', '\n');
         }
 
-
-
         public static void ProcessForceCommand(this CheckinOptions checkinOptions)
         {
-            MatchCollection workitemMatches;
-            if ((workitemMatches = GitTfsConstants.TfsForceRegex.Matches(checkinOptions.CheckinComment)).Count == 1)
+            MatchCollection workitemMatches = GitTfsConstants.TfsForceRegex.Matches(checkinOptions.CheckinComment);
+            if (workitemMatches.Count != 1)
+                return;
+
+            string overrideReason = workitemMatches[0].Groups["reason"].Value;
+            if (!string.IsNullOrWhiteSpace(overrideReason))
             {
-                string overrideReason = workitemMatches[0].Groups["reason"].Value;
-
-                if (!string.IsNullOrWhiteSpace(overrideReason))
-                {
-                    Trace.TraceInformation("Forcing the checkin: {0}", overrideReason);
-                    checkinOptions.Force = true;
-                    checkinOptions.OverrideReason = overrideReason;
-                }
-                checkinOptions.CheckinComment = GitTfsConstants.TfsForceRegex.Replace(checkinOptions.CheckinComment, "").Trim(' ', '\r', '\n');
+                Trace.TraceInformation("Forcing the checkin: {0}", overrideReason);
+                checkinOptions.Force = true;
+                checkinOptions.OverrideReason = overrideReason;
             }
+            checkinOptions.CheckinComment = GitTfsConstants.TfsForceRegex.Replace(checkinOptions.CheckinComment, "").Trim(' ', '\r', '\n');
         }
-
-
 
         public static void ProcessAuthor(this CheckinOptions checkinOptions, GitCommit commit, AuthorsFile authors)
         {


### PR DESCRIPTION
Prior to this PR, trailing whitespace (including CRLF or LF) was trimmed
from the message, **even** if no matching note was found. This was at
least unexpected. If such an unconditional cleanup should be done, it
better should be a step of its own.

Change it so that the whitespace trimming is only done when an actual note
was found (and therefore the message modified). This copies the
behaviour of other steps which make modifications to the commit message.

Removing this altoegether can be considered a behaviour change.
In practice, no one will notice as `git commit` itself will remove
trailing whitespace with `--cleanup=strip`, which is the default.
So in practice, there shouldn't be any trailing empty lines in the git
commits.

For better readability, two straight forward refactorings where included so
that the code is easier to understand and the different methods processing
the commit message follow the same structure after applying.
this change