### PR TITLE
TFS Authentication changes

### DIFF
--- a/src/GitTfs.Vs2015/TfsHelper.Vs2015.cs
+++ b/src/GitTfs.Vs2015/TfsHelper.Vs2015.cs
@@ -72,7 +72,7 @@ namespace GitTfs.Vs2015
 
         protected override TfsTeamProjectCollection GetTfsCredential(Uri uri)
         {
-            return HasCredentials ?
+            return HasUserName ?
                 new TfsTeamProjectCollection(uri, GetCredential(), new UICredentialsProvider()) :
                 new TfsTeamProjectCollection(uri, new UICredentialsProvider());
 #pragma warning restore 618

--- a/src/GitTfs.VsCommon/TfsHelper.Common.cs
+++ b/src/GitTfs.VsCommon/TfsHelper.Common.cs
@@ -20,6 +20,7 @@ using StructureMap.Attributes;
 using ChangeType = Microsoft.TeamFoundation.VersionControl.Client.ChangeType;
 using IdentityNotFoundException = Microsoft.TeamFoundation.VersionControl.Client.IdentityNotFoundException;
 using Microsoft.TeamFoundation.Build.Client;
+using Microsoft.VisualStudio.Services.Common;
 
 namespace GitTfs.VsCommon
 {
@@ -55,9 +56,21 @@ namespace GitTfs.VsCommon
 
         public string Password { get; set; }
 
-        public bool HasCredentials
+        public string PAT { get; set; }
+
+        public bool HasUserName
         {
-            get { return !string.IsNullOrEmpty(Username); }
+            get { return !string.IsNullOrEmpty(Username);  }
+        }
+
+        public bool HasPassword
+        {
+            get { return !string.IsNullOrEmpty(Password); }
+        }
+
+        public bool HasPAT
+        {
+            get { return !string.IsNullOrEmpty(PAT); }
         }
 
         public void EnsureAuthenticated()
@@ -96,8 +109,6 @@ namespace GitTfs.VsCommon
 
         protected NetworkCredential GetCredential()
         {
-            if (!HasCredentials)
-                return new NetworkCredential();
             var idx = Username.IndexOf('\\');
             if (idx >= 0)
             {

--- a/src/GitTfs.VsFake/TfsHelper.VsFake.cs
+++ b/src/GitTfs.VsFake/TfsHelper.VsFake.cs
@@ -40,6 +40,7 @@ namespace GitTfs.VsFake
         public string Url { get; set; }
         public string Username { get; set; }
         public string Password { get; set; }
+        public string PAT { get; set; }
 
         public void EnsureAuthenticated() { }
 

--- a/src/GitTfs/Commands/Create.cs
+++ b/src/GitTfs/Commands/Create.cs
@@ -49,6 +49,7 @@ ex : git tfs create http://myTfsServer:8080/tfs/TfsRepository myProjectName
             _tfsHelper.Url = tfsUrl;
             _tfsHelper.Username = _remoteOptions.Username;
             _tfsHelper.Password = _remoteOptions.Password;
+            _tfsHelper.PAT = _remoteOptions.PAT;
 
             var absoluteGitRepositoryPath = Path.GetFullPath(gitRepositoryPath);
             Trace.TraceInformation("Creating project folder...");

--- a/src/GitTfs/Commands/ListRemoteBranches.cs
+++ b/src/GitTfs/Commands/ListRemoteBranches.cs
@@ -34,6 +34,7 @@ namespace GitTfs.Commands
             _tfsHelper.Url = tfsUrl;
             _tfsHelper.Username = _remoteOptions.Username;
             _tfsHelper.Password = _remoteOptions.Password;
+            _tfsHelper.PAT = _remoteOptions.PAT;
             _tfsHelper.EnsureAuthenticated();
 
             if (!_tfsHelper.CanGetBranchInformation)

--- a/src/GitTfs/Commands/RemoteOptions.cs
+++ b/src/GitTfs/Commands/RemoteOptions.cs
@@ -24,6 +24,8 @@ namespace GitTfs.Commands
                         v => Username = v },
                     { "p|password=", "TFS password",
                         v => Password = v },
+                    { "pat=", "TFS Personal Access Token",
+                        v => PAT = v },
                     { "no-parallel", "Do not do parallel requests to TFS",
                         v => NoParallel = (v != null) },
                 };
@@ -37,6 +39,7 @@ namespace GitTfs.Commands
         public bool NoGitIgnore { get; set; }
         public string Username { get; set; }
         public string Password { get; set; }
+        public string PAT { get; set; }
         public bool NoParallel { get; set; }
     }
 }

--- a/src/GitTfs/Core/DerivedGitTfsRemote.cs
+++ b/src/GitTfs/Core/DerivedGitTfsRemote.cs
@@ -73,6 +73,18 @@ namespace GitTfs.Core
             }
         }
 
+        public string TfsPAT
+        {
+            get
+            {
+                throw DerivedRemoteException;
+            }
+            set
+            {
+                throw DerivedRemoteException;
+            }
+        }
+
         public string TfsRepositoryPath
         {
             get { return _tfsRepositoryPath; }

--- a/src/GitTfs/Core/GitTfsRemote.cs
+++ b/src/GitTfs/Core/GitTfsRemote.cs
@@ -37,8 +37,10 @@ namespace GitTfs.Core
             Id = info.Id;
             TfsUrl = info.Url;
             TfsRepositoryPath = info.Repository;
-            TfsUsername = info.Username;
-            TfsPassword = info.Password;
+            TfsUsername = info.Username ?? _remoteOptions.Username;
+            TfsPassword = info.Password ?? _remoteOptions.Password;
+            TfsPAT = info.PAT ?? _remoteOptions.PAT;
+
             Aliases = (info.Aliases ?? Enumerable.Empty<string>()).ToArray();
             IgnoreRegexExpression = info.IgnoreRegex;
             IgnoreExceptRegexExpression = info.IgnoreExceptRegex;
@@ -131,6 +133,12 @@ namespace GitTfs.Core
         {
             get { return Tfs.Password; }
             set { Tfs.Password = value; }
+        }
+
+        public string TfsPAT
+        {
+            get { return Tfs.PAT; }
+            set { Tfs.PAT = value; }
         }
 
         public string TfsRepositoryPath { get; set; }

--- a/src/GitTfs/Core/IGitTfsRemote.cs
+++ b/src/GitTfs/Core/IGitTfsRemote.cs
@@ -44,6 +44,7 @@ namespace GitTfs.Core
         bool Autotag { get; set; }
         string TfsUsername { get; set; }
         string TfsPassword { get; set; }
+        string TfsPAT { get; set; }
         IGitRepository Repository { get; set; }
         ITfsHelper Tfs { get; set; }
         int MaxChangesetId { get; set; }

--- a/src/GitTfs/Core/RemoteConfigConverter.cs
+++ b/src/GitTfs/Core/RemoteConfigConverter.cs
@@ -27,6 +27,8 @@ namespace GitTfs.Core
                         remote.Username = entry.Value;
                     else if (key == "password")
                         remote.Password = entry.Value;
+                    else if (key == "pat")
+                        remote.PAT = entry.Value;
                     else if (key == "ignore-paths")
                         remote.IgnoreRegex = entry.Value;
                     else if (key == "ignore-except")
@@ -53,6 +55,7 @@ namespace GitTfs.Core
                 yield return c(prefix + "repository", remote.Repository);
                 yield return c(prefix + "username", remote.Username);
                 yield return c(prefix + "password", remote.Password);
+                yield return c(prefix + "pat", remote.PAT);
                 yield return c(prefix + "ignore-paths", remote.IgnoreRegex);
                 yield return c(prefix + "ignore-except", remote.IgnoreExceptRegex);
                 yield return c(prefix + "gitignore-path", remote.GitIgnorePath);

--- a/src/GitTfs/Core/RemoteInfo.cs
+++ b/src/GitTfs/Core/RemoteInfo.cs
@@ -10,6 +10,7 @@ namespace GitTfs.Core
         public string Repository { get; set; }
         public string Username { get; set; }
         public string Password { get; set; }
+        public string PAT { get; set; }
         public string IgnoreRegex { get; set; }
         public string IgnoreExceptRegex { get; set; }
         public string GitIgnorePath { get; set; }

--- a/src/GitTfs/Core/TfsInterop/ITfsHelper.cs
+++ b/src/GitTfs/Core/TfsInterop/ITfsHelper.cs
@@ -10,6 +10,7 @@ namespace GitTfs.Core.TfsInterop
         string Url { get; set; }
         string Username { get; set; }
         string Password { get; set; }
+        string PAT { get; set; }
         IEnumerable<ITfsChangeset> GetChangesets(string path, int startVersion, IGitTfsRemote remote, int lastVersion = -1, bool byLots = false);
         void WithWorkspace(string directory, IGitTfsRemote remote, TfsChangesetInfo versionToFetch, Action<ITfsWorkspace> action);
         IShelveset CreateShelveset(IWorkspace workspace, string shelvesetName);


### PR DESCRIPTION
These changes will allow the user to take of various TFS authentication mechanisms:
- If --pat (Personal Access Token) is passed, then the PAT will be passed to the server. Requires https. (new feature)
- If only --username is passed, then the user will be prompted to enter their password
- If both --username and --password are passed, then those credentials are used.
- If --username, --password, and --pat are not passed, then trusted authentication will be used. This is useful for on-premise installations (bug fix, wasn't working)