### PR TITLE
Warn the user if a TFS changeset shall be assigned to multiple commits

### DIFF
--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -16,3 +16,4 @@
 * Add support for reading the remotes to delete in `git-tfs branch` from a file (#1425 by @ckorn)
 * Remove leftover `--no-metadata` argument from documentation, as feature is gone since v0.17.0 (#1447 by @siprbaum)
 * Add logging of conflicts for merge operation (#1448 by @idealist1508)
+* Fix rare issue when a TFS changeset shall be assigned to multiple commits (#1469 @cdrfun)

--- a/src/GitTfs/Core/GitRepository.cs
+++ b/src/GitTfs/Core/GitRepository.cs
@@ -810,7 +810,8 @@ namespace GitTfs.Core
                 {
                     if (pairs.TryGetValue(changesetId, out var commitSha))
                         Trace.TraceWarning("warning: Git commit {0} couldn't be assigned to TFS changeset '{1}' as git commit '{2}' was assigned already. Please correct the export file accordingly if needed", c.Sha, changesetId, commitSha);
-                    else pairs.Add(changesetId, c.Sha);
+                    else
+                        pairs.Add(changesetId, c.Sha);
                 }
                 else
                 {

--- a/src/GitTfs/Core/GitRepository.cs
+++ b/src/GitTfs/Core/GitRepository.cs
@@ -808,7 +808,9 @@ namespace GitTfs.Core
                 int changesetId;
                 if (TryParseChangesetId(c.Message, out changesetId))
                 {
-                    pairs.Add(changesetId, c.Sha);
+                    if (pairs.TryGetValue(changesetId, out var commitSha))
+                        Trace.TraceWarning("warning: Git commit {0} couldn't be assigned to TFS changeset '{1}' as git commit '{2}' was assigned already. Please correct the export file accordingly if needed", c.Sha, changesetId, commitSha);
+                    else pairs.Add(changesetId, c.Sha);
                 }
                 else
                 {


### PR DESCRIPTION
Warn the user if a TFS changeset shall be assigned to multiple commits.

This PR closes #1469