### PR TITLE
Fix #1366 Frequent (and endless) login requests with dev.azure.com

### DIFF
--- a/src/GitTfs/Core/GitRepository.cs
+++ b/src/GitTfs/Core/GitRepository.cs
@@ -123,12 +123,17 @@ namespace GitTfs.Core
             SetConfig(key, value.ToString().ToLower());
         }
 
-
         public IEnumerable<IGitTfsRemote> ReadAllTfsRemotes()
         {
             var remotes = GetTfsRemotes().Values;
-            foreach (var remote in remotes)
-                remote.EnsureTfsAuthenticated();
+            
+            var paths = remotes.Select(r => r.TfsRepositoryPath.Replace("$/", "").ToLower()).ToList();
+            var commonPrefix = paths.Count > 0 ? string.Join("", paths.Min().TakeWhile((c, i) => paths.All(s => s[i] == c))) : null;
+            if (!string.IsNullOrEmpty(commonPrefix))
+                remotes.First().EnsureTfsAuthenticated();
+            else
+                foreach (var remote in remotes)
+                    remote.EnsureTfsAuthenticated();
 
             return remotes;
         }


### PR DESCRIPTION
This is a fix issue #1366 Frequent (and endless) login requests with dev.azure.com
It implements @siprbaum suggestion "if all the paths are under the same path, authenticating for one is enough".
I'm again able to keep several git repos in sync with their tfvc counterparts in Azure and all the unit tests are passing.
