### PR TITLE
Add logging of conflicts for merge operation

### DIFF
--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -15,3 +15,4 @@
 * Don't authenticate again if the TFS server hasn't changed between the TFS remotes (#1424 by @ckorn)
 * Add support for reading the remotes to delete in `git-tfs branch` from a file (#1425 by @ckorn)
 * Remove leftover `--no-metadata` argument from documentation, as feature is gone since v0.17.0 (#1447 by @siprbaum)
+* Add logging of conflicts for merge operation (#1448 by @idealist1508)

--- a/src/GitTfs/Core/GitRepository.cs
+++ b/src/GitTfs/Core/GitRepository.cs
@@ -319,7 +319,18 @@ namespace GitTfs.Core
             var commit = _repository.Lookup<Commit>(commitish);
             if (commit == null)
                 throw new GitTfsException("error: commit '" + commitish + "' can't be found and merged into!");
-            return _repository.Merge(commit, _repository.Config.BuildSignature(new DateTimeOffset(DateTime.Now)));
+
+            var options = new MergeOptions
+            {
+                OnCheckoutNotify = (file, reason) =>
+                {
+                    if (reason == CheckoutNotifyFlags.Conflict)
+                        Trace.TraceError("conflict found: " + file);
+                    return true;
+                },
+                CheckoutNotifyFlags = CheckoutNotifyFlags.Conflict
+            };
+            return _repository.Merge(commit, _repository.Config.BuildSignature(new DateTimeOffset(DateTime.Now)), options);
         }
 
         public String GetCurrentCommit()


### PR DESCRIPTION
On a merge conflict was only a count of conflicts reported. 
![grafik](https://user-images.githubusercontent.com/4608274/211002356-6f7eb940-9132-49a4-afa2-4d71428ca0ff.png)

List of conflicts/files is shown now.
![grafik](https://user-images.githubusercontent.com/4608274/211002913-fa388a0f-549e-4c4f-a253-c74e555545b5.png)
