### PR TITLE
Fixes quick-clone authors file warning

### DIFF
--- a/src/GitTfs/GitTfs.cs
+++ b/src/GitTfs/GitTfs.cs
@@ -44,7 +44,7 @@ namespace GitTfs
             UpdateLoggerOnDebugging();
             Trace.WriteLine("Command run:" + _globals.CommandLineRun);
             if (RequiresValidGitRepository(command)) AssertValidGitRepository();
-            bool willCreateRepository = command.GetType() == typeof(Clone) || command.GetType() == typeof(Init);
+            bool willCreateRepository = command.GetType() == typeof(Clone) || command.GetType() == typeof(QuickClone) || command.GetType() == typeof(Init);
             ParseAuthorsAndSave(!willCreateRepository);
             var exitCode = Main(command, unparsedArgs);
             if (willCreateRepository)


### PR DESCRIPTION
This pull request should fix [issue#1435](https://github.com/git-tfs/git-tfs/issues/1435).