### PR TITLE
Misc Changes

### DIFF
--- a/src/GitTfs/Commands/Subtree.cs
+++ b/src/GitTfs/Commands/Subtree.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using NDesk.Options;
 using GitTfs.Core;
 using StructureMap;
+using System.Text.RegularExpressions;
 
 namespace GitTfs.Commands
 {
@@ -148,6 +149,10 @@ namespace GitTfs.Commands
 
                 int latest = Math.Max(owner.MaxChangesetId, remote.MaxChangesetId);
                 string msg = string.Format(GitTfsConstants.TfsCommitInfoFormat, owner.TfsUrl, owner.TfsRepositoryPath, latest);
+                var match = Regex.Match(owner.TfsRepositoryPath, @"\$/(?<TeamProject>[^/]*?)/?");
+                if (match.Success)
+                    msg = String.Concat(msg, Environment.NewLine, String.Format(GitTfsConstants.TfsCommitUrlFormat, owner.TfsUrl, match.Groups["TeamProject"].Value, latest));
+
                 msg = string.Format(@"Add '{0}/' from commit '{1}'
 
 {2}", Prefix, remote.MaxCommitHash, msg);

--- a/src/GitTfs/Core/GitTfsRemote.cs
+++ b/src/GitTfs/Core/GitTfsRemote.cs
@@ -875,8 +875,11 @@ namespace GitTfs.Core
         {
             var builder = new StringWriter();
             builder.WriteLine(tfsCheckinComment);
-            builder.WriteLine(GitTfsConstants.TfsCommitInfoFormat,
-                TfsUrl, TfsRepositoryPath, changesetId);
+            builder.WriteLine(GitTfsConstants.TfsCommitInfoFormat, TfsUrl, TfsRepositoryPath, changesetId);
+            var match = Regex.Match(TfsRepositoryPath, @"\$/(?<TeamProject>[^/]*?)/?");
+            if (match.Success)
+                builder.WriteLine(GitTfsConstants.TfsCommitUrlFormat, TfsUrl, match.Groups["TeamProject"].Value, changesetId);
+
             return builder.ToString();
         }
 

--- a/src/GitTfs/GitTfsConstants.cs
+++ b/src/GitTfs/GitTfsConstants.cs
@@ -17,6 +17,7 @@ namespace GitTfs
         public const string GitTfsPolicyOverrideCommentPrefix = GitTfsPrefix + "-force:";
         // e.g. git-tfs-id: [http://team:8080/]$/sandbox;C123
         public const string TfsCommitInfoFormat = "git-tfs-id: [{0}]{1};C{2}";
+        public const string TfsCommitUrlFormat = "git-tfs-url: {0}/{1}/_versionControl/changeset/{2}";
         public static readonly Regex TfsCommitInfoRegex =
                 new Regex("^\\s*" +
                           GitTfsPrefix +

--- a/src/GitTfs/Program.cs
+++ b/src/GitTfs/Program.cs
@@ -25,13 +25,33 @@ namespace GitTfs
         {
             try
             {
+                var sw = Stopwatch.StartNew();
+
                 Environment.ExitCode = MainCore(args);
+
+                sw.Stop();
+                // could write it out like this: mm\\:ss\\.ff, using readable format instead
+                Console.WriteLine("\r\nCompleted in {0}{1}{2}{3}",
+                    FormatTime(sw.Elapsed.Days, "day"), //hopefully this should never happen??? :)
+                    FormatTime(sw.Elapsed.Hours, "hour"),
+                    FormatTime(sw.Elapsed.Minutes, "minute"),
+                    FormatTime(sw.Elapsed.Seconds, "second"));
             }
             catch (Exception e)
             {
                 ReportException(e);
                 Environment.ExitCode = GitTfsExitCodes.ExceptionThrown;
             }
+        }
+
+        private static string FormatTime(int unit, string unitOfTime)
+        {
+            if (unit == 0)
+                return string.Empty;
+            else if (unit == 1)
+                return $"{unit} {unitOfTime} ";
+            else
+                return $"{unit} {unitOfTime}s ";
         }
 
         public static int MainCore(string[] args)


### PR DESCRIPTION
- Added a url to TFS changeset to the commit details when cloned or fetched. Allows the user to open up the changeset in TFS history if they so desire.  
- Added total elapsed time to the output after the command completes. This is purely informational so the user can see how long each command took.
