### PR TITLE
Commit .gitignore in each branch

### DIFF
--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -1,4 +1,5 @@
-* fix: read/write of `description` in bare repos ( #1487 by bramborman )
+* fix: read/write of `description` in bare repos ( #1487 by @bramborman )
 * chore: target .net v4.8 ( #1490 by @pmiossec )
 * chore: Update libgit2sharp to v0.30 ( #1492 by @pmiossec )
 * Fix handling of renamed branches for clone/fetch ( #1493 by @dh2i-sam )
+* Fix parent-less branches missing .gitignore ( #1518 by @bramborman )

--- a/src/GitTfs/Commands/Init.cs
+++ b/src/GitTfs/Commands/Init.cs
@@ -39,7 +39,6 @@ namespace GitTfs.Commands
             DoGitInitDb();
             VerifyGitUserConfig();
             SaveAuthorFileInRepository();
-            CommitTheGitIgnoreFile(_remoteOptions.GitIgnorePath);
             UseTheGitIgnoreFile(_remoteOptions.GitIgnorePath);
             GitTfsInit(tfsUrl, tfsRepositoryPath);
             return 0;
@@ -61,16 +60,6 @@ namespace GitTfs.Commands
         }
 
         private void SaveAuthorFileInRepository() => _authorsFileHelper.SaveAuthorFileInRepository(_globals.AuthorsFilePath, _globals.GitDir);
-
-        private void CommitTheGitIgnoreFile(string pathToGitIgnoreFile)
-        {
-            if (string.IsNullOrWhiteSpace(pathToGitIgnoreFile))
-            {
-                Trace.WriteLine("No .gitignore file specified to commit...");
-                return;
-            }
-            _globals.Repository.CommitGitIgnore(pathToGitIgnoreFile);
-        }
 
         private void UseTheGitIgnoreFile(string pathToGitIgnoreFile)
         {

--- a/src/GitTfs/Core/IGitRepository.cs
+++ b/src/GitTfs/Core/IGitRepository.cs
@@ -60,7 +60,7 @@ namespace GitTfs.Core
         bool Checkout(string commitish);
         IEnumerable<GitCommit> FindParentCommits(string fromCommit, string toCommit);
         bool IsPathIgnored(string relativePath);
-        string CommitGitIgnore(string pathToGitIgnoreFile);
+        string CommitGitIgnore(string pathToGitIgnoreFile, string branchName);
         void UseGitIgnore(string pathToGitIgnoreFile);
         IDictionary<int, string> GetCommitChangeSetPairs();
     }


### PR DESCRIPTION
I noticed parentless non-trunk branches don't have a gitignore commit when using the `--gitignore` parameter. Even though, files in them are ignored by GitTfs as per the specified gitignore.
Parent-less branches may appear when specifying the `--from=1234` parameter on a repo where branches created before changeset C1234 are merged somewhere later.

I made GitTfs create the gitignore commit when creating a commit that doesn't have a parent, ie when it's the first commit on a branch and the branch is not based on any other branch.

For this to work correctly, the commits with gitignore file have to differ in some way in order to get different hashes on each branch as otherwise all branches would share one gitignore commit and as such would all be related even though they should not be. I've added the branch name to the extended Git commit message to achieve this.