### PR TITLE
Fix PAT environment variable scopes priority

### DIFF
--- a/doc/release-notes/NEXT.md
+++ b/doc/release-notes/NEXT.md
@@ -2,3 +2,4 @@
 * chore: target .net v4.8 ( #1490 by @pmiossec )
 * chore: Update libgit2sharp to v0.30 ( #1492 by @pmiossec )
 * Fix handling of renamed branches for clone/fetch ( #1493 by @dh2i-sam )
+* Fix PAT environment variable scope priority ( #1520 by @bramborman )

--- a/src/GitTfs.VsCommon/TfsHelper.Vs2017Base.cs
+++ b/src/GitTfs.VsCommon/TfsHelper.Vs2017Base.cs
@@ -180,9 +180,7 @@ namespace GitTfs.VsCommon
         {
             VssCredentials vssCred = null;
 
-            string pat = Environment.GetEnvironmentVariable(gitTfsPatEnvironmentVariableName, EnvironmentVariableTarget.User)
-                ?? Environment.GetEnvironmentVariable(gitTfsPatEnvironmentVariableName, EnvironmentVariableTarget.Machine)
-                ?? Environment.GetEnvironmentVariable(gitTfsPatEnvironmentVariableName, EnvironmentVariableTarget.Process);
+            var pat = Environment.GetEnvironmentVariable(gitTfsPatEnvironmentVariableName);
 
             if (!string.IsNullOrWhiteSpace(pat))
             {


### PR DESCRIPTION
The current priority of environment variable scopes (targets) for PAT auth isn't what I believe anyone would expect.
It should imho be Process > User > System instead of current User > System > Process. This should also be the default when using the `GetEnvironmentVariable` method without a target (scope) as per [the docs](https://learn.microsoft.com/en-us/dotnet/fundamentals/runtime-libraries/system-environment-getenvironmentvariable#on-windows-systems).