### PR TITLE
Use relative path for /exclude in xcopy

### DIFF
--- a/src/GitTfs.Vs2015/GitTfs.Vs2015.csproj
+++ b/src/GitTfs.Vs2015/GitTfs.Vs2015.csproj
@@ -38,7 +38,7 @@
     <Reference Include="System.Windows.Forms" />
       </ItemGroup>
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /y /I &quot;$(TargetDir)*.dll&quot; &quot;$(SolutionDir)GitTfs\$(OutDir)$(ProjectName)&quot; /EXCLUDE:$(SolutionDir)build\files_to_ignore_during_post_build_copy.txt" />
+    <Exec Command="xcopy /y /I &quot;$(TargetDir)*.dll&quot; &quot;$(SolutionDir)GitTfs\$(OutDir)$(ProjectName)&quot; /EXCLUDE:..\build\files_to_ignore_during_post_build_copy.txt" />
   </Target>
   <Import Project="..\.paket\Paket.Restore.targets" />
 </Project>

--- a/src/GitTfs.Vs2017/GitTfs.Vs2017.csproj
+++ b/src/GitTfs.Vs2017/GitTfs.Vs2017.csproj
@@ -40,8 +40,8 @@
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /y /I &quot;$(TargetDir)*.dll&quot; &quot;$(SolutionDir)GitTfs\$(OutDir)$(ProjectName)&quot; /EXCLUDE:$(SolutionDir)build\files_to_ignore_during_post_build_copy.txt" />
-    <Exec Command="xcopy /y /I &quot;$(TargetDir)*.pdb&quot; &quot;$(SolutionDir)GitTfs\$(OutDir)$(ProjectName)&quot; /EXCLUDE:$(SolutionDir)build\files_to_ignore_during_post_build_copy.txt" />
+    <Exec Command="xcopy /y /I &quot;$(TargetDir)*.dll&quot; &quot;$(SolutionDir)GitTfs\$(OutDir)$(ProjectName)&quot; /EXCLUDE:..\build\files_to_ignore_during_post_build_copy.txt" />
+    <Exec Command="xcopy /y /I &quot;$(TargetDir)*.pdb&quot; &quot;$(SolutionDir)GitTfs\$(OutDir)$(ProjectName)&quot; /EXCLUDE:..\build\files_to_ignore_during_post_build_copy.txt" />
   </Target>
   <Import Project="..\.paket\Paket.Restore.targets" />
 </Project>

--- a/src/GitTfs.Vs2019/GitTfs.Vs2019.csproj
+++ b/src/GitTfs.Vs2019/GitTfs.Vs2019.csproj
@@ -40,8 +40,8 @@
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /y /I &quot;$(TargetDir)*.dll&quot; &quot;$(SolutionDir)GitTfs\$(OutDir)$(ProjectName)&quot; /EXCLUDE:$(SolutionDir)build\files_to_ignore_during_post_build_copy.txt" />
-    <Exec Command="xcopy /y /I &quot;$(TargetDir)*.pdb&quot; &quot;$(SolutionDir)GitTfs\$(OutDir)$(ProjectName)&quot; /EXCLUDE:$(SolutionDir)build\files_to_ignore_during_post_build_copy.txt" />
+    <Exec Command="xcopy /y /I &quot;$(TargetDir)*.dll&quot; &quot;$(SolutionDir)GitTfs\$(OutDir)$(ProjectName)&quot; /EXCLUDE:..\build\files_to_ignore_during_post_build_copy.txt" />
+    <Exec Command="xcopy /y /I &quot;$(TargetDir)*.pdb&quot; &quot;$(SolutionDir)GitTfs\$(OutDir)$(ProjectName)&quot; /EXCLUDE:..\build\files_to_ignore_during_post_build_copy.txt" />
   </Target>
   <Import Project="..\.paket\Paket.Restore.targets" />
 </Project>

--- a/src/GitTfs.Vs2022/GitTfs.Vs2022.csproj
+++ b/src/GitTfs.Vs2022/GitTfs.Vs2022.csproj
@@ -40,8 +40,8 @@
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /y /I &quot;$(TargetDir)*.dll&quot; &quot;$(SolutionDir)GitTfs\$(OutDir)$(ProjectName)&quot; /EXCLUDE:$(SolutionDir)build\files_to_ignore_during_post_build_copy.txt" />
-    <Exec Command="xcopy /y /I &quot;$(TargetDir)*.pdb&quot; &quot;$(SolutionDir)GitTfs\$(OutDir)$(ProjectName)&quot; /EXCLUDE:$(SolutionDir)build\files_to_ignore_during_post_build_copy.txt" />
+    <Exec Command="xcopy /y /I &quot;$(TargetDir)*.dll&quot; &quot;$(SolutionDir)GitTfs\$(OutDir)$(ProjectName)&quot; /EXCLUDE:..\build\files_to_ignore_during_post_build_copy.txt" />
+    <Exec Command="xcopy /y /I &quot;$(TargetDir)*.pdb&quot; &quot;$(SolutionDir)GitTfs\$(OutDir)$(ProjectName)&quot; /EXCLUDE:..\build\files_to_ignore_during_post_build_copy.txt" />
   </Target>
   <Import Project="..\.paket\Paket.Restore.targets" />
 </Project>


### PR DESCRIPTION
xcopy with /exclude to an absolute path that contains
spaces does not work.
But quotes also does not work for /exclude:
https://stackoverflow.com/a/43298176

So simply use a relative path.