### PR TITLE
Make fetch abort at any time by special temp file

### DIFF
--- a/doc/commands/clone.md
+++ b/doc/commands/clone.md
@@ -51,6 +51,8 @@ a TFS source tree and fetch all the changesets
       -c, --changeset=VALUE      The changeset to clone from (must be a number)
       -t, --up-to=VALUE          up-to changeset # (optional, -1 for up to 
                                    maximum, must be a number, not prefixed with C)
+                                 Additionally you can place a file "git-tfs-fetch-abort" in your
+                                   TEMP directory to abort the fetch at any time.
 		  --resumable            if an error occurred, try to continue when you restart clone
 								 with same parameters
 

--- a/doc/commands/fetch.md
+++ b/doc/commands/fetch.md
@@ -12,6 +12,8 @@ The fetch command fetch all the new changesets from a TFS remote
                                  The remote ID of the TFS to interact with
                                    default: default
       -t, --up-to=VALUE,        up-to changeset # (optional, -1 for up to maximum, must be a number, not prefixed with C) 
+                                Additionally you can place a file "git-tfs-fetch-abort" in your
+                                  TEMP directory to abort the fetch at any time.
       -I, --auto-tfs-remote, --auto-remote
                                  Auto-detect (from git history) the remote ID of
                                    the TFS to interact with

--- a/doc/commands/pull.md
+++ b/doc/commands/pull.md
@@ -56,6 +56,8 @@ The `pull` command fetches TFS changesets (like the `fetch` command) and merges
                                   The changeset to clone from (must be a number)
       -t, --up-to, --to=VALUE    up-to changeset # (optional, -1 for up to
                                   maximum, must be a number, not prefixed with 'C')
+                                 Additionally you can place a file "git-tfs-fetch-abort" in your
+                                   TEMP directory to abort the fetch at any time.
           --ignore-branches-regex=VALUE
                                   Don't initialize branches that match given regex
           --ignore-not-init-branches

--- a/src/GitTfs/Core/GitTfsRemote.cs
+++ b/src/GitTfs/Core/GitTfsRemote.cs
@@ -373,6 +373,7 @@ namespace GitTfs.Core
             // TFS 2010 doesn't like when we ask for history past its last changeset.
             if (MaxChangesetId >= latestChangesetId)
                 return fetchResult;
+            string abortFile = Path.Combine(Path.GetTempPath(), "git-tfs-fetch-abort");
 
             bool fetchRetrievedChangesets;
             do
@@ -388,6 +389,11 @@ namespace GitTfs.Core
                     fetchResult.NewChangesetCount++;
                     if (lastChangesetIdToFetch > 0 && changeset.Summary.ChangesetId > lastChangesetIdToFetch)
                         return fetchResult;
+                    if (File.Exists(abortFile))
+                    {
+                        Trace.TraceInformation($"Abort fetch because of abort file: {abortFile}");
+                        return fetchResult;
+                    }
                     string parentCommitSha = null;
                     if (changeset.IsMergeChangeset && !ProcessMergeChangeset(changeset, stopOnFailMergeCommit, ref parentCommitSha))
                     {


### PR DESCRIPTION
If the "up to changeset" value turns out to be too high I want to be able to abort the fetch at any time without just killing the process. Placing a file in the temp directory seems like a simple solution to me.
Also inform the user about the file. In case it is forgotten to be deleted.

I have to import a repository with over 60k changesets. So I do not know a good value of "up to changeset" from the start.
Setting it to a low value makes the process restarting too often.
So I just want to tell it to stop at any time.