### PR TITLE
Expand cloning command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ You need .NET 4.6.2 and the 2012 or 2013 version of Team Explorer installed (or 
     git tfs list-remote-branches http://tfs:8080/tfs/DefaultCollection
 
     # clone the whole repository (wait for a while...) :
-    git tfs clone http://tfs:8080/tfs/DefaultCollection $/some_project
+    git tfs clone http://tfs:8080/tfs/DefaultCollection $/some_project <dist_folder_where_to_clone>
 
     # or, if you're impatient (and want to work from the last changeset) :
-    git tfs quick-clone http://tfs:8080/tfs/DefaultCollection $/some_project
+    git tfs quick-clone http://tfs:8080/tfs/DefaultCollection $/some_project <dist_folder_where_to_clone>
 
     # or, if you're impatient (and want a specific changeset) :
     git tfs quick-clone http://tfs:8080/tfs/DefaultCollection $/some_project -c=145


### PR DESCRIPTION
Without explicitly providing the destination folder, the contents of repo was not cloned properly. I am not sure if anyone else encountered this, but I did and this was the solution to it.

I have not looked at your src and what you do in case of not providing a destination folder, but if you think this is a valid proposal, feel free to merge

