### PR TITLE
[WIP] Branch renames followup

### DIFF
--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -2,4 +2,5 @@
 * chore: target .net v4.8 ( #1490 by @pmiossec )
 * chore: Update libgit2sharp to v0.30 ( #1492 by @pmiossec )
 * Fix handling of renamed branches for clone/fetch ( #1493 by @dh2i-sam )
+* Fix handling of renamed branches for clone/fetch in additional cases ( #1514 by @bramborman )
 * Fix parent-less branches missing .gitignore ( #1518 by @bramborman )

--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -1,4 +1,5 @@
-* fix: read/write of `description` in bare repos ( #1487 by bramborman )
+* fix: read/write of `description` in bare repos ( #1487 by @bramborman )
 * chore: target .net v4.8 ( #1490 by @pmiossec )
 * chore: Update libgit2sharp to v0.30 ( #1492 by @pmiossec )
 * Fix handling of renamed branches for clone/fetch ( #1493 by @dh2i-sam )
+* Fix parent-less branches missing .gitignore ( #1518 by @bramborman )

--- a/src/GitTfs.VsFake/TfsHelper.VsFake.cs
+++ b/src/GitTfs.VsFake/TfsHelper.VsFake.cs
@@ -375,6 +375,8 @@ namespace GitTfs.VsFake
 
         public void DeleteShelveset(IWorkspace workspace, string shelvesetName) => throw new NotImplementedException();
 
+        public bool TryGetBranchNameBeforeRename(string path, int changeset, out string originalBranchName) => throw new NotImplementedException();
+
         #endregion
 
         private class FakeVersionControlServer : IVersionControlServer

--- a/src/GitTfs/Commands/Init.cs
+++ b/src/GitTfs/Commands/Init.cs
@@ -39,7 +39,6 @@ namespace GitTfs.Commands
             DoGitInitDb();
             VerifyGitUserConfig();
             SaveAuthorFileInRepository();
-            CommitTheGitIgnoreFile(_remoteOptions.GitIgnorePath);
             UseTheGitIgnoreFile(_remoteOptions.GitIgnorePath);
             GitTfsInit(tfsUrl, tfsRepositoryPath);
             return 0;
@@ -61,16 +60,6 @@ namespace GitTfs.Commands
         }
 
         private void SaveAuthorFileInRepository() => _authorsFileHelper.SaveAuthorFileInRepository(_globals.AuthorsFilePath, _globals.GitDir);
-
-        private void CommitTheGitIgnoreFile(string pathToGitIgnoreFile)
-        {
-            if (string.IsNullOrWhiteSpace(pathToGitIgnoreFile))
-            {
-                Trace.WriteLine("No .gitignore file specified to commit...");
-                return;
-            }
-            _globals.Repository.CommitGitIgnore(pathToGitIgnoreFile);
-        }
 
         private void UseTheGitIgnoreFile(string pathToGitIgnoreFile)
         {

--- a/src/GitTfs/Core/IGitRepository.cs
+++ b/src/GitTfs/Core/IGitRepository.cs
@@ -60,7 +60,7 @@ namespace GitTfs.Core
         bool Checkout(string commitish);
         IEnumerable<GitCommit> FindParentCommits(string fromCommit, string toCommit);
         bool IsPathIgnored(string relativePath);
-        string CommitGitIgnore(string pathToGitIgnoreFile);
+        string CommitGitIgnore(string pathToGitIgnoreFile, string branchName);
         void UseGitIgnore(string pathToGitIgnoreFile);
         IDictionary<int, string> GetCommitChangeSetPairs();
     }

--- a/src/GitTfs/Core/ITfsChangeset.cs
+++ b/src/GitTfs/Core/ITfsChangeset.cs
@@ -1,4 +1,4 @@
-﻿namespace GitTfs.Core
+namespace GitTfs.Core
 {
     public interface ITfsChangeset
     {
@@ -27,6 +27,6 @@
         /// </summary>
         string OmittedParentBranch { get; set; }
 
-        bool IsRenameChangeset { get; set; }
+        bool IsBranchRenameChangeset { get; }
     }
 }

--- a/src/GitTfs/Core/TfsInterop/ITfsHelper.cs
+++ b/src/GitTfs/Core/TfsInterop/ITfsHelper.cs
@@ -34,6 +34,7 @@ namespace GitTfs.Core.TfsInterop
         void CreateTfsRootBranch(string projectName, string mainBranch, string gitRepositoryPath, bool createTeamProjectFolder);
         bool IsExistingInTfs(string path);
         int FindMergeChangesetParent(string path, int firstChangeset, GitTfsRemote remote);
+        bool TryGetBranchNameBeforeRename(string path, int changeset, out string originalBranchName);
         /// <summary>
         /// Creates and maps a workspace for the given remote with the given local -> server directory mappings, at the given Tfs version,
         /// and then performs the action.

--- a/src/GitTfs/Core/TfsInterop/TfsChangeType.cs
+++ b/src/GitTfs/Core/TfsInterop/TfsChangeType.cs
@@ -16,6 +16,10 @@
         Branch = 0x0080,
         Merge = 0x0100,
 
-        Lock = 0x0200
+        Lock = 0x0200,
+
+        Rollback = 0x0400,
+        Property = 0x2000,
+        SourceRename = 0x0800,
     }
 }

--- a/src/GitTfs/Util/ChangeSieve.cs
+++ b/src/GitTfs/Util/ChangeSieve.cs
@@ -43,25 +43,6 @@ namespace GitTfs.Util
             });
         }
 
-        private bool? _renameBranchCommmit;
-        /// <summary>
-        /// Is the top-level folder deleted or renamed?
-        /// </summary>
-        public bool RenameBranchCommmit
-        {
-            get
-            {
-                if (!_renameBranchCommmit.HasValue)
-                {
-                    _renameBranchCommmit = NamedChanges.Any(c =>
-                        c.Change.Item.ItemType == TfsItemType.Folder
-                            && c.GitPath == string.Empty
-                            && c.Change.ChangeType.IncludesOneOf(TfsChangeType.Delete, TfsChangeType.Rename));
-                }
-                return _renameBranchCommmit.Value;
-            }
-        }
-
         public IEnumerable<IChange> GetChangesToFetch()
         {
             if (DeletesProject)


### PR DESCRIPTION
> This is a WIP - draft PR. Will update the description and code before marking ready for definite review.

A follow-up on the recently merged added support to support renamed branches.
While the other PR works "bottom-up", ie when the clone starts from the original name of branch that is then renamed. This adds support for the other way. When a branch is first fetched and its first changeset is a rename changeset, it first fetches the original branch.
As a result, all of the TFVC branch names have a separate branch in Git, what is a little bit cluttering, but can easily be manually cleaned up.

I've migrated a bunch of repos using builds of this branch merged together with #1517, #1518 and most of the changes in #1496.
As the changes are quite complex, this branch is based on #1518. When #1518 is merged, this should be rebased onto master.

TODO:
- [ ] verify child branches of previous trunk name are also cloned when they should