### PR TITLE
Add the Multi Workspace workaround to the PathTooLong issue

### DIFF
--- a/doc/Set-custom-workspace.md
+++ b/doc/Set-custom-workspace.md
@@ -42,7 +42,9 @@ Another better solution if you faced this problem is to use a custom workspace d
 
 You could set the workspace directory when cloning the tfs repository using the `--workspace` option :
 
-    git tfs clone http://server/tfs $/Project/trunk project --workspace="c:\ws"
+```DOS
+git tfs clone http://server/tfs $/Project/trunk project --workspace="c:\ws"
+```
 
 To set a custom workspace directory, you could also run the command (in a already existing repository):
 `git config git-tfs.workspace-dir c:\ws`
@@ -52,3 +54,78 @@ Note:
 - the `--workspace` option is also available with the `init`command
 
 More informations : See [here](https://github.com/git-tfs/git-tfs/issues/314) or [there](https://github.com/git-tfs/git-tfs/issues/430) or [there](https://github.com/git-tfs/git-tfs/pull/266)
+
+### Leverage TFVC workspace's Working Folders
+
+You applied the solutions above [Enable Win32 long paths](#enabling-windows-10-win32-long-path-support) and [Short Workspace](#move-clone-directory-closer-to-the-root-drive), yet you still get a TF400889/TF205022, what else can you do ?  Leverage the multi working folder of TFVC workspaces.
+
+Add the argument `--MultipleWorkingFoldersConfigFilePath={path to json file}`
+
+The JSON file should follow this schema.
+
+```JSON
+[
+  { 
+    "SourceControlFolder" : "$/{enter the TFVC path that is failing}",
+    "LocalFolder" : "{enter a local path (shorter the better) where files under the TFVC path above will end up}"
+  }
+]
+```
+
+This approach leverages the multiple Working Folders of a TFVC Workspace.  For more info on this, check Microsoft's article [Create and work with workspaces](https://learn.microsoft.com/en-us/azure/devops/repos/tfvc/create-work-workspaces?view=azure-devops).
+
+#### Example scenario
+
+Scenario:
+
+- TFS Url: `http://tfs:8080/tfs/DefaultCollection`
+- TFVC Path: `$/MyProject`
+- Workspace: `W:\`
+- Item too long: `$/MyProject/thisFolderIsIntentionalyLong/ReproduceThePathTooLongErrorWithTFVC/main/src/Foo/SomeClassThatIsSuperLongOrWhatever.cs`
+
+The git command would be:
+
+```DOS
+git tfs clone --workspace=W:\ http://tfs:8080/tfs/DefaultCollection $/MyProject
+```
+
+You get the TFS Path Too long error on the `$/MyProject/thisFolderIsIntentionalyLong/ReproduceThePathTooLongErrorWithTFVC/main/src/Foo/SomeClassThatIsSuperLongOrWhatever.cs`
+
+Apply the multiple Working Folders solution:
+
+- Create a file `C:\mapping.json` (the filename or placement does not matter)
+- Enter a TFVC Path and a short working folder.
+
+Note that the TFVC path entered is a sub-path of the failing item.
+
+```JSON
+[
+  { 
+    "SourceControlFolder" : "$/MyProject/thisFolderIsIntentionalyLong/ReproduceThePathTooLongErrorWithTFVC/main",
+    "LocalFolder" : "x:\\1"
+  }
+]
+```
+
+Rerun the git command with the argument `--MultipleWorkingFoldersConfigFilePath="c:\mapping.json"`
+
+```DOS
+git tfs clone --workspace=W:\ --MultipleWorkingFoldersConfigFilePath="c:\mapping.json" http://tfs:8080/tfs/DefaultCollection $/MyProject
+```
+
+The TFVC Workspace will contain the following Working Folders:
+
+| Source Control Folder | Local Folder |
+| --------------------- | ------------ |
+| $/MyProject           | W:\          |
+| $/MyProject/thisFolderIsIntentionalyLong/ReproduceThePathTooLongErrorWithTFVC/main | X:\1 |
+
+Without this approach, the file `src/Foo/SomeClassThatIsSuperLongOrWhatever.cs` would end up under:
+
+`W:\MyProject\thisFolderIsIntentionalyLong\ReproduceThePathTooLongErrorWithTFVC\main\src\Foo\SomeClassThatIsSuperLongOrWhatever.cs`
+
+Triggering the Path too long exception.
+
+With the multiple Working Folders, that file will be under:
+
+`X:\1\src\Foo\SomeClassThatIsSuperLongOrWhatever.cs`

--- a/src/GitTfs/Commands/RemoteOptions.cs
+++ b/src/GitTfs/Commands/RemoteOptions.cs
@@ -26,6 +26,8 @@ namespace GitTfs.Commands
                         v => Password = v },
                     { "no-parallel", "Do not do parallel requests to TFS",
                         v => NoParallel = (v != null) },
+                    { "MultipleWorkingFoldersConfigFilePath=", "Pass the path to a JSON file containing the workplace's folder mapping. Try the '--workspace' workaround first, if that's not enough. pass a json file containing a list of Working Folders mappings.  See online docs for details and for json schema.",
+                        v => MultipleWorkingFoldersConfigFilePath = v},
                 };
             }
         }
@@ -38,5 +40,16 @@ namespace GitTfs.Commands
         public string Username { get; set; }
         public string Password { get; set; }
         public bool NoParallel { get; set; }
+
+        /// <summary>
+        /// Workaround/Hack for the TF400889/TF205022.  Path to a json file containing mappings between [Source Control Folder] and [Local Folder]
+        /// </summary>
+        /// <remarks>
+        /// <para>When you encounter a Path too long error TF400889/TF205022, the first step is try specifying a short <see cref="WorkspacePath"/>.  
+        /// If even that fails, then the only workaround is to map the failing source control folder ($/x/y/z) to a different, short, local folder (c:\x\1)
+        /// <seealso cref="https://learn.microsoft.com/en-us/azure/devops/repos/tfvc/create-work-workspaces?view=azure-devops&redirectedfrom=MSDN&f1url=%3FappId%3DDev16IDEF1%26l%3DEN-US%26k%3Dk(vs.tfc.sourcecontrol.DialogEditWorkspace)%26rd%3Dtrue#q-why-would-i-need-to-change-the-working-folders-how-should-i-do-it"/>
+        /// </para>
+        /// </remarks>
+        public string MultipleWorkingFoldersConfigFilePath { get; set; }
     }
 }

--- a/src/GitTfs/Commands/WorkingFolderMapping.cs
+++ b/src/GitTfs/Commands/WorkingFolderMapping.cs
@@ -1,0 +1,28 @@
+﻿namespace GitTfs.Commands
+{
+    /// <summary>
+    /// Source Control Folder to Local folder mapping
+    /// </summary>
+    /// <remarks>
+    /// <para>This class is used by the deserialization of the JSON in the git tfs clone --MultipleWorkingFoldersConfigFilePath</para>
+    /// </remarks>
+    /// <see cref="https://learn.microsoft.com/en-us/azure/devops/repos/tfvc/create-work-workspaces?view=azure-devops"/>
+    public class WorkingFolderMapping
+    {
+        /// <summary>
+        /// The TFVC/Source Control Path.  Starting with a $/
+        /// </summary>
+        /// <example>
+        /// $/Foo/Bar
+        /// </example>
+        public string SourceControlFolder { get; set; }
+
+        /// <summary>
+        /// The Local folder where any item under the the specified <see cref="SourceControlFolder"/> will be downloaded to.  Shorter the better.
+        /// </summary>
+        /// <example>
+        /// C:\x\1
+        /// </example>
+        public string LocalFolder { get; set; }
+    }
+}

--- a/src/GitTfs/Core/DerivedGitTfsRemote.cs
+++ b/src/GitTfs/Core/DerivedGitTfsRemote.cs
@@ -303,6 +303,8 @@ namespace GitTfs.Core
             get { throw DerivedRemoteException; }
         }
 
+        public IReadOnlyList<Tuple<string, string>> FolderMappings => throw new NotImplementedException();
+
         public void Merge(string sourceTfsPath, string targetTfsPath)
         {
             throw DerivedRemoteException;

--- a/src/GitTfs/Core/GitTfsRemote.cs
+++ b/src/GitTfs/Core/GitTfsRemote.cs
@@ -45,6 +45,22 @@ namespace GitTfs.Core
             IgnoreExceptRegexExpression = info.IgnoreExceptRegex;
             _useGitIgnore = !_remoteOptions.NoGitIgnore && (_remoteOptions.UseGitIgnore || IsGitIgnoreSupportEnabled());
 
+            if (!string.IsNullOrWhiteSpace(remoteOptions.MultipleWorkingFoldersConfigFilePath))
+            {
+                if (System.IO.File.Exists((remoteOptions.MultipleWorkingFoldersConfigFilePath)))
+                {
+                    Trace.TraceInformation("MultipleWorkingFoldersConfigFilePath path: [{0}]", remoteOptions.MultipleWorkingFoldersConfigFilePath);
+
+                    IList<WorkingFolderMapping> mappings = Newtonsoft.Json.JsonConvert.DeserializeObject<IList<WorkingFolderMapping>>(System.IO.File.ReadAllText(remoteOptions.MultipleWorkingFoldersConfigFilePath));
+
+                    FolderMappings = (IReadOnlyList<Tuple<string, string>>)mappings.Select(c => new Tuple<string, string>(c.SourceControlFolder, c.LocalFolder));
+                }
+                else
+                {
+                    throw new FileNotFoundException("The file specified with the --MultipleWorkingFoldersConfigFilePath was not found");
+                }
+            }
+
             Autotag = info.Autotag;
 
             IsSubtree = CheckSubtree();
@@ -149,6 +165,8 @@ namespace GitTfs.Core
             }
         }
         private string[] tfsSubtreePaths = null;
+
+        public IReadOnlyList<Tuple<string, string>> FolderMappings { get; }
 
         public string IgnoreRegexExpression { get; }
         public string IgnoreExceptRegexExpression { get; }

--- a/src/GitTfs/Core/IGitTfsRemote.cs
+++ b/src/GitTfs/Core/IGitTfsRemote.cs
@@ -38,6 +38,11 @@ namespace GitTfs.Core
         /// Valid if the remote has subtrees, which occurs when <see cref="TfsRepositoryPath"/> is null.
         /// </summary>
         string[] TfsSubtreePaths { get; }
+
+        /// <summary>
+        /// Part of the solution for Path Too Long
+        /// </summary>
+        IReadOnlyList<Tuple<string, string>> FolderMappings { get; }
         string IgnoreRegexExpression { get; }
         string IgnoreExceptRegexExpression { get; }
         bool Autotag { get; }

--- a/src/GitTfs/Core/TfsWorkspace.cs
+++ b/src/GitTfs/Core/TfsWorkspace.cs
@@ -177,7 +177,14 @@ namespace GitTfs.Core
 
         public string GetLocalPath(string path)
         {
-            return Path.Combine(_localDirectory, path);
+            var localPath = Path.Combine(_localDirectory, path);
+
+            if (System.IO.File.Exists(localPath))
+            {
+                return localPath;
+            }
+
+            return this._workspace.GetLocalItemForServerItem($"{Remote.TfsRepositoryPath}/{path}");
         }
 
         public void Add(string path)

--- a/src/GitTfs/paket.references
+++ b/src/GitTfs/paket.references
@@ -1,3 +1,4 @@
 LibGit2Sharp
 nlog
 structuremap
+Newtonsoft.Json

--- a/src/paket.dependencies
+++ b/src/paket.dependencies
@@ -8,6 +8,7 @@ source https://api.nuget.org/v3/index.json
 //because there is some subtleties on how we use it in our project:
 //https://github.com/git-tfs/git-tfs/blob/master/doc/paket.md
 
+nuget Newtonsoft.Json 10.0.2
 nuget nlog
 nuget LibGit2Sharp ~> 0.26.1
 nuget Moq

--- a/src/paket.lock
+++ b/src/paket.lock
@@ -8,6 +8,7 @@ NUGET
     Moq (4.14.7)
       Castle.Core (>= 4.4)
       System.Threading.Tasks.Extensions (>= 4.5.1)
+    Newtonsoft.Json (10.0.2)
     NLog (4.7.5)
     structuremap (2.6.3)
     structuremap.automocking (2.6.3)


### PR DESCRIPTION
[x] run and verify that existing tests pass. Add some new units tests, if needed.
[x] update the documentation, if needed.
[ ] update the [release notes file](https://github.com/git-tfs/git-tfs/tree/master/doc/release-notes/NEXT.md) NOT done...

There are situations where the workaround of using a very short path for a custom workspace is not enough.

The solution implemented leverages a TFVC workspace's ability to have multiple Working Folders. A new ```git tfs clone``` argument was created ```--MultipleWorkingFoldersConfigFilePath``` that allows the user to specify a json file containing an array of folder mappings that are passed along to the creation of the Workspace. These mappings are "SourceControlFolder" and "LocalFolder".

- SourceControlFolder: TFVC path ($/...) triggering the Path too long
- LocalFolder: a local folder (shorter the better) where the items will be mapped to.

I've updated the doc/Set-custom-workspace.md with the instructions and an example/scenario