### PR TITLE
Enable PAT Authentication through GIT_TFS_PAT environmental variable

### DIFF
--- a/src/GitTfs.VsCommon/TfsHelper.Vs2017Base.cs
+++ b/src/GitTfs.VsCommon/TfsHelper.Vs2017Base.cs
@@ -187,8 +187,12 @@ namespace GitTfs.VsCommon
 
         protected override TfsTeamProjectCollection GetTfsCredential(Uri uri)
         {
+            var token = System.Environment.GetEnvironmentVariable("GIT_TFS_PAT");
             var vssCred = HasCredentials
-                ? new VssClientCredentials(new WindowsCredential(GetCredential()))
+                ? ((string.IsNullOrEmpty(Username) && !string.IsNullOrEmpty(token) || Password == "pat")?
+                    new VssBasicCredential(string.Empty, token):
+                    new VssClientCredentials(new WindowsCredential(GetCredential()))
+                  )
                 : VssClientCredentials.LoadCachedCredentials(uri, false, CredentialPromptType.PromptIfNeeded);
 
             return new TfsTeamProjectCollection(uri, vssCred);


### PR DESCRIPTION
If a PAT token is exported through `GIT_TFS_PAT` environment variable, authentication will be done using PAT token.  
Assume GIT_TFS_CLIENT is 2017 or above.