### PR TITLE
Object ref error when cloning a repo

### DIFF
--- a/src/GitTfs.VsCommon/TfsHelper.Common.cs
+++ b/src/GitTfs.VsCommon/TfsHelper.Common.cs
@@ -521,6 +521,7 @@ namespace GitTfs.VsCommon
                     new ItemIdentifier(tfsPathBranchToCreate),
                     new ItemIdentifier[] { new ItemIdentifier(tfsPathParentBranch), },
                     null)
+                .Where(x => x.SourceChangeset?.ChangesetId != null)
                 .OrderByDescending(x => x.SourceChangeset.ChangesetId);
             MergeInfo lastMerge = null;
             foreach (var extendedMerge in merges)


### PR DESCRIPTION
git tfs clone https://mytfsrepo.net/tfscollection $/repo .

Cloning a very old repo (10+ years old) and I kept getting object ref errors.  Upon debugging, it looks like GetMergeInfo is failing because some merges have null source changesets.  I'm making an educated guess that they were from branches that were deleted? Either way, adding a .Where(x => x.SourceChangeset?.ChangesetId != null) allows it to get past the issue and continue the clone.