### PR TITLE
GitTfsRemote: Make --changeset keep already commited files

### DIFF
--- a/src/GitTfs/Core/GitTfsRemote.cs
+++ b/src/GitTfs/Core/GitTfsRemote.cs
@@ -857,7 +857,7 @@ namespace GitTfs.Core
             LogEntry result = null;
             WithWorkspace(changeset.Summary, workspace =>
             {
-                var treeBuilder = workspace.Remote.Repository.GetTreeBuilder(null);
+                var treeBuilder = workspace.Remote.Repository.GetTreeBuilder(lastCommit);
                 result = changeset.CopyTree(treeBuilder, workspace);
                 result.Tree = treeBuilder.GetTree();
             });


### PR DESCRIPTION
On `git tfs clone ...` with both `--changeset=VALUE` and `--gitignore=VALUE`, `--changeset` option causes "git-tfs" to start with "a clean sheet" (an empty tree), probably expecting it to be the changeset to clone from into initial/root commit, thus not paying attention if there are any files commited already, ending up loosing them (like ".gitignore" one, in case of `--gitignore=VALUE`).

That might make sense by itself, if initial changeset would always be cloned into initial/root commit - yet, while not caring about the tree to start from, CopyTree() build logic does actually care about possibly existing commits, last one being added as cloned initial changeset commit parent. But because its already existing tree is disregarded, cloned initial changeset commit additionally removes all previously existing files, making the resulting tree appear as if history started with cloned initial changeset commit only, instead of whichever commit(s) preceded it.

To get the `--changeset` logic in sync, caring _both_ about already existing commit(s) _and_ corresponding tree(s), when present, let's make sure to start cloning into an existing (last commit) tree, instead of an empty one.

Resolve #1381 