### PR TITLE
Fix handling of renamed branches for clone/fetch

### DIFF
--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -1,3 +1,4 @@
 * fix: read/write of `description` in bare repos ( #1487 by bramborman )
 * chore: target .net v4.8 ( #1490 by @pmiossec )
 * chore: Update libgit2sharp to v0.30 ( #1492 by @pmiossec )
+* Fix handling of renamed branches for clone/fetch ( #1493 by @dh2i-sam )

--- a/src/GitTfs/Core/GitTfsRemote.cs
+++ b/src/GitTfs/Core/GitTfsRemote.cs
@@ -326,6 +326,11 @@ namespace GitTfs.Core
             if (MaxChangesetId >= latestChangesetId)
                 return fetchResult;
 
+            // If a branch is the result of a branch rename operation,
+            // the first commit on the branch will be the rename commit.
+            // In this case, we still want to fetch it, and we use firstOnBranch
+            // to track this state.
+            bool firstOnBranch = true;
             bool fetchRetrievedChangesets;
             do
             {
@@ -335,6 +340,11 @@ namespace GitTfs.Core
                 fetchRetrievedChangesets = false;
                 foreach (var changeset in fetchedChangesets)
                 {
+                    if (firstOnBranch &&
+                        _properties.InitialChangeset.HasValue &&
+                        changeset.Summary.ChangesetId >= _properties.InitialChangeset.Value)
+                        firstOnBranch = false;
+
                     fetchRetrievedChangesets = true;
 
                     fetchResult.NewChangesetCount++;
@@ -350,7 +360,7 @@ namespace GitTfs.Core
                     var parentSha = (renameResult != null && renameResult.IsProcessingRenameChangeset) ? renameResult.LastParentCommitBeforeRename : MaxCommitHash;
                     var isFirstTFSCommitInRepository = (MaxChangesetId == 0);
                     var log = Apply(parentSha, changeset, objects);
-                    if (changeset.IsRenameChangeset && !isFirstTFSCommitInRepository)
+                    if (changeset.IsRenameChangeset && !isFirstTFSCommitInRepository && !firstOnBranch)
                     {
                         if (renameResult == null || !renameResult.IsProcessingRenameChangeset)
                         {
@@ -637,10 +647,12 @@ namespace GitTfs.Core
             var branchesDatas = Tfs.GetRootChangesetForBranch(tfsBranch.Path, parentChangesetId);
 
             IGitTfsRemote remote = null;
+            bool first = true;
             foreach (var branch in branchesDatas)
             {
                 var rootChangesetId = branch.SourceBranchChangesetId;
-                remote = InitBranch(_remoteOptions, tfsBranch.Path, rootChangesetId, true);
+                remote = InitBranch(_remoteOptions, branch.TfsBranchPath, rootChangesetId, first, renameResult: renameResult);
+                first = false;
                 if (remote == null)
                 {
                     Trace.TraceInformation("warning: root commit not found corresponding to changeset " + rootChangesetId);
@@ -652,7 +664,12 @@ namespace GitTfs.Core
                 {
                     try
                     {
-                        remote.Fetch(renameResult: renameResult);
+                        IFetchResult lastFetch = remote.Fetch(renameResult: renameResult);
+                        if (lastFetch != null &&
+                            lastFetch.IsProcessingRenameChangeset)
+                            renameResult = lastFetch;
+                        else
+                            renameResult = null;
                     }
                     finally
                     {
@@ -969,7 +986,11 @@ namespace GitTfs.Core
             string sha1RootCommit = null;
             if (rootChangesetId != -1)
             {
-                sha1RootCommit = Repository.FindCommitHashByChangesetId(rootChangesetId);
+                if (renameResult != null &&
+                    renameResult.IsProcessingRenameChangeset)
+                    sha1RootCommit = renameResult.LastParentCommitBeforeRename;
+                else
+                    sha1RootCommit = Repository.FindCommitHashByChangesetId(rootChangesetId);
                 if (fetchParentBranch && string.IsNullOrWhiteSpace(sha1RootCommit))
                 {
                     try

--- a/src/GitTfs/Core/GitTfsRemote.cs
+++ b/src/GitTfs/Core/GitTfsRemote.cs
@@ -651,7 +651,7 @@ namespace GitTfs.Core
             foreach (var branch in branchesDatas)
             {
                 var rootChangesetId = branch.SourceBranchChangesetId;
-                remote = InitBranch(_remoteOptions, branch.TfsBranchPath, rootChangesetId, isFirstBranchChangeset, renameResult: renameResult);
+                remote = InitBranch(_remoteOptions, branch.TfsBranchPath, rootChangesetId, fetchParentBranch: isFirstBranchChangeset, renameResult: renameResult);
                 isFirstBranchChangeset = false;
                 if (remote == null)
                 {


### PR DESCRIPTION
The bug that this is intended to fix appears to be documented in #1029.  I've been trying to migrate a TFS repository to Git, and need complete history.  My repository has maybe five branches that have been renamed, and I've lost patience with working around this bug by manually initializing remotes of the deleted former branch names to ensure that preceding changesets are present, as well as manually enumerating all of the branches.

The fix has three facets:

In GitTfsRemote.FetchWithMerge(), apply special handling to initial branch commits that are renaming, as rename destination branches will have these.

In GitTfsRemote.InitTfsRemoteOfChangeset(), when iterating over branch ancestry, call InitBranch() on the ancestor branch path, not the target branch path.  Also only request fetching of parents for the most distant ancestor.  Also when handling renamed branches, set the renameResult parameter for the successor.

In GitTfsRemote.InitTfsBranch(), pull the initial commit ID out of renameResult, if provided.