### PR TITLE
Enabling PAT authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,15 +103,6 @@ Have a look to more detailed git-tfs use cases:
 * [Git (ProGit v2 book)](https://git-scm.com/book/en/v2)
 * [Last ProGit2 release to cover Git Tfs and migration](https://github.com/progit/progit2/releases/tag/2.1.245)
 
-## Authentication
-By default, git-tfs will attempt to use current user Windows credentials, or cached user credentials in the case of connecting to Azure DevOps or remote TFS server. Connecting to an Azure DevOps organization may prompt you to login to your organization, which may also include additional multi-factor/2FA authentication steps.
-
-In some scenarios, such as bulk operations or automated scripting scenarios (like in a pipeline task), you may wish to bypass this user interactive dialog. To do so, you may leverage a Personal Access Token (PAT) from Azure DevOps stored in your local machines environment variables, named as `GIT_TFS_PAT`. You can easily set this environment variable via command-line:
-```
-setx GIT_TFS_PAT insert_pat_here
-```
-After setting this environment variable, all interactions to a TFS server/Azure DevOps will use this PAT for authentication. No user credentials will be used, nor offered. In order to return to normal user interactive logins, delete this environment variable.
-
 ## Available commands / options
 
 This is the complete list of commands in the master branch on github.
@@ -163,6 +154,7 @@ This is the complete list of commands in the master branch on github.
 * diagnostics (for git-tfs developers only) - since 0.9
 
 * [config file](doc/config.md)
+* For authentification with user credentials or using a PAT, [clone](doc/commands/clone.md#Authentication) command.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -106,9 +106,9 @@ Have a look to more detailed git-tfs use cases:
 ## Authentication
 By default, git-tfs will attempt to use current user Windows credentials, or cached user credentials in the case of connecting to Azure DevOps or remote TFS server. Connecting to an Azure DevOps organization may prompt you to login to your organization, which may also include additional multi-factor/2FA authentication steps.
 
-In some scenarios, such as bulk operations or automated scripting scenarios (like in a pipeline task), you may wish to bypass this user interactive dialog. To do so, you may leverage a Personal Access Token (PAT) from Azure DevOps stored in your local machines environment variables, named as `GITTFS_PAT`. You can easily set this environment variable via command-line:
+In some scenarios, such as bulk operations or automated scripting scenarios (like in a pipeline task), you may wish to bypass this user interactive dialog. To do so, you may leverage a Personal Access Token (PAT) from Azure DevOps stored in your local machines environment variables, named as `GIT_TFS_PAT`. You can easily set this environment variable via command-line:
 ```
-setx GITTFS_PAT insert_pat_here
+setx GIT_TFS_PAT insert_pat_here
 ```
 After setting this environment variable, all interactions to a TFS server/Azure DevOps will use this PAT for authentication. No user credentials will be used, nor offered. In order to return to normal user interactive logins, delete this environment variable.
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,15 @@ Have a look to more detailed git-tfs use cases:
 * [Git (ProGit v2 book)](https://git-scm.com/book/en/v2)
 * [Last ProGit2 release to cover Git Tfs and migration](https://github.com/progit/progit2/releases/tag/2.1.245)
 
+## Authentication
+By default, git-tfs will attempt to use current user Windows credentials, or cached user credentials in the case of connecting to Azure DevOps or remote TFS server. Connecting to an Azure DevOps organization may prompt you to login to your organization, which may also include additional multi-factor/2FA authentication steps.
+
+In some scenarios, such as bulk operations or automated scripting scenarios (like in a pipeline task), you may wish to bypass this user interactive dialog. To do so, you may leverage a Personal Access Token (PAT) from Azure DevOps stored in your local machines environment variables, named as `GITTFS_PAT`. You can easily set this environment variable via command-line:
+```
+setx GITTFS_PAT insert_pat_here
+```
+After setting this environment variable, all interactions to a TFS server/Azure DevOps will use this PAT for authentication. No user credentials will be used, nor offered. In order to return to normal user interactive logins, delete this environment variable.
+
 ## Available commands / options
 
 This is the complete list of commands in the master branch on github.

--- a/doc/commands/branch.md
+++ b/doc/commands/branch.md
@@ -136,7 +136,7 @@ You can use the parameter `--no-fetch`, to initialize the branch by creating its
 
 ### Authentication
 
-For the use of parameters `--username` and `--password`, see the [clone](clone.md) command.
+For the use of parameters `--username` and `--password` or authenticate using a PAT, see the [clone](clone.md) command.
 
 ### Map TFS users to git users
 

--- a/doc/commands/clone.md
+++ b/doc/commands/clone.md
@@ -195,10 +195,21 @@ You could download a `.gitignore` file for your language or project from the [gi
 
 ### Authentication
 
-If the TFS server need an authentication, you could use the _--username_ and _--password_ parameters. If you don't specify theses informations, you will be prompted to enter them. If you use these parameters, the informations, git-tfs will store these informations (in the .git/config file --in clear--) and never prompt you again. If you don't want your password to be saved, don't use these options.
+#### Using credentials
+
+If the TFS server need an authentication, you could use the _--username_ and _--password_ parameters. If you don't specify these informations, you will be prompted to enter them. If you use these parameters, the informations, git-tfs will store these informations (in the .git/config file --in clear--) and never prompt you again. If you don't want your password to be saved, don't use these options.
 
     git tfs clone http://tfs:8080/tfs/DefaultCollection $/Project1 -u=DISSRVTFS03\peter.pan -p=wendy
 
+#### Using a PAT (Personal Access Token)
+
+By default, git-tfs will attempt to use current user Windows credentials, or cached user credentials in the case of connecting to Azure DevOps or remote TFS server. Connecting to an Azure DevOps organization may prompt you to login to your organization, which may also include additional multi-factor/2FA authentication steps.
+
+In some scenarios, such as bulk operations or automated scripting scenarios (like in a pipeline task), you may wish to bypass this user interactive dialog. To do so, you may leverage a Personal Access Token (PAT) from Azure DevOps stored in your local machines environment variables, named as `GIT_TFS_PAT`. You can easily set this environment variable via command-line:
+```
+setx GIT_TFS_PAT insert_pat_here
+```
+After setting this environment variable, all interactions to a TFS server/Azure DevOps will use this PAT for authentication. No user credentials will be used, nor offered. In order to return to normal user interactive logins, delete this environment variable.
 
 ### Map TFS users to git users
 

--- a/doc/commands/list-remote-branches.md
+++ b/doc/commands/list-remote-branches.md
@@ -53,7 +53,7 @@ However, it is recommended to clone the root branch and then use the [`branch`](
 
 ### Authentication
 
-If the TFS server needs an authentication, you could use the _--username_ and _--password_ parameters. If you don't specify this information, you will be prompted to enter them. This information is not stored by git-tfs.
+If the TFS server needs an authentication, you could use the _--username_ and _--password_ parameters or authenticate with a PAT (See the [clone](clone.md) command for details). If you don't specify this information, you will be prompted to enter them. This information is not stored by git-tfs.
 
     git tfs list-remote-branches http://tfs:8080/tfs/DefaultCollection -u=DISSRVTFS03\peter.pan -p=wendy
 

--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -17,3 +17,4 @@
 * Remove leftover `--no-metadata` argument from documentation, as feature is gone since v0.17.0 (#1447 by @siprbaum)
 * Add logging of conflicts for merge operation (#1448 by @idealist1508)
 * Fix rare issue when a TFS changeset shall be assigned to multiple commits (#1469 @cdrfun)
+* Add PAT authentication support through `GIT_TFS_PAT` environment variable (#1476 by @ryancdotnet)

--- a/src/GitTfs.VsCommon/TfsHelper.Vs2017Base.cs
+++ b/src/GitTfs.VsCommon/TfsHelper.Vs2017Base.cs
@@ -35,7 +35,7 @@ namespace GitTfs.VsCommon
         private const string myTeamExplorerFolder =
             @"Common7\IDE\CommonExtensions\Microsoft\TeamFoundation\Team Explorer";
 
-        private const string gitTfsPatEnvironmentVariableName = "GITTFS_PAT";
+        private const string gitTfsPatEnvironmentVariableName = "GIT_TFS_PAT";
 
         private readonly List<string> myAssemblySearchPaths;
 
@@ -197,7 +197,7 @@ namespace GitTfs.VsCommon
 
             if (!String.IsNullOrWhiteSpace(pat))
             {
-                Console.WriteLine("A GITTFS_PAT personal access token was detected. Establishing TFS credentials using PAT...");
+                Console.WriteLine($"A {gitTfsPatEnvironmentVariableName} environment variable was detected. Establishing TFS credentials using PAT...");
 
                 vssCred = new VssBasicCredential(string.Empty, pat);
 

--- a/src/GitTfs.VsCommon/TfsHelper.Vs2017Base.cs
+++ b/src/GitTfs.VsCommon/TfsHelper.Vs2017Base.cs
@@ -195,24 +195,24 @@ namespace GitTfs.VsCommon
                 ?? Environment.GetEnvironmentVariable(gitTfsPatEnvironmentVariableName, EnvironmentVariableTarget.Machine)
                 ?? Environment.GetEnvironmentVariable(gitTfsPatEnvironmentVariableName, EnvironmentVariableTarget.Process);
 
-            if (!String.IsNullOrWhiteSpace(pat))
+            if (!string.IsNullOrWhiteSpace(pat))
             {
-                Console.WriteLine($"A {gitTfsPatEnvironmentVariableName} environment variable was detected. Establishing TFS credentials using PAT...");
+                Trace.WriteLine($"A {gitTfsPatEnvironmentVariableName} environment variable was detected. Establishing TFS credentials using PAT...");
 
                 vssCred = new VssBasicCredential(string.Empty, pat);
 
-                Console.WriteLine("PAT-based VSS Credentials created.");
+                Trace.WriteLine("PAT-based VSS Credentials created.");
             }
 
             if (vssCred == null)
             {
-                Console.WriteLine("Establishing TFS credentials using user identity...");
+                Trace.WriteLine("Establishing TFS credentials using user identity...");
 
                 vssCred = HasCredentials
                     ? new VssClientCredentials(new WindowsCredential(GetCredential()))
                     : VssClientCredentials.LoadCachedCredentials(uri, false, CredentialPromptType.PromptIfNeeded);
 
-                Console.WriteLine("Identity-based VSS credentials created.");
+                Trace.WriteLine("Identity-based VSS credentials created.");
             }
 
             return new TfsTeamProjectCollection(uri, vssCred);


### PR DESCRIPTION
After reviewing a few others' attempts at enabling PAT authentication to Azure DevOps, I thought I would try my hand at it. There were some quirks that I've worked out in this version, and I hope it is useful for others.

The main difference I've made is that when a `GIT_TFS_PAT` environment variable is present, it bypasses any chances at user interactive authentication. This helps with debugging things like automated scripts, because you won't get false negatives as user prompts when the PAT env var is detected and it's possible bad, the authentication will simply just fail.

### A note for folks wanting to use this build directly
So because this repo has fallen out of active support, you may be wondering if you can download this branch, build it, and use this version for your own pipelines/automation scripts. Well, you can! I didn't even bother with the build.ps1/cake scripts. All I did was download this repo, open the GitTfs.sln in Visual Studio 2022, *switch to this branch*, rebuild the solution, and voila! You should have the output under src/GitTfs/bin/...

Note: If you do change anything in the common code, which is shared code amongst all the other VS-versioned projects, you'll need to rebuild all to have those VS-versioned projects build and push their binaries to the src/GitTfs/bin/... folder (it's a post-build step on each of those projects). This was a major source of my troubles when testing this code out, as I didn't rebuild the right projects during testing. Just be safe and rebuild everything.

### About migrating from TFVC(TFS) to Git
I ended up using this version of git-tfs to enable an Azure Pipeline to automate conversion/migration of TFVC(TFS) code into Git repositories. It works great!
