### PR TITLE
Better handle and propagate fetch errors

### DIFF
--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -1,4 +1,5 @@
-* fix: read/write of `description` in bare repos ( #1487 by bramborman )
+* fix: read/write of `description` in bare repos ( #1487 by @bramborman )
 * chore: target .net v4.8 ( #1490 by @pmiossec )
 * chore: Update libgit2sharp to v0.30 ( #1492 by @pmiossec )
 * Fix handling of renamed branches for clone/fetch ( #1493 by @dh2i-sam )
+* Better handle and propagate fetch errors ( #1517 by @bramborman )

--- a/src/GitTfs/Commands/Clone.cs
+++ b/src/GitTfs/Commands/Clone.cs
@@ -106,15 +106,19 @@ namespace GitTfs.Commands
 
                 if (retVal == 0)
                 {
-                    _fetch.Run(_fetch.BranchStrategy == BranchStrategy.All);
+                    retVal = _fetch.Run(_fetch.BranchStrategy == BranchStrategy.All);
                     _globals.Repository.GarbageCollect();
                 }
 
-                if (_fetch.BranchStrategy == BranchStrategy.All && _initBranch != null)
+                if (retVal == 0)
                 {
-                    _initBranch.CloneAllBranches = true;
+                    if (_fetch.BranchStrategy == BranchStrategy.All && _initBranch != null)
+                    {
+                        _initBranch.CloneAllBranches = true;
 
-                    retVal = _initBranch.Run();
+                        retVal = _initBranch.Run();
+                        _globals.Repository.GarbageCollect();
+                    }
                 }
             }
             catch (GitTfsException)

--- a/src/GitTfs/Commands/QuickFetch.cs
+++ b/src/GitTfs/Commands/QuickFetch.cs
@@ -1,4 +1,4 @@
-﻿using GitTfs.Core;
+using GitTfs.Core;
 
 namespace GitTfs.Commands
 {
@@ -18,14 +18,12 @@ namespace GitTfs.Commands
             _properties = properties;
         }
 
-        protected override void DoFetch(IGitTfsRemote remote, bool stopOnFailMergeCommit)
+        protected override IFetchResult DoFetch(IGitTfsRemote remote, bool stopOnFailMergeCommit)
         {
-            if (InitialChangeset.HasValue)
-                remote.QuickFetch(InitialChangeset.Value, false, false);
-            else
-                remote.QuickFetch(-1, false, false);
+            var fetchResult = remote.QuickFetch(InitialChangeset ?? -1, false, false);
             _properties.InitialChangeset = remote.MaxChangesetId;
             _properties.PersistAllOverrides();
+            return fetchResult;
         }
     }
 }

--- a/src/GitTfs/Core/DerivedGitTfsRemote.cs
+++ b/src/GitTfs/Core/DerivedGitTfsRemote.cs
@@ -136,7 +136,7 @@ namespace GitTfs.Core
 
         public IFetchResult FetchWithMerge(int mergeChangesetId, bool stopOnFailMergeCommit = false, IRenameResult renameResult = null, params string[] parentCommitsHashes) => throw DerivedRemoteException;
 
-        public void QuickFetch(int changesetId, bool ignoreRestricted, bool printRestrictionHint) => throw DerivedRemoteException;
+        public IFetchResult QuickFetch(int changesetId, bool ignoreRestricted, bool printRestrictionHint) => throw DerivedRemoteException;
 
         public void Unshelve(string a, string b, string c, Action<Exception> h, bool force) => throw DerivedRemoteException;
 

--- a/src/GitTfs/Core/GitTfsRemote.cs
+++ b/src/GitTfs/Core/GitTfsRemote.cs
@@ -402,13 +402,9 @@ namespace GitTfs.Core
                 var parentChangesetId = Tfs.FindMergeChangesetParent(TfsRepositoryPath, changeset.Summary.ChangesetId, this);
                 if (parentChangesetId < 1)  // Handle missing merge parent info
                 {
-                    if (stopOnFailMergeCommit)
-                    {
-                        return false;
-                    }
-                    Trace.TraceInformation("warning: this changeset " + changeset.Summary.ChangesetId +
-                                     " is a merge changeset. But git-tfs is unable to determine the parent changeset.");
-                    return true;
+                    Trace.TraceInformation($"warning: this changeset C{changeset.Summary.ChangesetId} is a merge changeset" +
+                        " but git-tfs is unable to determine the parent changeset.");
+                    return !stopOnFailMergeCommit;
                 }
                 var shaParent = Repository.FindCommitHashByChangesetId(parentChangesetId);
                 if (shaParent == null)
@@ -423,19 +419,19 @@ namespace GitTfs.Core
                 }
                 else
                 {
+                    Trace.TraceInformation($"warning: this changeset C{changeset.Summary.ChangesetId} is a merge changeset" +
+                        $" but git-tfs failed to find and fetch the parent changeset C{parentChangesetId}." +
+                        (stopOnFailMergeCommit ? null : " The parent changeset will be ignored..."));
+
                     if (stopOnFailMergeCommit)
                         return false;
-
-                    Trace.TraceInformation("warning: this changeset " + changeset.Summary.ChangesetId +
-                                     " is a merge changeset. But git-tfs failed to find and fetch the parent changeset "
-                                     + parentChangesetId + ". Parent changeset will be ignored...");
                 }
             }
             else
             {
-                Trace.TraceInformation("info: this changeset " + changeset.Summary.ChangesetId +
-                                 " is a merge changeset. But was not treated as is because of your git setting...");
-                changeset.OmittedParentBranch = ";C" + changeset.Summary.ChangesetId;
+                Trace.TraceInformation($"info: this changeset C{changeset.Summary.ChangesetId} is a merge changeset" +
+                    " but was not treated as such because of your git setting...");
+                changeset.OmittedParentBranch = $";C{changeset.Summary.ChangesetId}";
             }
             return true;
         }
@@ -558,20 +554,25 @@ namespace GitTfs.Core
 
             if (tfsRemote != null && string.Compare(tfsRemote.TfsRepositoryPath, TfsRepositoryPath, StringComparison.InvariantCultureIgnoreCase) != 0)
             {
-                Trace.TraceInformation("\tFetching from dependent TFS remote '{0}'...", tfsRemote.Id);
+                Trace.TraceInformation($"Fetching from dependent TFS remote '{tfsRemote.Id}'...");
+                IFetchResult fetchResult = null;
                 try
                 {
-                    var fetchResult = ((GitTfsRemote)tfsRemote).FetchWithMerge(-1, stopOnFailMergeCommit, parentChangesetId, renameResult);
+                    fetchResult = ((GitTfsRemote)tfsRemote).FetchWithMerge(-1, stopOnFailMergeCommit, parentChangesetId, renameResult);
                 }
                 finally
                 {
                     Trace.WriteLine("Cleaning...");
                     tfsRemote.CleanupWorkspaceDirectory();
 
-                    if (tfsRemote.Repository.IsBare)
+                    if (fetchResult?.IsSuccess == true && tfsRemote.Repository.IsBare)
                         tfsRemote.Repository.UpdateRef(GitRepository.ShortToLocalName(tfsRemote.Id), tfsRemote.MaxCommitHash);
                 }
-                return Repository.FindCommitHashByChangesetId(parentChangesetId);
+
+                var sha = Repository.FindCommitHashByChangesetId(parentChangesetId);
+                if (sha == null)
+                    Trace.TraceWarning($"warning: fetching of remote for C{parentChangesetId} didn't fetch the specified changeset.");
+                return sha;
             }
             return null;
         }
@@ -623,7 +624,7 @@ namespace GitTfs.Core
                 }
                 else if (tfsBranch == null)
                 {
-                    Trace.TraceInformation("error: branch not found. Verify that all the folders have been converted to branches (or something else :().\n\tpath {0}", tfsPath);
+                    Trace.TraceInformation($"error: branch not found in TFS. Verify that all the folders have been converted to branches (or something else :().\n\tpath {tfsPath}");
                     tfsRemote = null;
                     omittedParentBranch = ";C" + parentChangesetId;
                 }
@@ -683,7 +684,7 @@ namespace GitTfs.Core
             return remote;
         }
 
-        public void QuickFetch(int changesetId, bool ignoreRestricted, bool printRestrictionHint)
+        public IFetchResult QuickFetch(int changesetId, bool ignoreRestricted, bool printRestrictionHint)
         {
             try
             {
@@ -693,12 +694,23 @@ namespace GitTfs.Core
                 else
                     changeset = Tfs.GetChangeset(changesetId, this);
                 quickFetch(changeset);
+                return new FetchResult()
+                {
+                    IsSuccess = true,
+                    LastFetchedChangesetId = changesetId,
+                    NewChangesetCount = 1,
+                };
             }
             catch (Exception ex)
             {
                 Trace.WriteLine("Quick fetch failed: " + ex.Message);
                 if (!IgnoreException(ex.Message, ignoreRestricted, printRestrictionHint))
                     throw;
+
+                return new FetchResult()
+                {
+                    IsSuccess = false,
+                };
             }
         }
 
@@ -727,8 +739,7 @@ namespace GitTfs.Core
             }
             else
                 lowerBoundChangesetId = MaxChangesetId + 1;
-            Trace.WriteLine(RemoteRef + ": Getting changesets from " + lowerBoundChangesetId +
-                " to " + lastVersion + " ...", "info");
+            Trace.WriteLine($"{RemoteRef}: Getting changesets from C{lowerBoundChangesetId} to C{lastVersion} ...", "info");
             if (!IsSubtreeOwner)
                 return Tfs.GetChangesets(TfsRepositoryPath, lowerBoundChangesetId, this, lastVersion, byLots);
 

--- a/src/GitTfs/Core/IGitTfsRemote.cs
+++ b/src/GitTfs/Core/IGitTfsRemote.cs
@@ -61,7 +61,7 @@ namespace GitTfs.Core
         string GetPathInGitRepo(string tfsPath);
         IFetchResult Fetch(bool stopOnFailMergeCommit = false, int lastChangesetIdToFetch = -1, IRenameResult renameResult = null);
         IFetchResult FetchWithMerge(int mergeChangesetId, bool stopOnFailMergeCommit = false, IRenameResult renameResult = null, params string[] parentCommitsHashes);
-        void QuickFetch(int changesetId, bool ignoreRestricted, bool printRestrictionHint = true);
+        IFetchResult QuickFetch(int changesetId, bool ignoreRestricted, bool printRestrictionHint = true);
         void Unshelve(string shelvesetOwner, string shelvesetName, string destinationBranch, Action<Exception> ignorableErrorHandler, bool force);
         void Shelve(string shelvesetName, string treeish, TfsChangesetInfo parentChangeset, CheckinOptions options, bool evaluateCheckinPolicies);
         bool HasShelveset(string shelvesetName);

--- a/src/GitTfs/Program.cs
+++ b/src/GitTfs/Program.cs
@@ -37,7 +37,7 @@ namespace GitTfs
             return container.GetInstance<GitTfs>().Run(new List<string>(args));
         }
 
-        private static void ReportException(Exception e)
+        private static void ReportException(Exception e, bool printLogFilePath = true)
         {
             var gitTfsException = e as GitTfsException;
             if (gitTfsException != null)
@@ -45,7 +45,7 @@ namespace GitTfs
                 Trace.WriteLine(gitTfsException);
                 Trace.TraceError(gitTfsException.Message);
                 if (gitTfsException.InnerException != null)
-                    ReportException(gitTfsException.InnerException);
+                    ReportException(gitTfsException.InnerException, false);
                 if (!gitTfsException.RecommendedSolutions.IsEmpty())
                 {
                     Trace.TraceError("You may be able to resolve this problem.");
@@ -60,7 +60,8 @@ namespace GitTfs
                 ReportInternalException(e);
             }
 
-            Trace.TraceWarning("All the logs could be found in the log file: " + _logFilePath);
+            if (printLogFilePath)
+                Trace.TraceWarning($"All the logs could be found in the log file: {_logFilePath}");
         }
 
         private static void ReportInternalException(Exception e)


### PR DESCRIPTION
Start or improve handling of fetch errors in various places.
Don't print log file path more than once.
Also collect garbage after cloning all branches.