### PR TITLE
Fix the problem where a wrong branch is returned

### DIFF
--- a/src/GitTfs/Core/TfsInterop/IBranch.cs
+++ b/src/GitTfs/Core/TfsInterop/IBranch.cs
@@ -77,12 +77,14 @@ namespace GitTfs.Core.TfsInterop
                 }
             }
             var roots = branchTrees.Values.Where(b => b.IsRoot);
-            return roots.FirstOrDefault(b =>
+            var branchTreesWithMatchingPath = roots.Where(b =>
             {
                 var visitor = new BranchTreeContainsPathVisitor(remoteTfsPath, searchExactPath);
                 b.AcceptVisitor(visitor);
                 return visitor.Found;
             });
+            
+            return branchTreesWithMatchingPath?.FirstOrDefault(b => string.Equals(b.Path, remoteTfsPath));
         }
 
         public static void AcceptVisitor(this BranchTree branch, IBranchTreeVisitor treeVisitor, int level = 0)


### PR DESCRIPTION
If several branch names starts the same way (ex: MyBranch and MyBranchBis), git tfs can return MyBranchBis instead of MyBranch when asked to clone MyBranch

cf. Issue #1454