### PR TITLE
Fix for possible exception when fetching work item information

### DIFF
--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -1,2 +1,3 @@
 * Keep already committed files (e.g. `.gitignore`) when cloning with `--changeset` (#1382 by @boogisha)
 * Correct WorkItem URL in the changeset metadata (#1396 by @siprbaum)
+* Fix a rare error fetching the workitems associated to a changeset (#1395 @drolevar)

--- a/src/GitTfs.Vs2015/TfsHelper.Vs2015.cs
+++ b/src/GitTfs.Vs2015/TfsHelper.Vs2015.cs
@@ -36,10 +36,6 @@ namespace GitTfs.Vs2015
             return string.Empty;
 #endif
         }
-        protected override bool HasWorkItems(Changeset changeset)
-        {
-            return Retry.Do(() => changeset.AssociatedWorkItems.Length > 0);
-        }
 
         private string GetVsInstallDir()
         {

--- a/src/GitTfs.VsCommon/TfsHelper.Vs2017Base.cs
+++ b/src/GitTfs.VsCommon/TfsHelper.Vs2017Base.cs
@@ -112,11 +112,6 @@ namespace GitTfs.VsCommon
             myAssemblySearchPaths.Add(Path.Combine(myVisualStudioInstallationPath, myTeamExplorerFolder));
         }
 
-        protected override bool HasWorkItems(Changeset changeset)
-        {
-            return Retry.Do(() => changeset.AssociatedWorkItems.Length > 0);
-        }
-
         /// <summary>
         /// Enumerates the list of installed VS instances and returns the first one
         /// matching <see cref="MajorVersion"/>. Right now there is no way for the user to influence


### PR DESCRIPTION
When trying to convert a legacy repo, I was getting the following exception, probably because some internal discrepancies in the project definition:
``TF201077: The work item type  cannot be found. It may have been renamed or destroyed.``
I've added this try/catch to enable the process to continue even if some work item information cannot be fetched.