### PR TITLE
Cleanups and deadcode removal

### DIFF
--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -4,3 +4,5 @@
 * Remove support for TFS 2008 (#1397 @siprbaum)
 * Fix #1398: no automatic line ending conversion when git tfs clone was called with a 
   `--gitignore` parameter (#1399 by siprbaum)
+* Speed up git-tfs startup time by removing a useless `git rev-parse --show-prefix` invocation.
+  In addition, make a lot of small internal cleanups eliminating dead code (#1400 by siprbaum)

--- a/src/GitTfs.VsCommon/TfsHelper.Common.cs
+++ b/src/GitTfs.VsCommon/TfsHelper.Common.cs
@@ -1367,30 +1367,4 @@ namespace GitTfs.VsCommon
             return queuedBuild.Build;
         }
     }
-
-    public class ItemDownloadStrategy : IItemDownloadStrategy
-    {
-        private readonly TfsApiBridge _bridge;
-
-        public ItemDownloadStrategy(TfsApiBridge bridge)
-        {
-            _bridge = bridge;
-        }
-
-        public TemporaryFile DownloadFile(IItem item)
-        {
-            var temp = new TemporaryFile();
-            try
-            {
-                _bridge.Unwrap<Item>(item).DownloadFile(temp);
-                return temp;
-            }
-            catch (Exception)
-            {
-                Trace.WriteLine(string.Format("Something went wrong downloading \"{0}\" in changeset {1}", item.ServerItem, item.ChangesetId));
-                temp.Dispose();
-                throw;
-            }
-        }
-    }
 }

--- a/src/GitTfs.VsCommon/Wrappers.cs
+++ b/src/GitTfs.VsCommon/Wrappers.cs
@@ -139,13 +139,11 @@ namespace GitTfs.VsCommon
 
     public class WrapperForItem : WrapperFor<Item>, IItem
     {
-        private readonly IItemDownloadStrategy _downloadStrategy;
         private readonly TfsApiBridge _bridge;
         private readonly Item _item;
 
-        public WrapperForItem(IItemDownloadStrategy downloadStrategy, TfsApiBridge bridge, Item item) : base(item)
+        public WrapperForItem(TfsApiBridge bridge, Item item) : base(item)
         {
-            _downloadStrategy = downloadStrategy;
             _bridge = bridge;
             _item = item;
         }
@@ -187,7 +185,18 @@ namespace GitTfs.VsCommon
 
         public TemporaryFile DownloadFile()
         {
-            return _downloadStrategy.DownloadFile(this);
+            var temp = new TemporaryFile();
+            try
+            {
+                _bridge.Unwrap<Item>(_item).DownloadFile(temp);
+                return temp;
+            }
+            catch (Exception)
+            {
+                Trace.WriteLine(string.Format("Something went wrong downloading \"{0}\" in changeset {1}", _item.ServerItem, _item.ChangesetId));
+                temp.Dispose();
+                throw;
+            }
         }
     }
 

--- a/src/GitTfs/Core/DerivedGitTfsRemote.cs
+++ b/src/GitTfs/Core/DerivedGitTfsRemote.cs
@@ -34,7 +34,6 @@ namespace GitTfs.Core
         public string Id
         {
             get { return "(derived)"; }
-            set { throw DerivedRemoteException; }
         }
 
         public string TfsUrl

--- a/src/GitTfs/Core/DerivedGitTfsRemote.cs
+++ b/src/GitTfs/Core/DerivedGitTfsRemote.cs
@@ -147,7 +147,6 @@ namespace GitTfs.Core
         public IGitRepository Repository
         {
             get { throw DerivedRemoteException; }
-            set { throw DerivedRemoteException; }
         }
 
         public ITfsHelper Tfs

--- a/src/GitTfs/Core/DerivedGitTfsRemote.cs
+++ b/src/GitTfs/Core/DerivedGitTfsRemote.cs
@@ -133,7 +133,6 @@ namespace GitTfs.Core
         public string IgnoreExceptRegexExpression
         {
             get { throw DerivedRemoteException; }
-            set { throw DerivedRemoteException; }
         }
 
         public string GitIgnorePath

--- a/src/GitTfs/Core/DerivedGitTfsRemote.cs
+++ b/src/GitTfs/Core/DerivedGitTfsRemote.cs
@@ -45,7 +45,6 @@ namespace GitTfs.Core
         public bool Autotag
         {
             get { throw DerivedRemoteException; }
-            set { throw DerivedRemoteException; }
         }
 
         public string TfsUsername

--- a/src/GitTfs/Core/DerivedGitTfsRemote.cs
+++ b/src/GitTfs/Core/DerivedGitTfsRemote.cs
@@ -39,7 +39,6 @@ namespace GitTfs.Core
         public string TfsUrl
         {
             get { return _tfsUrl; }
-            set { throw DerivedRemoteException; }
         }
 
         public bool Autotag

--- a/src/GitTfs/Core/DerivedGitTfsRemote.cs
+++ b/src/GitTfs/Core/DerivedGitTfsRemote.cs
@@ -128,7 +128,6 @@ namespace GitTfs.Core
         public string IgnoreRegexExpression
         {
             get { throw DerivedRemoteException; }
-            set { throw DerivedRemoteException; }
         }
 
         public string IgnoreExceptRegexExpression

--- a/src/GitTfs/Core/DerivedGitTfsRemote.cs
+++ b/src/GitTfs/Core/DerivedGitTfsRemote.cs
@@ -74,7 +74,6 @@ namespace GitTfs.Core
         public string TfsRepositoryPath
         {
             get { return _tfsRepositoryPath; }
-            set { throw DerivedRemoteException; }
         }
 
         public string[] TfsSubtreePaths

--- a/src/GitTfs/Core/DerivedGitTfsRemote.cs
+++ b/src/GitTfs/Core/DerivedGitTfsRemote.cs
@@ -135,12 +135,6 @@ namespace GitTfs.Core
             get { throw DerivedRemoteException; }
         }
 
-        public string GitIgnorePath
-        {
-            get { throw DerivedRemoteException; }
-            set { throw DerivedRemoteException; }
-        }
-
         public IGitRepository Repository
         {
             get { throw DerivedRemoteException; }

--- a/src/GitTfs/Core/GitCommandException.cs
+++ b/src/GitTfs/Core/GitCommandException.cs
@@ -5,7 +5,7 @@ namespace GitTfs.Core
 {
     public class GitCommandException : Exception
     {
-        public Process Process { get; set; }
+        public Process Process { get; }
 
         public GitCommandException(string message, Process process) : base(message)
         {

--- a/src/GitTfs/Core/GitRepository.cs
+++ b/src/GitTfs/Core/GitRepository.cs
@@ -69,8 +69,6 @@ namespace GitTfs.Core
         }
 
         public string GitDir { get; }
-        public string WorkingCopyPath { get; set; }
-        public string WorkingCopySubdir { get; set; }
 
         protected override GitProcess Start(string[] command, Action<ProcessStartInfo> initialize)
         {
@@ -81,10 +79,6 @@ namespace GitTfs.Core
         {
             if (GitDir != null)
                 gitCommand.EnvironmentVariables["GIT_DIR"] = GitDir;
-            if (WorkingCopyPath != null)
-                gitCommand.WorkingDirectory = WorkingCopyPath;
-            if (WorkingCopySubdir != null)
-                gitCommand.WorkingDirectory = Path.Combine(gitCommand.WorkingDirectory, WorkingCopySubdir);
         }
 
         public string GetConfig(string key)

--- a/src/GitTfs/Core/GitRepository.cs
+++ b/src/GitTfs/Core/GitRepository.cs
@@ -68,7 +68,7 @@ namespace GitTfs.Core
             return "refs/remotes/tfs/" + branchName;
         }
 
-        public string GitDir { get; set; }
+        public string GitDir { get; }
         public string WorkingCopyPath { get; set; }
         public string WorkingCopySubdir { get; set; }
 

--- a/src/GitTfs/Core/GitTfsGatedCheckinException.cs
+++ b/src/GitTfs/Core/GitTfsGatedCheckinException.cs
@@ -6,9 +6,9 @@ namespace GitTfs.Core
 {
     public class GitTfsGatedCheckinException : GitTfsException
     {
-        public string ShelvesetName { get; set; }
+        public string ShelvesetName { get; }
         public ReadOnlyCollection<KeyValuePair<string, Uri>> AffectedBuildDefinitions { get; set; }
-        public string CheckInTicket { get; set; }
+        public string CheckInTicket { get; }
 
         public GitTfsGatedCheckinException(string shelvesetName, ReadOnlyCollection<KeyValuePair<string, Uri>> affectedBuildDefinitions, string checkInTicket)
             : base("Gated checkin detected!")

--- a/src/GitTfs/Core/GitTfsRemote.cs
+++ b/src/GitTfs/Core/GitTfsRemote.cs
@@ -99,7 +99,7 @@ namespace GitTfs.Core
             firstChangesetId = changesetId;
         }
 
-        public bool IsSubtree { get; private set; }
+        public bool IsSubtree { get; }
 
         public bool IsSubtreeOwner
         {

--- a/src/GitTfs/Core/GitTfsRemote.cs
+++ b/src/GitTfs/Core/GitTfsRemote.cs
@@ -151,7 +151,7 @@ namespace GitTfs.Core
         }
         private string[] tfsSubtreePaths = null;
 
-        public string IgnoreRegexExpression { get; set; }
+        public string IgnoreRegexExpression { get; }
         public string IgnoreExceptRegexExpression { get; set; }
         public string GitIgnorePath { get; set; }
         public bool UseGitIgnore { get; set; }

--- a/src/GitTfs/Core/GitTfsRemote.cs
+++ b/src/GitTfs/Core/GitTfsRemote.cs
@@ -155,7 +155,7 @@ namespace GitTfs.Core
         public string IgnoreExceptRegexExpression { get; set; }
         public string GitIgnorePath { get; set; }
         public bool UseGitIgnore { get; set; }
-        public IGitRepository Repository { get; set; }
+        public IGitRepository Repository { get; }
         public ITfsHelper Tfs { get; }
 
         public string OwningRemoteId { get; private set; }

--- a/src/GitTfs/Core/GitTfsRemote.cs
+++ b/src/GitTfs/Core/GitTfsRemote.cs
@@ -119,7 +119,7 @@ namespace GitTfs.Core
 
         private string[] Aliases { get; set; }
 
-        public bool Autotag { get; set; }
+        public bool Autotag { get; }
 
         public string TfsUsername
         {

--- a/src/GitTfs/Core/GitTfsRemote.cs
+++ b/src/GitTfs/Core/GitTfsRemote.cs
@@ -109,7 +109,7 @@ namespace GitTfs.Core
             }
         }
 
-        public string Id { get; set; }
+        public string Id { get; }
 
         public string TfsUrl
         {

--- a/src/GitTfs/Core/GitTfsRemote.cs
+++ b/src/GitTfs/Core/GitTfsRemote.cs
@@ -156,7 +156,7 @@ namespace GitTfs.Core
         public string GitIgnorePath { get; set; }
         public bool UseGitIgnore { get; set; }
         public IGitRepository Repository { get; set; }
-        public ITfsHelper Tfs { get; set; }
+        public ITfsHelper Tfs { get; }
 
         public string OwningRemoteId { get; private set; }
 

--- a/src/GitTfs/Core/GitTfsRemote.cs
+++ b/src/GitTfs/Core/GitTfsRemote.cs
@@ -152,7 +152,7 @@ namespace GitTfs.Core
         private string[] tfsSubtreePaths = null;
 
         public string IgnoreRegexExpression { get; }
-        public string IgnoreExceptRegexExpression { get; set; }
+        public string IgnoreExceptRegexExpression { get; }
         public string GitIgnorePath { get; set; }
         public bool UseGitIgnore { get; set; }
         public IGitRepository Repository { get; }

--- a/src/GitTfs/Core/GitTfsRemote.cs
+++ b/src/GitTfs/Core/GitTfsRemote.cs
@@ -36,7 +36,7 @@ namespace GitTfs.Core
 
             RemoteInfo = info;
             Id = info.Id;
-            TfsUrl = info.Url;
+            Tfs.Url = info.Url;
             TfsRepositoryPath = info.Repository;
             TfsUsername = info.Username;
             TfsPassword = info.Password;
@@ -114,7 +114,6 @@ namespace GitTfs.Core
         public string TfsUrl
         {
             get { return Tfs.Url; }
-            set { Tfs.Url = value; }
         }
 
         private string[] Aliases { get; set; }

--- a/src/GitTfs/Core/GitTfsRemote.cs
+++ b/src/GitTfs/Core/GitTfsRemote.cs
@@ -133,7 +133,7 @@ namespace GitTfs.Core
             set { Tfs.Password = value; }
         }
 
-        public string TfsRepositoryPath { get; set; }
+        public string TfsRepositoryPath { get; }
 
         /// <summary>
         /// Gets the TFS server-side paths of all subtrees of this remote.

--- a/src/GitTfs/Core/GitTfsRemote.cs
+++ b/src/GitTfs/Core/GitTfsRemote.cs
@@ -18,6 +18,7 @@ namespace GitTfs.Core
         private readonly Globals _globals;
         private readonly RemoteOptions _remoteOptions;
         private readonly ConfigProperties _properties;
+        private readonly bool _useGitIgnore;
         private int? firstChangesetId;
         private int? maxChangesetId;
         private string maxCommitHash;
@@ -42,8 +43,7 @@ namespace GitTfs.Core
             Aliases = (info.Aliases ?? Enumerable.Empty<string>()).ToArray();
             IgnoreRegexExpression = info.IgnoreRegex;
             IgnoreExceptRegexExpression = info.IgnoreExceptRegex;
-            GitIgnorePath = _remoteOptions.GitIgnorePath ?? info.GitIgnorePath;
-            UseGitIgnore = !_remoteOptions.NoGitIgnore && (_remoteOptions.UseGitIgnore || IsGitIgnoreSupportEnabled());
+            _useGitIgnore = !_remoteOptions.NoGitIgnore && (_remoteOptions.UseGitIgnore || IsGitIgnoreSupportEnabled());
 
             Autotag = info.Autotag;
 
@@ -153,8 +153,6 @@ namespace GitTfs.Core
 
         public string IgnoreRegexExpression { get; }
         public string IgnoreExceptRegexExpression { get; }
-        public string GitIgnorePath { get; set; }
-        public bool UseGitIgnore { get; set; }
         public IGitRepository Repository { get; }
         public ITfsHelper Tfs { get; }
 
@@ -271,7 +269,7 @@ namespace GitTfs.Core
 
         private bool IsPathIgnored(string path)
         {
-            return UseGitIgnore && Repository.IsPathIgnored(path);
+            return _useGitIgnore && Repository.IsPathIgnored(path);
         }
 
         private Bouncer _ignorance;

--- a/src/GitTfs/Core/IGitRepository.cs
+++ b/src/GitTfs/Core/IGitRepository.cs
@@ -7,7 +7,7 @@ namespace GitTfs.Core
 {
     public interface IGitRepository : IGitHelpers
     {
-        string GitDir { get; set; }
+        string GitDir { get; }
         string GetConfig(string key);
         T GetConfig<T>(string key);
         T GetConfig<T>(string key, T defaultValue);

--- a/src/GitTfs/Core/IGitTfsRemote.cs
+++ b/src/GitTfs/Core/IGitTfsRemote.cs
@@ -30,7 +30,7 @@ namespace GitTfs.Core
     {
         bool IsDerived { get; }
         RemoteInfo RemoteInfo { get; }
-        string Id { get; set; }
+        string Id { get; }
         string TfsUrl { get; set; }
         string TfsRepositoryPath { get; set; }
         /// <summary>

--- a/src/GitTfs/Core/IGitTfsRemote.cs
+++ b/src/GitTfs/Core/IGitTfsRemote.cs
@@ -44,7 +44,7 @@ namespace GitTfs.Core
         bool Autotag { get; set; }
         string TfsUsername { get; set; }
         string TfsPassword { get; set; }
-        IGitRepository Repository { get; set; }
+        IGitRepository Repository { get; }
         ITfsHelper Tfs { get; }
         int MaxChangesetId { get; set; }
         string MaxCommitHash { get; set; }

--- a/src/GitTfs/Core/IGitTfsRemote.cs
+++ b/src/GitTfs/Core/IGitTfsRemote.cs
@@ -40,7 +40,7 @@ namespace GitTfs.Core
         string[] TfsSubtreePaths { get; }
         string IgnoreRegexExpression { get; }
         string IgnoreExceptRegexExpression { get; }
-        bool Autotag { get; set; }
+        bool Autotag { get; }
         string TfsUsername { get; set; }
         string TfsPassword { get; set; }
         IGitRepository Repository { get; }

--- a/src/GitTfs/Core/IGitTfsRemote.cs
+++ b/src/GitTfs/Core/IGitTfsRemote.cs
@@ -40,7 +40,6 @@ namespace GitTfs.Core
         string[] TfsSubtreePaths { get; }
         string IgnoreRegexExpression { get; }
         string IgnoreExceptRegexExpression { get; }
-        string GitIgnorePath { get; set; }
         bool Autotag { get; set; }
         string TfsUsername { get; set; }
         string TfsPassword { get; set; }

--- a/src/GitTfs/Core/IGitTfsRemote.cs
+++ b/src/GitTfs/Core/IGitTfsRemote.cs
@@ -32,7 +32,7 @@ namespace GitTfs.Core
         RemoteInfo RemoteInfo { get; }
         string Id { get; }
         string TfsUrl { get; set; }
-        string TfsRepositoryPath { get; set; }
+        string TfsRepositoryPath { get; }
         /// <summary>
         /// Gets the TFS server-side paths of all subtrees of this remote.
         /// Valid if the remote has subtrees, which occurs when <see cref="TfsRepositoryPath"/> is null.

--- a/src/GitTfs/Core/IGitTfsRemote.cs
+++ b/src/GitTfs/Core/IGitTfsRemote.cs
@@ -38,7 +38,7 @@ namespace GitTfs.Core
         /// Valid if the remote has subtrees, which occurs when <see cref="TfsRepositoryPath"/> is null.
         /// </summary>
         string[] TfsSubtreePaths { get; }
-        string IgnoreRegexExpression { get; set; }
+        string IgnoreRegexExpression { get; }
         string IgnoreExceptRegexExpression { get; set; }
         string GitIgnorePath { get; set; }
         bool Autotag { get; set; }

--- a/src/GitTfs/Core/IGitTfsRemote.cs
+++ b/src/GitTfs/Core/IGitTfsRemote.cs
@@ -39,7 +39,7 @@ namespace GitTfs.Core
         /// </summary>
         string[] TfsSubtreePaths { get; }
         string IgnoreRegexExpression { get; }
-        string IgnoreExceptRegexExpression { get; set; }
+        string IgnoreExceptRegexExpression { get; }
         string GitIgnorePath { get; set; }
         bool Autotag { get; set; }
         string TfsUsername { get; set; }

--- a/src/GitTfs/Core/IGitTfsRemote.cs
+++ b/src/GitTfs/Core/IGitTfsRemote.cs
@@ -31,7 +31,7 @@ namespace GitTfs.Core
         bool IsDerived { get; }
         RemoteInfo RemoteInfo { get; }
         string Id { get; }
-        string TfsUrl { get; set; }
+        string TfsUrl { get; }
         string TfsRepositoryPath { get; }
         /// <summary>
         /// Gets the TFS server-side paths of all subtrees of this remote.

--- a/src/GitTfs/Core/IGitTfsRemote.cs
+++ b/src/GitTfs/Core/IGitTfsRemote.cs
@@ -45,7 +45,7 @@ namespace GitTfs.Core
         string TfsUsername { get; set; }
         string TfsPassword { get; set; }
         IGitRepository Repository { get; set; }
-        ITfsHelper Tfs { get; set; }
+        ITfsHelper Tfs { get; }
         int MaxChangesetId { get; set; }
         string MaxCommitHash { get; set; }
         string RemoteRef { get; }

--- a/src/GitTfs/Core/TfsChangeset.cs
+++ b/src/GitTfs/Core/TfsChangeset.cs
@@ -14,7 +14,7 @@ namespace GitTfs.Core
         private readonly IChangeset _changeset;
         private readonly AuthorsFile _authors;
         public TfsChangesetInfo Summary { get; set; }
-        public int BaseChangesetId { get; set; }
+        public int BaseChangesetId { get; }
 
         public TfsChangeset(ITfsHelper tfs, IChangeset changeset, AuthorsFile authors)
         {

--- a/src/GitTfs/Core/TfsInterop/IItem.cs
+++ b/src/GitTfs/Core/TfsInterop/IItem.cs
@@ -13,9 +13,4 @@ namespace GitTfs.Core.TfsInterop
         long ContentLength { get; }
         TemporaryFile DownloadFile();
     }
-
-    public interface IItemDownloadStrategy
-    {
-        TemporaryFile DownloadFile(IItem item);
-    }
 }

--- a/src/GitTfs/Core/TfsInterop/RootBranch.cs
+++ b/src/GitTfs/Core/TfsInterop/RootBranch.cs
@@ -17,9 +17,9 @@ namespace GitTfs.Core.TfsInterop
             TfsBranchPath = tfsBranchPath;
         }
 
-        public int SourceBranchChangesetId { get; private set; }
-        public int TargetBranchChangesetId { get; private set; }
-        public string TfsBranchPath { get; private set; }
+        public int SourceBranchChangesetId { get; }
+        public int TargetBranchChangesetId { get; }
+        public string TfsBranchPath { get; }
         public bool IsRenamedBranch { get; set; }
 
         private string DebuggerDisplay

--- a/src/GitTfs/GitTfs.cs
+++ b/src/GitTfs/GitTfs.cs
@@ -111,15 +111,6 @@ namespace GitTfs
 
         public void InitializeGlobals()
         {
-            var git = _container.GetInstance<IGitHelpers>();
-            try
-            {
-                _globals.StartingRepositorySubDir = git.CommandOneline("rev-parse", "--show-prefix");
-            }
-            catch (Exception)
-            {
-                _globals.StartingRepositorySubDir = "";
-            }
             if (_globals.GitDir != null)
             {
                 _globals.GitDirSetByUser = true;

--- a/src/GitTfs/Globals.cs
+++ b/src/GitTfs/Globals.cs
@@ -96,8 +96,6 @@ namespace GitTfs
 
         public bool GitDirSetByUser { get; set; }
 
-        public string StartingRepositorySubDir { get; set; }
-
         public IGitRepository Repository { get; set; }
 
         public int GcCountdown { get; set; }

--- a/src/GitTfsTest/Commands/InitBranchTest.cs
+++ b/src/GitTfsTest/Commands/InitBranchTest.cs
@@ -39,14 +39,13 @@ namespace GitTfs.Test.Commands
             globals.GitDir = ".git";
 
             trunkGitTfsRemoteMock = new Mock<IGitTfsRemote>().SetupAllProperties();
+            trunkGitTfsRemoteMock.SetupGet(p => p.Tfs).Returns(tfsHelper);
             trunkGitTfsRemoteMock.Name = nameof(trunkGitTfsRemoteMock);
             var trunkGitTfsRemote = trunkGitTfsRemoteMock.Object;
             trunkGitTfsRemote.TfsUsername = "user";
             trunkGitTfsRemote.TfsPassword = "pwd";
             trunkGitTfsRemote.TfsRepositoryPath = "$/MyProject/Trunk";
             trunkGitTfsRemote.TfsUrl = "http://myTfsServer:8080/tfs";
-            trunkGitTfsRemote.Tfs = tfsHelper;
-            //trunkGitTfsRemote.Tfs = new TfsHelper(mocks.Container, null);
 
             newBranchRemoteMock = Mock.Get(mocks.Get<IGitTfsRemote>()).SetupAllProperties();
             newBranchRemoteMock.Name = nameof(newBranchRemoteMock);
@@ -77,7 +76,7 @@ namespace GitTfs.Test.Commands
 
             trunkGitTfsRemoteMock.Name = nameof(trunkGitTfsRemoteMock);
             trunkGitTfsRemoteMock.Setup(t => t.InitBranch(It.IsAny<RemoteOptions>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<IRenameResult>())).Returns(newBranchRemoteMock.Object).Verifiable();
-            trunkGitTfsRemoteMock.Object.Tfs = tfsHelperMock.Object;
+            trunkGitTfsRemoteMock.SetupGet(x => x.Tfs).Returns(tfsHelperMock.Object);
 
             gitRepositoryMock.Name = nameof(gitRepositoryMock);
             gitRepositoryMock.Setup(x => x.ReadTfsRemote("default")).Returns(trunkGitTfsRemoteMock.Object).Verifiable();
@@ -110,12 +109,14 @@ namespace GitTfs.Test.Commands
 
             tfsHelperMock.Setup(t => t.GetRootChangesetForBranch("$/MyProject/MyBranch", -1, null)).Returns(new List<RootBranch>() { new RootBranch(2010, "$/MyProject/MyBranch") });
 
-            IGitTfsRemote existingBranchRemote = new Mock<IGitTfsRemote>().SetupAllProperties().Object;
+            TfsHelper tfsHelper = new TfsHelper(mocks.Container, null);
+            Mock<IGitTfsRemote> gitTfsRemoteMock = new Mock<IGitTfsRemote>().SetupAllProperties();
+            gitTfsRemoteMock.SetupGet(x => x.Tfs).Returns(tfsHelper);
+            IGitTfsRemote existingBranchRemote = gitTfsRemoteMock.Object;
             existingBranchRemote.TfsUsername = "user";
             existingBranchRemote.TfsPassword = "pwd";
             existingBranchRemote.TfsRepositoryPath = "$/MyProject/MyBranch";
             existingBranchRemote.TfsUrl = "http://myTfsServer:8080/tfs";
-            existingBranchRemote.Tfs = new TfsHelper(mocks.Container, null);
 
             gitRepository.Name = nameof(gitRepository);
             gitRepository.Setup(x => x.ReadTfsRemote("default")).Returns(trunkGitTfsRemoteMock.Object).Verifiable();
@@ -367,7 +368,7 @@ namespace GitTfs.Test.Commands
             remote.TfsPassword = "pwd";
             remote.TfsRepositoryPath = "$/MyProject/Trunk";
             remote.TfsUrl = "http://myTfsServer:8080/tfs";
-            remote.Tfs = new TfsHelper(mocks.Container, null);
+            remoteMock.SetupGet(x => x.Tfs).Returns(new TfsHelper(mocks.Container, null));
 
             //Not Very Clean!!! Don't know how to test that :(
             //If the InvalidOperationException is thrown, it's that the Helper.Run() is Called => That's what is expected!

--- a/src/GitTfsTest/Commands/InitBranchTest.cs
+++ b/src/GitTfsTest/Commands/InitBranchTest.cs
@@ -44,7 +44,7 @@ namespace GitTfs.Test.Commands
             var trunkGitTfsRemote = trunkGitTfsRemoteMock.Object;
             trunkGitTfsRemote.TfsUsername = "user";
             trunkGitTfsRemote.TfsPassword = "pwd";
-            trunkGitTfsRemote.TfsRepositoryPath = "$/MyProject/Trunk";
+            trunkGitTfsRemoteMock.SetupGet(x => x.TfsRepositoryPath).Returns("$/MyProject/Trunk");
             trunkGitTfsRemote.TfsUrl = "http://myTfsServer:8080/tfs";
 
             newBranchRemoteMock = Mock.Get(mocks.Get<IGitTfsRemote>()).SetupAllProperties();
@@ -115,7 +115,7 @@ namespace GitTfs.Test.Commands
             IGitTfsRemote existingBranchRemote = gitTfsRemoteMock.Object;
             existingBranchRemote.TfsUsername = "user";
             existingBranchRemote.TfsPassword = "pwd";
-            existingBranchRemote.TfsRepositoryPath = "$/MyProject/MyBranch";
+            gitTfsRemoteMock.SetupGet(x => x.TfsRepositoryPath).Returns("$/MyProject/MyBranch");
             existingBranchRemote.TfsUrl = "http://myTfsServer:8080/tfs";
 
             gitRepository.Name = nameof(gitRepository);
@@ -366,7 +366,7 @@ namespace GitTfs.Test.Commands
             var remote = remoteMock.Object;
             remote.TfsUsername = "user";
             remote.TfsPassword = "pwd";
-            remote.TfsRepositoryPath = "$/MyProject/Trunk";
+            remoteMock.SetupGet(x => x.TfsRepositoryPath).Returns("$/MyProject/Trunk");
             remote.TfsUrl = "http://myTfsServer:8080/tfs";
             remoteMock.SetupGet(x => x.Tfs).Returns(new TfsHelper(mocks.Container, null));
 

--- a/src/GitTfsTest/Commands/InitBranchTest.cs
+++ b/src/GitTfsTest/Commands/InitBranchTest.cs
@@ -45,7 +45,7 @@ namespace GitTfs.Test.Commands
             trunkGitTfsRemote.TfsUsername = "user";
             trunkGitTfsRemote.TfsPassword = "pwd";
             trunkGitTfsRemoteMock.SetupGet(x => x.TfsRepositoryPath).Returns("$/MyProject/Trunk");
-            trunkGitTfsRemote.TfsUrl = "http://myTfsServer:8080/tfs";
+            trunkGitTfsRemoteMock.SetupGet(x => x.TfsUrl).Returns("http://myTfsServer:8080/tfs");
 
             newBranchRemoteMock = Mock.Get(mocks.Get<IGitTfsRemote>()).SetupAllProperties();
             newBranchRemoteMock.Name = nameof(newBranchRemoteMock);
@@ -116,7 +116,7 @@ namespace GitTfs.Test.Commands
             existingBranchRemote.TfsUsername = "user";
             existingBranchRemote.TfsPassword = "pwd";
             gitTfsRemoteMock.SetupGet(x => x.TfsRepositoryPath).Returns("$/MyProject/MyBranch");
-            existingBranchRemote.TfsUrl = "http://myTfsServer:8080/tfs";
+            gitTfsRemoteMock.SetupGet(x => x.TfsUrl).Returns("http://myTfsServer:8080/tfs");
 
             gitRepository.Name = nameof(gitRepository);
             gitRepository.Setup(x => x.ReadTfsRemote("default")).Returns(trunkGitTfsRemoteMock.Object).Verifiable();
@@ -367,7 +367,7 @@ namespace GitTfs.Test.Commands
             remote.TfsUsername = "user";
             remote.TfsPassword = "pwd";
             remoteMock.SetupGet(x => x.TfsRepositoryPath).Returns("$/MyProject/Trunk");
-            remote.TfsUrl = "http://myTfsServer:8080/tfs";
+            remoteMock.SetupGet(x => x.TfsUrl).Returns("http://myTfsServer:8080/tfs");
             remoteMock.SetupGet(x => x.Tfs).Returns(new TfsHelper(mocks.Container, null));
 
             //Not Very Clean!!! Don't know how to test that :(

--- a/src/GitTfsTest/Commands/InitBranchTest.cs
+++ b/src/GitTfsTest/Commands/InitBranchTest.cs
@@ -49,7 +49,7 @@ namespace GitTfs.Test.Commands
 
             newBranchRemoteMock = Mock.Get(mocks.Get<IGitTfsRemote>()).SetupAllProperties();
             newBranchRemoteMock.Name = nameof(newBranchRemoteMock);
-            newBranchRemoteMock.Object.Id = gitBranchToInit;
+            newBranchRemoteMock.SetupGet(r => r.Id).Returns(gitBranchToInit);
         }
         #endregion
 
@@ -210,7 +210,7 @@ namespace GitTfs.Test.Commands
             #region Branch2
             var newBranch2RemoteMock = new Mock<IGitTfsRemote>();
             newBranch2RemoteMock.Name = nameof(newBranch2RemoteMock);
-            newBranch2RemoteMock.Object.Id = GIT_BRANCH_TO_INIT2;
+            newBranch2RemoteMock.SetupGet(r => r.Id).Returns(GIT_BRANCH_TO_INIT2);
 
             var rootChangeSetB2 = 2000;
             tfsHelperMock.Setup(t => t.GetRootChangesetForBranch(tfsPathBranch2, -1, null)).Returns(new List<RootBranch>() { new RootBranch(rootChangeSetB2, tfsPathBranch2) });
@@ -269,7 +269,7 @@ namespace GitTfs.Test.Commands
 
             #region Branch2
             var newBranch2RemoteMock = new Mock<IGitTfsRemote>();
-            newBranch2RemoteMock.Object.Id = GIT_BRANCH_TO_INIT2;
+            newBranch2RemoteMock.SetupGet(r => r.Id).Returns(GIT_BRANCH_TO_INIT2);
 
             var rootChangeSetB2 = 2000;
             tfsHelperMock.Setup(t => t.GetRootChangesetForBranch(tfsPathBranch2, -1, null)).Returns(new List<RootBranch>() { new RootBranch(rootChangeSetB2, tfsPathBranch2) });
@@ -332,7 +332,7 @@ namespace GitTfs.Test.Commands
 
             #region Branch2
             var newBranch2RemoteMock = new Mock<IGitTfsRemote>();
-            newBranch2RemoteMock.Object.Id = GIT_BRANCH_TO_INIT2;
+            newBranch2RemoteMock.SetupGet(r => r.Id).Returns(GIT_BRANCH_TO_INIT2);
 
             var rootChangeSetB2 = 2000;
             tfsHelperMock.Setup(t => t.GetRootChangesetForBranch(tfsPathBranch2, -1, null)).Returns(new List<RootBranch>() { new RootBranch(rootChangeSetB2, tfsPathBranch2) });

--- a/src/GitTfsTest/Core/TfsWorkspaceTests.cs
+++ b/src/GitTfsTest/Core/TfsWorkspaceTests.cs
@@ -23,8 +23,8 @@ namespace GitTfs.Test.Core
             TfsChangesetInfo contextVersion = new Mock<TfsChangesetInfo>().Object;
             var remoteMock = new Mock<IGitTfsRemote>();
             remoteMock.SetupAllProperties();
+            remoteMock.SetupGet(x => x.Repository).Returns(new Mock<IGitRepository>().Object);
             IGitTfsRemote remote = remoteMock.Object;
-            remote.Repository = new Mock<IGitRepository>().Object;
             ITfsHelper tfsHelper = new Mock<ITfsHelper>().Object;
             CheckinPolicyEvaluator policyEvaluator = new CheckinPolicyEvaluator();
 


### PR DESCRIPTION
All straight forward and invididually reviewable commits accumulated in this PR.
Only 1c862a61bc (Globals: remove unused property StartingRepsitorySubDir) introduces a slight
change in behaviour by removing an useless `git rev-parse --show-prefix` invocation.