### PR TITLE
Remove `--no-metadata` from documentation

### DIFF
--- a/doc/commands/fetch.md
+++ b/doc/commands/fetch.md
@@ -23,10 +23,6 @@ The fetch command fetch all the new changesets from a TFS remote
                                    users
           --batch-size=VALUE     Size of the batch of tfs changesets fetched (-1 for all in one batch)
           --ignore-regex=VALUE   a regex of files to ignore
-          --no-metadata          leave out the 'git-tfs-id:' tag in commit
-                                   messages
-                                   Use this when you're exporting from TFS and
-                                   don't need to put data back into TFS.
 		  --ignore-branches-regex=VALUE 
 								 Don't initialize branches that match given regex
 		  --ignore-not-init-branches

--- a/doc/commands/init.md
+++ b/doc/commands/init.md
@@ -23,10 +23,6 @@ Prefer the [clone](clone.md) command to initialize and fetch changesets from a T
           --workspace=VALUE      set tfs workspace to a specific folder (a
                                    shorter path is better!)
           --ignore-regex=VALUE   a regex of files to ignore
-          --no-metadata          leave out the 'git-tfs-id:' tag in commit
-                                   messages
-                                   Use this when you're exporting from TFS and
-                                   don't need to put data back into TFS.
       -u, --username=VALUE       TFS username
       -p, --password=VALUE       TFS password
           --no-parallel          Do not do parallel requests to TFS

--- a/doc/commands/pull.md
+++ b/doc/commands/pull.md
@@ -21,10 +21,6 @@ The `pull` command fetches TFS changesets (like the `fetch` command) and merges
           --authors=VALUE        Path to an Authors file to map TFS users to Git
                                    users
           --ignore-regex=VALUE   a regex of files to ignore
-          --no-metadata          leave out the 'git-tfs-id:' tag in commit
-                                   messages
-                                   Use this when you're exporting from TFS and
-                                   don't need to put data back into TFS.
       -A, --authors=VALUE        Path to an Authors file to map TFS users to Git
                                   users (will be kept in cache and used for all
                                   the following commands)

--- a/doc/commands/quick-clone.md
+++ b/doc/commands/quick-clone.md
@@ -37,11 +37,6 @@ Useful for making code changes or additions where past history isn't relevant.
 			(Type: Value required, Value Type:[String])
 			The --initial-branch option to pass to git-init (requires Git >= 2.28.0).
 
-		--no-metadata
-			(Type: Flag, Value Type:[Boolean])
-			If specified, git-tfs will leave out the git-tfs-id: lines at the end of every
-				commit.
-
 		--ignore-regex
 			(Type: Value required, Value Type:[String])
 			If specified, git-tfs will not sync any paths that match this regular expression.

--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -14,3 +14,4 @@
   fails if you specify the `--gitignore` option (#1412 by @fineol)
 * Don't authenticate again if the TFS server hasn't changed between the TFS remotes (#1424 by @ckorn)
 * Add support for reading the remotes to delete in `git-tfs branch` from a file (#1425 by @ckorn)
+* Remove leftover `--no-metadata` argument from documentation, as feature is gone since v0.17.0 (#1447 by @siprbaum)

--- a/doc/samples/sample.html
+++ b/doc/samples/sample.html
@@ -45,10 +45,6 @@ where options are:
         (Type: Value required, Value Type:[Object])
         The --shared option to pass to git-init.
 
-    --no-metadata
-        (Type: Flag, Value Type:[Boolean])
-        If specified, git-tfs will leave out the git-tfs-id: lines at the end of every commit.
-
     --template
         (Type: Value required, Value Type:[String])
         The --template option to pass to git-init.

--- a/doc/samples/sample.txt
+++ b/doc/samples/sample.txt
@@ -23,10 +23,6 @@ where options are:
         (Type: Value required, Value Type:[Object])
         The --shared option to pass to git-init.
 
-    --no-metadata
-        (Type: Flag, Value Type:[Boolean])
-        If specified, git-tfs will leave out the git-tfs-id: lines at the end of every commit.
-
     --template
         (Type: Value required, Value Type:[String])
         The --template option to pass to git-init.


### PR DESCRIPTION
The feature is gone since v0.17.0 and was removed in 4c2ab71e ("Remove unused config no-meta-data (see #281, #283).", 2013-01-10)

Remove the leftover comments to avoid any further confusion.
Note: For removing the `git-tfs-id:` markers at the end of the commit
message, see the howto at https://github.com/git-tfs/git-tfs/blob/master/doc/usecases/migrate_tfs_to_git.md#clean-commits-optional
