### PR TITLE
Small fixes

### DIFF
--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -1,0 +1,1 @@
+* fix: read/write of `description` in bare repos

--- a/src/GitTfs/Commands/Info.cs
+++ b/src/GitTfs/Commands/Info.cs
@@ -61,7 +61,7 @@ namespace GitTfs.Commands
         {
             try
             {
-                var repoDescription = File.ReadAllLines(@".git\description");
+                var repoDescription = File.ReadAllLines(Path.Combine(_globals.GitDir, "description"));
                 if (repoDescription.Length == 0 || !repoDescription[0].StartsWith("$/"))
                     return;
 

--- a/src/GitTfs/Commands/Init.cs
+++ b/src/GitTfs/Commands/Init.cs
@@ -100,11 +100,11 @@ namespace GitTfs.Commands
             var runResult = Run(tfsUrl, tfsRepositoryPath);
             try
             {
-                File.WriteAllText(@".git\description", tfsRepositoryPath + "\n" + HideUserCredentials(_globals.CommandLineRun));
+                File.WriteAllText(Path.Combine(_globals.GitDir, "description"), tfsRepositoryPath + "\n" + HideUserCredentials(_globals.CommandLineRun));
             }
             catch (Exception)
             {
-                Trace.WriteLine("warning: Unable to update de repository description!");
+                Trace.WriteLine("warning: Unable to update the repository description!");
             }
             return runResult;
         }

--- a/src/GitTfs/Core/GitTfsRemote.cs
+++ b/src/GitTfs/Core/GitTfsRemote.cs
@@ -701,7 +701,7 @@ namespace GitTfs.Core
         {
             int lowerBoundChangesetId;
 
-            // If we're starting at the Root side of a branch commit (e.g. C1), but there ar
+            // If we're starting at the Root side of a branch commit (e.g. C1), but there are
             // invalid commits between C1 and the actual branch side of the commit operation
             // (e.g. a Folder with the branch name was created [C2] and then deleted [C3],
             // then the root-side was branched [C4; C1 --branch--> C4]), this will detecte
@@ -967,7 +967,7 @@ private void DoGcIfNeeded()
                 string.IsNullOrWhiteSpace(gitBranchNameExpected) ? tfsRepositoryPath : gitBranchNameExpected);
             if (string.IsNullOrWhiteSpace(gitBranchName))
                 throw new GitTfsException("error: The Git branch name '" + gitBranchName + "' is not valid...\n");
-            Trace.WriteLine("Git local branch will be :" + gitBranchName);
+            Trace.WriteLine("Git local branch will be : " + gitBranchName);
 
             string sha1RootCommit = null;
             if (rootChangesetId != -1)

--- a/src/GitTfs/Core/GitTfsRemote.cs
+++ b/src/GitTfs/Core/GitTfsRemote.cs
@@ -756,9 +756,9 @@ namespace GitTfs.Core
 
         private string TagPrefix => "refs/tags/tfs/" + Id + "/";
 
-public string RemoteRef => "refs/remotes/tfs/" + Id;
+        public string RemoteRef => "refs/remotes/tfs/" + Id;
 
-private void DoGcIfNeeded()
+        private void DoGcIfNeeded()
         {
             Trace.WriteLine("GC Countdown: " + _globals.GcCountdown);
             if (--_globals.GcCountdown < 0)

--- a/src/build.ps1
+++ b/src/build.ps1
@@ -78,5 +78,5 @@ if (!(Test-Path $CAKE_EXE)) {
 
 # Start Cake
 Write-Host "Running build script..."
-Invoke-Expression "& `"$CAKE_EXE`" `"$Script`" --paths_tools=`"$TOOLS_DIR`" --target=`"$Target`" --configuration=`"$Configuration`" --verbosity=`"$Verbosity`" $UseDryRun $UseExperimental $ScriptArgs"
+Invoke-Expression "& `"$CAKE_EXE`" `"$Script`" --paths_tools=`"$TOOLS_DIR`" --target=`"$Target`" --configuration=`"$Configuration`" --verbosity=`"$Verbosity`" $UseDryRun $ScriptArgs"
 exit $LASTEXITCODE

--- a/src/build.ps1
+++ b/src/build.ps1
@@ -15,13 +15,9 @@ The build script target to run.
 The build configuration to use.
 .PARAMETER Verbosity
 Specifies the amount of information to be displayed.
-.PARAMETER Experimental
-Tells Cake to use the latest Roslyn release.
 .PARAMETER WhatIf
 Performs a dry run of the build script.
 No tasks will be executed.
-.PARAMETER Mono
-Tells Cake to use the Mono scripting engine.
 
 .LINK
 http://cakebuild.net
@@ -36,10 +32,8 @@ Param(
     [string]$Configuration = "Debug",
     [ValidateSet("Quiet", "Minimal", "Normal", "Verbose", "Diagnostic")]
     [string]$Verbosity = "Verbose",
-    [switch]$Experimental,
     [Alias("DryRun","Noop")]
     [switch]$WhatIf,
-    [switch]$Mono,
     [switch]$SkipToolPackageRestore,
     [Parameter(Position=0,Mandatory=$false,ValueFromRemainingArguments=$true)]
     [string[]]$ScriptArgs


### PR DESCRIPTION
Fixing a few small issues, mostly typos/formatting, but also the build script which simply crashed on referencing a non-existent variable in case PowerShell strict mode was enabled.

Most notably this also fixes accessing the `description` file in bare repos.