### PR TITLE
Add documentation that cloning on a network share is not supported

### DIFF
--- a/doc/commands/clone.md
+++ b/doc/commands/clone.md
@@ -53,6 +53,13 @@ a TFS source tree and fetch all the changesets
 		  --resumable            if an error occurred, try to continue when you restart clone
 								 with same parameters
 
+## Remark
+
+Make sure that you use a local drive (and not a network share) where the clone is stored.
+`git-tfs` didn't receive any explicit testing for cloning on a network share and there are known reports
+like [Issue 1373](https://github.com/git-tfs/git-tfs/issues/1373) where cloning/fetching a shelveset
+didn't work when the clone was done on a network share.
+
 ## Examples
 ### Simple
 To clone all of `$/Project1` from your TFS server `tfs`

--- a/doc/commands/quick-clone.md
+++ b/doc/commands/quick-clone.md
@@ -67,6 +67,13 @@ Useful for making code changes or additions where past history isn't relevant.
 			(Type: Flag, Value Type:[Boolean])
 			parents
 
+## Remark
+
+Make sure that you use a local drive (and not a network share) where the clone is stored.
+`git-tfs` didn't receive any explicit testing for cloning on a network share and there are known reports
+like [Issue 1373](https://github.com/git-tfs/git-tfs/issues/1373) where cloning/fetching a shelveset
+didn't work when the clone was done on a network share.
+
 ## Examples
 
 ### Simple


### PR DESCRIPTION
A user reported in #1373 that cloning failed with an exception in libgit2

  LibGit2Sharp.LibGit2SharpException: failed to create temporary file 'P:/_GIT/.git/objects/tmp_object_git2_a05280'

Investigation revealed that the clone was done on a network share.
Switching to a local path worked.

Add a remark section to clone and quick-clone to document that a local
drive should be used for cloning.

closes #1373