### PR TITLE
Support for various TFS Authentication

### DIFF
--- a/doc/release-notes/v0.33.0.md
+++ b/doc/release-notes/v0.33.0.md
@@ -1,0 +1,8 @@
+* added ability to pass in PAT token, only valid for 2017, 2019, using --pat
+* added code to use trusted credentials if PAT and Username / Password are not passed in
+* added code to prompt for password if only username is passed in
+* altered clone code to only query branches specific to the TFS path being cloned IF the path is not $/. This greatly speeds up the cloning 
+* altered clone code to allow cloning of folders as well as branches IF the branch strategy is none
+* added TFS url to the changeset to the commit message
+* added total elapsed time to the output after the command completes
+

--- a/src/GitTfs.Vs2015/GitTfs.Vs2015.csproj
+++ b/src/GitTfs.Vs2015/GitTfs.Vs2015.csproj
@@ -34,6 +34,11 @@
     <None Include="app.config" />
     <None Include="paket.references" />
   </ItemGroup>
+  <!-- <ItemGroup> -->
+    <!-- <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="14.0.0" /> -->
+    <!-- <PackageReference Include="Microsoft.TeamFoundationServer.ExtendedClient" Version="14.0.0" /> -->
+    <!-- <PackageReference Include="Newtonsoft.Json" Version="10.0.3" /> -->
+  <!-- </ItemGroup> -->
       <ItemGroup>
     <Reference Include="System.Windows.Forms" />
       </ItemGroup>

--- a/src/GitTfs.Vs2015/TfsHelper.Vs2015.cs
+++ b/src/GitTfs.Vs2015/TfsHelper.Vs2015.cs
@@ -72,7 +72,7 @@ namespace GitTfs.Vs2015
 
         protected override TfsTeamProjectCollection GetTfsCredential(Uri uri)
         {
-            return HasCredentials ?
+            return HasUserName ?
                 new TfsTeamProjectCollection(uri, GetCredential(), new UICredentialsProvider()) :
                 new TfsTeamProjectCollection(uri, new UICredentialsProvider());
 #pragma warning restore 618

--- a/src/GitTfs.Vs2017/GitTfs.Vs2017.csproj
+++ b/src/GitTfs.Vs2017/GitTfs.Vs2017.csproj
@@ -36,6 +36,14 @@
   <ItemGroup>
     <None Include="paket.references" />
   </ItemGroup>
+  <!-- <ItemGroup> -->
+    <!-- <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="15.112.1" /> -->
+    <!-- <PackageReference Include="Microsoft.TeamFoundationServer.ExtendedClient" Version="15.112.1" /> -->
+    <!-- <PackageReference Include="Microsoft.VisualStudio.RegDetour" Version="16.10.31320.204" /> -->
+    <!-- <PackageReference Include="Microsoft.VisualStudio.Settings.15.0" Version="15.0.26606" /> -->
+    <!-- <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="1.15.103"/> -->
+    <!-- <PackageReference Include="Newtonsoft.Json" Version="10.0.3" /> -->
+  <!-- </ItemGroup> -->
   <ItemGroup>
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>

--- a/src/GitTfs.Vs2019/GitTfs.Vs2019.csproj
+++ b/src/GitTfs.Vs2019/GitTfs.Vs2019.csproj
@@ -36,6 +36,14 @@
   <ItemGroup>
     <None Include="paket.references" />
   </ItemGroup>
+  <!-- <ItemGroup> -->
+    <!-- <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.0.0" /> -->
+    <!-- <PackageReference Include="Microsoft.TeamFoundationServer.ExtendedClient" Version="16.0.0" /> -->
+    <!-- <PackageReference Include="Microsoft.VisualStudio.RegDetour" Version="16.10.31320.204" /> -->
+    <!-- <PackageReference Include="Microsoft.VisualStudio.Settings.15.0" Version="16.0.0" /> -->
+    <!-- <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="1.15.103" /> -->
+    <!-- <PackageReference Include="Newtonsoft.Json" Version="10.0.3" /> -->
+  <!-- </ItemGroup> -->
   <ItemGroup>
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>

--- a/src/GitTfs.VsCommon/TfsHelper.Vs2017Base.cs
+++ b/src/GitTfs.VsCommon/TfsHelper.Vs2017Base.cs
@@ -195,9 +195,14 @@ namespace GitTfs.VsCommon
 
         protected override TfsTeamProjectCollection GetTfsCredential(Uri uri)
         {
-            var vssCred = HasCredentials
-                ? new VssClientCredentials(new WindowsCredential(GetCredential()))
-                : VssClientCredentials.LoadCachedCredentials(uri, false, CredentialPromptType.PromptIfNeeded);
+            VssCredentials vssCred;
+
+            if (HasPAT)
+                vssCred = new VssBasicCredential(string.Empty, PAT);
+            else if (HasUserName && !HasPassword)
+                vssCred = VssClientCredentials.LoadCachedCredentials(uri, false, CredentialPromptType.PromptIfNeeded);
+            else
+                vssCred = new VssClientCredentials(new WindowsCredential(GetCredential()));
 
             return new TfsTeamProjectCollection(uri, vssCred);
 #pragma warning restore 618

--- a/src/GitTfs.VsFake/GitTfs.VsFake.csproj
+++ b/src/GitTfs.VsFake/GitTfs.VsFake.csproj
@@ -11,6 +11,9 @@
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
   </ItemGroup>
+  <!-- <ItemGroup> -->
+    <!-- <PackageReference Include="StructureMap" Version="2.6.3" /> -->
+  <!-- </ItemGroup> -->
   <ItemGroup>
     <ProjectReference Include="..\GitTfs\GitTfs.csproj" />
   </ItemGroup>

--- a/src/GitTfs.VsFake/TfsHelper.VsFake.cs
+++ b/src/GitTfs.VsFake/TfsHelper.VsFake.cs
@@ -40,6 +40,7 @@ namespace GitTfs.VsFake
         public string Url { get; set; }
         public string Username { get; set; }
         public string Password { get; set; }
+        public string PAT { get; set; }
 
         public void EnsureAuthenticated() { }
 
@@ -531,6 +532,21 @@ namespace GitTfs.VsFake
         }
 
         public void DeleteShelveset(IWorkspace workspace, string shelvesetName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool ValidateTfsFolder(string remoteTfsPath)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void ClearBranches()
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<IBranchObject> GetBranches(string remoteTfsPath, bool getAlsoDeletedBranches = false, bool searchAllBranches = true)
         {
             throw new NotImplementedException();
         }

--- a/src/GitTfs/Commands/Create.cs
+++ b/src/GitTfs/Commands/Create.cs
@@ -49,6 +49,7 @@ ex : git tfs create http://myTfsServer:8080/tfs/TfsRepository myProjectName
             _tfsHelper.Url = tfsUrl;
             _tfsHelper.Username = _remoteOptions.Username;
             _tfsHelper.Password = _remoteOptions.Password;
+            _tfsHelper.PAT = _remoteOptions.PAT;
 
             var absoluteGitRepositoryPath = Path.GetFullPath(gitRepositoryPath);
             Trace.TraceInformation("Creating project folder...");

--- a/src/GitTfs/Commands/ListRemoteBranches.cs
+++ b/src/GitTfs/Commands/ListRemoteBranches.cs
@@ -34,6 +34,7 @@ namespace GitTfs.Commands
             _tfsHelper.Url = tfsUrl;
             _tfsHelper.Username = _remoteOptions.Username;
             _tfsHelper.Password = _remoteOptions.Password;
+            _tfsHelper.PAT = _remoteOptions.PAT;
             _tfsHelper.EnsureAuthenticated();
 
             if (!_tfsHelper.CanGetBranchInformation)

--- a/src/GitTfs/Commands/RemoteOptions.cs
+++ b/src/GitTfs/Commands/RemoteOptions.cs
@@ -24,6 +24,8 @@ namespace GitTfs.Commands
                         v => Username = v },
                     { "p|password=", "TFS password",
                         v => Password = v },
+                    { "pat=", "TFS Personal Access Token",
+                        v => PAT = v },
                     { "no-parallel", "Do not do parallel requests to TFS",
                         v => NoParallel = (v != null) },
                 };
@@ -37,6 +39,7 @@ namespace GitTfs.Commands
         public bool NoGitIgnore { get; set; }
         public string Username { get; set; }
         public string Password { get; set; }
+        public string PAT { get; set; }
         public bool NoParallel { get; set; }
     }
 }

--- a/src/GitTfs/Core/DerivedGitTfsRemote.cs
+++ b/src/GitTfs/Core/DerivedGitTfsRemote.cs
@@ -73,6 +73,18 @@ namespace GitTfs.Core
             }
         }
 
+        public string TfsPAT
+        {
+            get
+            {
+                throw DerivedRemoteException;
+            }
+            set
+            {
+                throw DerivedRemoteException;
+            }
+        }
+
         public string TfsRepositoryPath
         {
             get { return _tfsRepositoryPath; }

--- a/src/GitTfs/Core/GitTfsRemote.cs
+++ b/src/GitTfs/Core/GitTfsRemote.cs
@@ -37,8 +37,12 @@ namespace GitTfs.Core
             Id = info.Id;
             TfsUrl = info.Url;
             TfsRepositoryPath = info.Repository;
-            TfsUsername = info.Username;
-            TfsPassword = info.Password;
+            //TIM C: I found this to be very confusing. The tfs user name /password appears to come the
+            //remoteoptions object, and not the info object, so I coalesced them, to just cover both bases
+            TfsUsername = info.Username ?? _remoteOptions.Username;
+            TfsPassword = info.Password ?? _remoteOptions.Password;
+            TfsPAT = info.PAT ?? _remoteOptions.PAT;
+
             Aliases = (info.Aliases ?? Enumerable.Empty<string>()).ToArray();
             IgnoreRegexExpression = info.IgnoreRegex;
             IgnoreExceptRegexExpression = info.IgnoreExceptRegex;
@@ -132,6 +136,13 @@ namespace GitTfs.Core
             get { return Tfs.Password; }
             set { Tfs.Password = value; }
         }
+
+        public string TfsPAT
+        {
+            get { return Tfs.PAT; }
+            set { Tfs.PAT = value; }
+        }
+
 
         public string TfsRepositoryPath { get; set; }
 
@@ -875,8 +886,13 @@ namespace GitTfs.Core
         {
             var builder = new StringWriter();
             builder.WriteLine(tfsCheckinComment);
-            builder.WriteLine(GitTfsConstants.TfsCommitInfoFormat,
-                TfsUrl, TfsRepositoryPath, changesetId);
+            builder.WriteLine(GitTfsConstants.TfsCommitInfoFormat, TfsUrl, TfsRepositoryPath, changesetId);
+
+            var match = Regex.Match(TfsRepositoryPath, @"\$/(?<TeamProject>[^/]*?)/");
+            if (match.Success)
+                builder.WriteLine(GitTfsConstants.TfsCommitUrlFormat, TfsUrl, match.Groups["TeamProject"].Value, changesetId);
+
+
             return builder.ToString();
         }
 

--- a/src/GitTfs/Core/IGitTfsRemote.cs
+++ b/src/GitTfs/Core/IGitTfsRemote.cs
@@ -44,6 +44,7 @@ namespace GitTfs.Core
         bool Autotag { get; set; }
         string TfsUsername { get; set; }
         string TfsPassword { get; set; }
+        string TfsPAT { get; set; }
         IGitRepository Repository { get; set; }
         ITfsHelper Tfs { get; set; }
         int MaxChangesetId { get; set; }

--- a/src/GitTfs/Core/RemoteConfigConverter.cs
+++ b/src/GitTfs/Core/RemoteConfigConverter.cs
@@ -27,6 +27,8 @@ namespace GitTfs.Core
                         remote.Username = entry.Value;
                     else if (key == "password")
                         remote.Password = entry.Value;
+                    else if (key == "pat")
+                        remote.PAT = entry.Value;
                     else if (key == "ignore-paths")
                         remote.IgnoreRegex = entry.Value;
                     else if (key == "ignore-except")
@@ -53,6 +55,7 @@ namespace GitTfs.Core
                 yield return c(prefix + "repository", remote.Repository);
                 yield return c(prefix + "username", remote.Username);
                 yield return c(prefix + "password", remote.Password);
+                yield return c(prefix + "pat", remote.PAT);
                 yield return c(prefix + "ignore-paths", remote.IgnoreRegex);
                 yield return c(prefix + "ignore-except", remote.IgnoreExceptRegex);
                 yield return c(prefix + "gitignore-path", remote.GitIgnorePath);

--- a/src/GitTfs/Core/RemoteInfo.cs
+++ b/src/GitTfs/Core/RemoteInfo.cs
@@ -10,6 +10,7 @@ namespace GitTfs.Core
         public string Repository { get; set; }
         public string Username { get; set; }
         public string Password { get; set; }
+        public string PAT { get; set; }
         public string IgnoreRegex { get; set; }
         public string IgnoreExceptRegex { get; set; }
         public string GitIgnorePath { get; set; }

--- a/src/GitTfs/Core/TfsInterop/IBranch.cs
+++ b/src/GitTfs/Core/TfsInterop/IBranch.cs
@@ -58,13 +58,13 @@ namespace GitTfs.Core.TfsInterop
         ///     If the root branch matching the search criteria was not found, it try to search by all deleted branches to.
         ///     This can usable if the user want to clone a deleted branch.
         /// </remarks>
-        public static BranchTree GetRootTfsBranchForRemotePath(this ITfsHelper tfs, string remoteTfsPath, bool searchExactPath = true)
-            => GetRootTfsBranchForRemotePath(tfs, remoteTfsPath, searchExactPath, false) ??
-               GetRootTfsBranchForRemotePath(tfs, remoteTfsPath, searchExactPath, true);
+        public static BranchTree GetRootTfsBranchForRemotePath(this ITfsHelper tfs, string remoteTfsPath, bool searchExactPath = true, bool searchAllBranches = true)
+            => GetRootTfsBranchForRemotePath(tfs, remoteTfsPath, searchExactPath, false, searchAllBranches) ??
+               GetRootTfsBranchForRemotePath(tfs, remoteTfsPath, searchExactPath, true, searchAllBranches);
 
-        private static BranchTree GetRootTfsBranchForRemotePath(this ITfsHelper tfs, string remoteTfsPath, bool searchExactPath, bool searchDeletedBranches)
+        private static BranchTree GetRootTfsBranchForRemotePath(this ITfsHelper tfs, string remoteTfsPath, bool searchExactPath, bool searchDeletedBranches, bool searchAllBranches = true)
         {
-            var branches = tfs.GetBranches(searchDeletedBranches);
+            var branches = tfs.GetBranches(remoteTfsPath, searchDeletedBranches, searchAllBranches);
             var branchTrees = branches.Aggregate(new Dictionary<string, BranchTree>(StringComparer.OrdinalIgnoreCase), (dict, branch) => dict.Tap(d => d.Add(branch.Path, new BranchTree(branch))));
             foreach (var branch in branchTrees.Values)
             {

--- a/src/GitTfs/Core/TfsInterop/ITfsHelper.cs
+++ b/src/GitTfs/Core/TfsInterop/ITfsHelper.cs
@@ -10,6 +10,7 @@ namespace GitTfs.Core.TfsInterop
         string Url { get; set; }
         string Username { get; set; }
         string Password { get; set; }
+        string PAT { get; set; }
         IEnumerable<ITfsChangeset> GetChangesets(string path, int startVersion, IGitTfsRemote remote, int lastVersion = -1, bool byLots = false);
         void WithWorkspace(string directory, IGitTfsRemote remote, TfsChangesetInfo versionToFetch, Action<ITfsWorkspace> action);
         IShelveset CreateShelveset(IWorkspace workspace, string shelvesetName);
@@ -30,8 +31,11 @@ namespace GitTfs.Core.TfsInterop
         IList<RootBranch> GetRootChangesetForBranch(string tfsPathBranchToCreate, int lastChangesetIdToCheck = -1, string tfsPathParentBranch = null);
         IEnumerable<TfsLabel> GetLabels(string tfsPathBranch, string nameFilter = null);
         bool CanGetBranchInformation { get; }
+        bool ValidateTfsFolder(string remoteTfsPath);
+        void ClearBranches();
         IEnumerable<string> GetAllTfsRootBranchesOrderedByCreation();
         IEnumerable<IBranchObject> GetBranches(bool getDeletedBranches = false);
+        IEnumerable<IBranchObject> GetBranches(string remoteTfsPath, bool getAlsoDeletedBranches = false, bool searchAllBranches = true);
         void EnsureAuthenticated();
         void CreateBranch(string sourcePath, string targetPath, int changesetId, string comment = null);
         void CreateTfsRootBranch(string projectName, string mainBranch, string gitRepositoryPath, bool createTeamProjectFolder);

--- a/src/GitTfs/GitTfs.csproj
+++ b/src/GitTfs/GitTfs.csproj
@@ -29,6 +29,12 @@
     <None Include="Core\TfsInterop\README.txt" />
     <None Include="paket.references" />
   </ItemGroup>
+  <!-- <ItemGroup> -->
+    <!-- <PackageReference Include="LibGit2Sharp" Version="0.26.1" /> -->
+    <!-- <PackageReference Include="nlog" Version="4.7.10" /> -->
+    <!-- <PackageReference Include="StructureMap" Version="2.6.3" /> -->
+    <!-- <PackageReference Include="StructureMap.AutoMocking" Version="2.6.3" /> -->
+  <!-- </ItemGroup> -->
   <ItemGroup>
     <ProjectReference Include="..\NDesk.Options\NDesk.Options.csproj" />
   </ItemGroup>

--- a/src/GitTfs/GitTfsConstants.cs
+++ b/src/GitTfs/GitTfsConstants.cs
@@ -17,6 +17,7 @@ namespace GitTfs
         public const string GitTfsPolicyOverrideCommentPrefix = GitTfsPrefix + "-force:";
         // e.g. git-tfs-id: [http://team:8080/]$/sandbox;C123
         public const string TfsCommitInfoFormat = "git-tfs-id: [{0}]{1};C{2}";
+        public const string TfsCommitUrlFormat = "git-tfs-url: {0}/{1}/_versionControl/changeset/{2}";
         public static readonly Regex TfsCommitInfoRegex =
                 new Regex("^\\s*" +
                           GitTfsPrefix +

--- a/src/GitTfs/Program.cs
+++ b/src/GitTfs/Program.cs
@@ -25,13 +25,33 @@ namespace GitTfs
         {
             try
             {
+                var sw = Stopwatch.StartNew();
+
                 Environment.ExitCode = MainCore(args);
+
+                sw.Stop();
+                // could write it out like this: mm\\:ss\\.ff, using readable format instead
+                Console.WriteLine("\r\nCompleted in {0}{1}{2}{3}",
+                    FormatTime(sw.Elapsed.Days, "day"), //hopefully this should never happen??? :)
+                    FormatTime(sw.Elapsed.Hours, "hour"), 
+                    FormatTime(sw.Elapsed.Minutes, "minute"), 
+                    FormatTime(sw.Elapsed.Seconds, "second"));
             }
             catch (Exception e)
             {
                 ReportException(e);
                 Environment.ExitCode = GitTfsExitCodes.ExceptionThrown;
             }
+        }
+
+        private static string FormatTime(int unit, string unitOfTime)
+        {
+            if (unit == 0)
+                return string.Empty;
+            else if (unit == 1)
+                return $"{unit} {unitOfTime} ";
+            else
+                return $"{unit} {unitOfTime}s ";
         }
 
         public static int MainCore(string[] args)

--- a/src/GitTfsTest/GitTfsTest.csproj
+++ b/src/GitTfsTest/GitTfsTest.csproj
@@ -52,5 +52,15 @@
     <EmbeddedResource Include="Fixtures\vtccds\fd30d6210bb40fd2c9b689f0bf8b2833" />
     <None Include="paket.references" />
   </ItemGroup>
+  <!-- <ItemGroup> -->
+    <!-- <PackageReference Include="LibGit2Sharp" Version="0.26.1" /> -->
+    <!-- <PackageReference Include="Moq" Version="4.16.1" /> -->
+    <!-- <PackageReference Include="nlog" Version="4.7.10" /> -->
+    <!-- <PackageReference Include="StructureMap" Version="2.6.3" /> -->
+    <!-- <PackageReference Include="StructureMap.AutoMocking" Version="2.6.3" /> -->
+    <!-- <PackageReference Include="xunit" Version="2.4.1" /> -->
+    <!-- <PackageReference Include="xunit.assert" Version="2.4.1" /> -->
+    <!-- <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" /> -->
+  <!-- </ItemGroup> -->
   <Import Project="..\.paket\Paket.Restore.targets" />
 </Project>

--- a/src/paket.dependencies
+++ b/src/paket.dependencies
@@ -8,6 +8,9 @@ source https://api.nuget.org/v3/index.json
 //because there is some subtleties on how we use it in our project:
 //https://github.com/git-tfs/git-tfs/blob/master/doc/paket.md
 
+// Refer to the docs as to which TeamFoundationServer package version goes to which group: 
+//		https://docs.microsoft.com/en-us/azure/devops/integrate/concepts/dotnet-client-libraries?view=azure-devops#package-and-azure-devops-server-version-mapping-table
+
 nuget nlog
 nuget LibGit2Sharp ~> 0.26.1
 nuget Moq


### PR DESCRIPTION
- commented out paket targets in all projects (blocked by our firewall)
- added all nuget packages as appropriate for the versions
 - undid these two for the commit. Left package references commented out in the projects
- added ability to pass in PAT token, only valid for 2017, 2019
 - I was not able to test the PAT unfortunately as our TFS does not support https, but I tested it being passed in and correctly assigned to the credentials.
- added code to use trusted credentials if PAT and Username / Password are not passed in
- added code to prompt for password if only username is passed in
- altered clone code to only query branches specific to the TFS path being cloned IF the path is not $/. This greatly speeds up the cloning
- altered clone code to allow cloning of folders as well as branches IF the branch strategy is none
- added TFS url to the changeset to the commit message
- added total elapsed time to the output after the command completes
