### PR TITLE
Fix outdated branches

### DIFF
--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -1,4 +1,5 @@
-* fix: read/write of `description` in bare repos ( #1487 by bramborman )
+* fix: read/write of `description` in bare repos ( #1487 by @bramborman )
 * chore: target .net v4.8 ( #1490 by @pmiossec )
 * chore: Update libgit2sharp to v0.30 ( #1492 by @pmiossec )
 * Fix handling of renamed branches for clone/fetch ( #1493 by @dh2i-sam )
+* Fix cases where branches weren't updated to latest changesets on init ( #1516 by @bramborman )


### PR DESCRIPTION
This commit fixes two separate cases of branches being outdated even after a fresh clone with `--branches=all` specified.

### 1. First issue
It seems that if a branch was partially fetched as a dependency of some other branch, when the program gets to completely fetch it afterwards, it doesn't update the ref to the latest fetched commit.

This is a screenshot taken before this fix. As you can see, the `tfs/` ref is three commits ahead of the local branch after fresh clone. With this PR, the local branch is on the latest commit as well.
![outdated-branch](https://github.com/user-attachments/assets/fdb28fae-9f05-4237-80a7-e1edda30f9c9)

### 2. Second issue
I'm not sure if this can happen without #1514 where I noticed this issue, but believe it cannot hurt anything (except performance, possibly) even without the change in #1514.
Consider the two screenshots below. First shows a freshly cloned Git repo before this fix, the second a freshly cloned Git repo after this fix. As you can see, the first screenshot is missing one whole commit and has `Renamed_TestBranching/Dev` on an incorrect commit.
The `TestBranching/Dev` branch was one changeset ahead of `TestBranching/Main` when `TestBranching` was renamed to `Renamed_TestBranching`.
The `RemoveAlreadyFetchedBranches` method incorrectly removes the `TestBranching/Dev` from collection of branches to fetch as dependency of `Renamed_TestBranching/Dev`. But the `TestBranching/Dev` branch is not fully fetched to Git, though - misses the one changeset it's ahead of `TestBranching/Main`. The `Renamed_TestBranching/Dev` branch is then based on incorrect commit in Git and following `git gc` invoked by GitTfs fails.
I was debugging the code around this, hoping to fix the `RemoveAlreadyFetchedBranches` method. But it acts on data provided by some other methods that are used in multiple places. Also the naming of the variables around is pretty hard to understand to me. So I worry changing something there might introduce other bugs in other places, and also am unsure of what to change. Moreover, I don't think removing this method does that much of a harm. At worst the code would now double-check that everything is fetched, what shouldn't take much time, and even if it does, being correct is more important than being fast. So this code is also more error-prone.

The `default` branch is `Renamed_TestBranching/Main`.
![before](https://github.com/user-attachments/assets/7bc7b346-5a03-43a4-9293-81c53b972f11)
![after](https://github.com/user-attachments/assets/4b7f441b-c7a5-4945-be95-831883567a45)

After creating these screenshots I fixed the missing `tfs/TestBranching/Dev` remote as can be seen on the second screenshot. Simply by not deleting a fetched remote if it existed before the fetch.
