### PR TITLE
Fix #1398 - no automatic line ending conversion when --gitignore was given

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,6 @@ Please, read our short and simple [guidelines](CONTRIBUTING.md) and our doc on h
 Especially, don't forget:
 
 * to run the build task `.\build.ps1 -Target "FormatCode"` before committing (to keep code formatting consistent, and pull request easier to review)
-* to set `core.autocrlf` to `true` (`git config core.autocrlf true`)
 * to indent your code using 4 spaces (even if `.editorconfig` should take care of that).
 
 ## Migrations

--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -2,3 +2,5 @@
 * Correct WorkItem URL in the changeset metadata (#1396 by @siprbaum)
 * Fix a rare error fetching the workitems associated to a changeset (#1395 @drolevar)
 * Remove support for TFS 2008 (#1397 @siprbaum)
+* Fix #1398: no automatic line ending conversion when git tfs clone was called with a 
+  `--gitignore` parameter (#1399 by siprbaum)

--- a/src/GitTfs/Commands/Init.cs
+++ b/src/GitTfs/Commands/Init.cs
@@ -162,6 +162,10 @@ namespace GitTfs.Commands
 
             _globals.Repository.SetConfig(GitTfsConstants.IgnoreBranches, false);
             _globals.Repository.SetConfig(GitTfsConstants.IgnoreNotInitBranches, false);
+            _globals.Repository.SetConfig("core.autocrlf", _initOptions.GitInitAutoCrlf);
+
+            if (_initOptions.GitInitIgnoreCase != null)
+                _globals.Repository.SetConfig("core.ignorecase", _initOptions.GitInitIgnoreCase);
         }
 
         private string[] BuildInitCommand()
@@ -186,7 +190,7 @@ namespace GitTfs.Commands
                 Url = tfsUrl,
                 Repository = tfsRepositoryPath,
                 RemoteOptions = _remoteOptions,
-            }, _initOptions.GitInitAutoCrlf, _initOptions.GitInitIgnoreCase);
+            });
         }
     }
 

--- a/src/GitTfs/Core/Bootstrapper.cs
+++ b/src/GitTfs/Core/Bootstrapper.cs
@@ -26,7 +26,7 @@ namespace GitTfs.Core
                     Url = changeset.Remote.TfsUrl,
                     Repository = changeset.Remote.TfsRepositoryPath,
                     RemoteOptions = _remoteOptions,
-                }, string.Empty, null);
+                });
                 remote.UpdateTfsHead(changeset.GitCommit, changeset.ChangesetId);
                 Trace.TraceInformation("-> new remote '" + remote.Id + "'");
             }

--- a/src/GitTfs/Core/Bootstrapper.cs
+++ b/src/GitTfs/Core/Bootstrapper.cs
@@ -26,7 +26,7 @@ namespace GitTfs.Core
                     Url = changeset.Remote.TfsUrl,
                     Repository = changeset.Remote.TfsRepositoryPath,
                     RemoteOptions = _remoteOptions,
-                }, string.Empty);
+                }, string.Empty, null);
                 remote.UpdateTfsHead(changeset.GitCommit, changeset.ChangesetId);
                 Trace.TraceInformation("-> new remote '" + remote.Id + "'");
             }

--- a/src/GitTfs/Core/GitRepository.cs
+++ b/src/GitTfs/Core/GitRepository.cs
@@ -174,24 +174,6 @@ namespace GitTfs.Core
             return _cachedRemotes ?? (_cachedRemotes = ReadTfsRemotes());
         }
 
-        public IGitTfsRemote CreateTfsRemote(RemoteInfo remote, string autocrlf, string ignorecase)
-        {
-            if (HasRemote(remote.Id))
-                throw new GitTfsException("A remote with id \"" + remote.Id + "\" already exists.");
-
-            // The autocrlf default (as indicated by a null) is false and is set to override the system-wide setting.
-            // When creating branches we use the empty string to indicate that we do not want to set the value at all.
-            if (autocrlf == null)
-                autocrlf = "false";
-            if (autocrlf != string.Empty)
-                _repository.Config.Set("core.autocrlf", autocrlf);
-
-            if (ignorecase != null)
-                _repository.Config.Set("core.ignorecase", ignorecase);
-
-            return CreateTfsRemote(remote);
-        }
-
         public IGitTfsRemote CreateTfsRemote(RemoteInfo remote)
         {
             foreach (var entry in _remoteConfigReader.Dump(remote))

--- a/src/GitTfs/Core/GitRepository.cs
+++ b/src/GitTfs/Core/GitRepository.cs
@@ -174,7 +174,7 @@ namespace GitTfs.Core
             return _cachedRemotes ?? (_cachedRemotes = ReadTfsRemotes());
         }
 
-        public IGitTfsRemote CreateTfsRemote(RemoteInfo remote, string autocrlf = null, string ignorecase = null)
+        public IGitTfsRemote CreateTfsRemote(RemoteInfo remote, string autocrlf, string ignorecase)
         {
             if (HasRemote(remote.Id))
                 throw new GitTfsException("A remote with id \"" + remote.Id + "\" already exists.");
@@ -189,6 +189,11 @@ namespace GitTfs.Core
             if (ignorecase != null)
                 _repository.Config.Set("core.ignorecase", ignorecase);
 
+            return CreateTfsRemote(remote);
+        }
+
+        public IGitTfsRemote CreateTfsRemote(RemoteInfo remote)
+        {
             foreach (var entry in _remoteConfigReader.Dump(remote))
             {
                 if (entry.Value != null)
@@ -206,6 +211,7 @@ namespace GitTfs.Core
 
             return _cachedRemotes[remote.Id] = gitTfsRemote;
         }
+
 
         public void DeleteTfsRemote(IGitTfsRemote remote)
         {

--- a/src/GitTfs/Core/GitTfsRemote.cs
+++ b/src/GitTfs/Core/GitTfsRemote.cs
@@ -1089,7 +1089,7 @@ namespace GitTfs.Core
                     Url = TfsUrl,
                     Repository = tfsRepositoryPath,
                     RemoteOptions = remoteOptions
-                }, string.Empty);
+                }, string.Empty, null);
                 tfsRemote.ExportMetadatas = ExportMetadatas;
                 tfsRemote.ExportWorkitemsMapping = ExportWorkitemsMapping;
             }

--- a/src/GitTfs/Core/GitTfsRemote.cs
+++ b/src/GitTfs/Core/GitTfsRemote.cs
@@ -1089,7 +1089,7 @@ namespace GitTfs.Core
                     Url = TfsUrl,
                     Repository = tfsRepositoryPath,
                     RemoteOptions = remoteOptions
-                }, string.Empty, null);
+                });
                 tfsRemote.ExportMetadatas = ExportMetadatas;
                 tfsRemote.ExportWorkitemsMapping = ExportWorkitemsMapping;
             }

--- a/src/GitTfs/Core/IGitRepository.cs
+++ b/src/GitTfs/Core/IGitRepository.cs
@@ -16,7 +16,6 @@ namespace GitTfs.Core
         IEnumerable<IGitTfsRemote> ReadAllTfsRemotes();
         IGitTfsRemote ReadTfsRemote(string remoteId);
         IGitTfsRemote CreateTfsRemote(RemoteInfo remoteInfo);
-        IGitTfsRemote CreateTfsRemote(RemoteInfo remoteInfo, string autocrlf, string ignorecase);
         void DeleteTfsRemote(IGitTfsRemote remoteId);
         IEnumerable<string> GetGitRemoteBranches(string gitRemote);
         bool HasRemote(string remoteId);

--- a/src/GitTfs/Core/IGitRepository.cs
+++ b/src/GitTfs/Core/IGitRepository.cs
@@ -15,7 +15,8 @@ namespace GitTfs.Core
         void SetConfig(string key, bool value);
         IEnumerable<IGitTfsRemote> ReadAllTfsRemotes();
         IGitTfsRemote ReadTfsRemote(string remoteId);
-        IGitTfsRemote CreateTfsRemote(RemoteInfo remoteInfo, string autocrlf = null, string ignorecase = null);
+        IGitTfsRemote CreateTfsRemote(RemoteInfo remoteInfo);
+        IGitTfsRemote CreateTfsRemote(RemoteInfo remoteInfo, string autocrlf, string ignorecase);
         void DeleteTfsRemote(IGitTfsRemote remoteId);
         IEnumerable<string> GetGitRemoteBranches(string gitRemote);
         bool HasRemote(string remoteId);


### PR DESCRIPTION
In #1398 it was reported that when a TFS repo is cloned with the `--gitignore` parameter,
e.g.  `git-tfs clone <TFS-SERVER> "<TFS-REPO>" --gitignore=<GITIGNORE> then the files
imported from TFS had their line ending converted if they had a CRLF and the user
has core.autocrlf=true either in system or global config set, which is the default.

This merge contains the necessary patches to fix this.

Fixes #1398 