### PR TITLE
Authenticate each server only once

### DIFF
--- a/src/GitTfs.VsCommon/TfsHelper.Common.cs
+++ b/src/GitTfs.VsCommon/TfsHelper.Common.cs
@@ -30,6 +30,7 @@ namespace GitTfs.VsCommon
         protected TfsTeamProjectCollection _server;
         private static bool _resolverInstalled;
         private AuthorsFile _authorsFile;
+        private Uri _lastAuthenticatedUri;
 
         public TfsHelperBase(TfsApiBridge bridge, IContainer container)
         {
@@ -85,9 +86,15 @@ namespace GitTfs.VsCommon
                 {
                     uri = new Uri(Url);
                 }
-
-                _server = GetTfsCredential(uri);
-                _server.EnsureAuthenticated();
+                // Only authenticate if the TFS Server Uri is different to the last authenticated Uri,
+                // avoiding useless authentication attempts on an already authenticated server.
+                // This covers only the common case that the remotes are on the same TFS server.
+                if (_lastAuthenticatedUri?.ToString() != uri.ToString())
+                {
+                    _server = GetTfsCredential(uri);
+                    _server.EnsureAuthenticated();
+                    _lastAuthenticatedUri = uri;
+                }
             }
         }
 


### PR DESCRIPTION
Without this optimization for each of my over 2000 remote
branches the server is authenticated.
Taking ages.