### PR TITLE
exportmap: Add option to list commitids of all touched branches

### DIFF
--- a/doc/commands/exportmap.md
+++ b/doc/commands/exportmap.md
@@ -8,6 +8,7 @@ The exportmap command creates a mapping file of Tfs ChangeSet Id and Commit Id f
     where options are:
     
         -f=VALUE 	The path to the mapping file
+        -m, --include-multiple-branches 	Outputs the commitid for each branch the changeset touches
 								
 ## Examples
 

--- a/src/GitTfs/Commands/ExportMap.cs
+++ b/src/GitTfs/Commands/ExportMap.cs
@@ -23,11 +23,14 @@ namespace GitTfs.Commands
         }
 
         public string FilePath { get; set; }
+        public bool WithChangesetsOnMultipleBranches { get; set; } = false;
 
         public OptionSet OptionSet => new OptionSet
                 {
                      { "f|file=", "The output file path",
-                        f => FilePath = f }
+                        f => FilePath = f },
+                     { "m|include-multiple-branches", "Outputs the commitid for each branch the changeset touches",
+                        v => WithChangesetsOnMultipleBranches = (v != null) }
                 };
 
         public int Run()
@@ -37,8 +40,8 @@ namespace GitTfs.Commands
                 return _helper.Run(this);
             }
 
-            var commits = _globals.Repository.GetCommitChangeSetPairs();
-            File.WriteAllLines(FilePath, commits.Select(map => $"{map.Key}-{map.Value}"));
+            var commits = _globals.Repository.GetCommitChangeSetPairs(WithChangesetsOnMultipleBranches);
+            File.WriteAllLines(FilePath, commits.Select(map => $"{map.Key}-{string.Join(" ", map.Value)}"));
 
             return 0;
         }

--- a/src/GitTfs/Core/IGitRepository.cs
+++ b/src/GitTfs/Core/IGitRepository.cs
@@ -62,6 +62,6 @@ namespace GitTfs.Core
         bool IsPathIgnored(string relativePath);
         string CommitGitIgnore(string pathToGitIgnoreFile);
         void UseGitIgnore(string pathToGitIgnoreFile);
-        IDictionary<int, string> GetCommitChangeSetPairs();
+        IDictionary<int, List<string>> GetCommitChangeSetPairs(bool withChangesetsOnMultipleBranches);
     }
 }


### PR DESCRIPTION
In TFS a changeset can touch more than one branch. In git there is a commit for each branch created.
Add an option to list all commitids for a changeset instead of printing a warning.
Do not change the previous functionality to be backwards compatible.