### PR TITLE
Lookup commit id with changeset id and branch name

### DIFF
--- a/src/GitTfs.VsCommon/TfsHelper.Common.cs
+++ b/src/GitTfs.VsCommon/TfsHelper.Common.cs
@@ -317,7 +317,7 @@ namespace GitTfs.VsCommon
                 var rootChangesetInChildBranch = rootChangesetMergeInfo.SourceChangeset == rootChangesetInParentBranch ?
                     rootChangesetMergeInfo.TargetChangeset : rootChangesetMergeInfo.SourceChangeset;
 
-                var rootBranch = new RootBranch(rootChangesetInParentBranch, rootChangesetInChildBranch, tfsPathBranchToCreate);
+                var rootBranch = new RootBranch(rootChangesetInParentBranch, tfsPathParentBranch, rootChangesetInChildBranch, tfsPathBranchToCreate);
                 var added = AddNewRootBranch(rootBranches, rootBranch);
 
                 if (added && renameFromBranch != null)

--- a/src/GitTfs.VsFake/TfsHelper.VsFake.cs
+++ b/src/GitTfs.VsFake/TfsHelper.VsFake.cs
@@ -292,6 +292,7 @@ namespace GitTfs.VsFake
                 {
                     var rootBranch = new RootBranch(
                         firstBranchChangeset.BranchChangesetDatas.RootChangesetId,
+                        firstBranchChangeset.BranchChangesetDatas.ParentBranch,
                         firstBranchChangeset.Id,
                         firstBranchChangeset.BranchChangesetDatas.BranchPath
                     );
@@ -304,7 +305,7 @@ namespace GitTfs.VsFake
                 rootBranches.Reverse();
                 return rootBranches;
             }
-            rootBranches.Add(new RootBranch(-1, tfsPathBranchToCreate));
+            rootBranches.Add(new RootBranch(-1, null, tfsPathBranchToCreate));
             return rootBranches;
         }
 

--- a/src/GitTfs/Commands/Checkout.cs
+++ b/src/GitTfs/Commands/Checkout.cs
@@ -33,7 +33,7 @@ namespace GitTfs.Commands
             int changesetId;
             if (!int.TryParse(id, out changesetId))
                 throw new GitTfsException("error: wrong format for changeset id...");
-            var sha = _globals.Repository.FindCommitHashByChangesetId(changesetId);
+            var sha = _globals.Repository.FindCommitHashByChangesetId(string.Empty, changesetId).SingleOrDefault();
             if (string.IsNullOrEmpty(sha))
                 throw new GitTfsException("error: commit not found for this changeset id...");
             if (ReturnShaOnly)

--- a/src/GitTfs/Commands/InitBranch.cs
+++ b/src/GitTfs/Commands/InitBranch.cs
@@ -108,12 +108,12 @@ namespace GitTfs.Commands
             foreach (var rootBranch in creationBranchData)
             {
                 Trace.WriteLine("Processing " + (rootBranch.IsRenamedBranch ? "renamed " : string.Empty) + "branch :"
-                    + rootBranch.TfsBranchPath + " (" + rootBranch.SourceBranchChangesetId + ")");
-                var cbd = new BranchCreationDatas() { RootChangesetId = rootBranch.SourceBranchChangesetId, TfsRepositoryPath = rootBranch.TfsBranchPath };
+                    + rootBranch.TfsBranchPath + " (" + rootBranch.SourceBranchChangesetId + "@" + rootBranch.TfsSourceBranchPath + ")");
+                var cbd = new BranchCreationDatas() { RootChangesetId = rootBranch.SourceBranchChangesetId, TfsRepositoryPath = rootBranch.TfsBranchPath, RootTfsBranch = rootBranch.TfsSourceBranchPath };
                 if (cbd.TfsRepositoryPath == tfsBranchPath)
                     cbd.GitBranchNameExpected = gitBranchNameExpected;
 
-                branchTfsRemote = defaultRemote.InitBranch(_remoteOptions, cbd.TfsRepositoryPath, cbd.RootChangesetId, !NoFetch, cbd.GitBranchNameExpected, fetchResult);
+                branchTfsRemote = defaultRemote.InitBranch(_remoteOptions, cbd.TfsRepositoryPath, cbd.RootChangesetId, !NoFetch, cbd.RootTfsBranch, cbd.GitBranchNameExpected, fetchResult);
                 if (branchTfsRemote == null)
                 {
                     throw new GitTfsException("error: Couldn't fetch parent branch\n");
@@ -146,7 +146,7 @@ namespace GitTfs.Commands
             for (int i = creationBranchData.Count - 1; i > 0; i--)
             {
                 var branch = creationBranchData[i];
-                if (defaultRemote.Repository.FindCommitHashByChangesetId(branch.SourceBranchChangesetId) != null)
+                if (defaultRemote.Repository.FindCommitHashByChangesetId(branch.TfsSourceBranchPath, branch.SourceBranchChangesetId) != null)
                 {
                     for (int j = 0; j < i; j++)
                     {
@@ -162,6 +162,7 @@ namespace GitTfs.Commands
             public string TfsRepositoryPath { get; set; }
             public string GitBranchNameExpected { get; set; }
             public int RootChangesetId { get; set; }
+            public string RootTfsBranch { get; set; }
         }
 
         [DebuggerDisplay("{TfsRepositoryPath} C{RootChangesetId}")]

--- a/src/GitTfs/Commands/Labels.cs
+++ b/src/GitTfs/Commands/Labels.cs
@@ -87,7 +87,7 @@ namespace GitTfs.Commands
 
                 Trace.WriteLine("LabelId:" + label.Id + "/ChangesetId:" + label.ChangesetId + "/LabelName:" + label.Name + "/Owner:" + label.Owner);
                 Trace.WriteLine("Try to find changeset in git repository...");
-                string sha1TagCommit = _globals.Repository.FindCommitHashByChangesetId(label.ChangesetId);
+                string sha1TagCommit = _globals.Repository.FindCommitHashByChangesetId(string.Empty, label.ChangesetId).SingleOrDefault();
                 if (string.IsNullOrWhiteSpace(sha1TagCommit))
                 {
                     Trace.WriteLine("This label does not match an existing commit...");

--- a/src/GitTfs/Commands/Rcheckin.cs
+++ b/src/GitTfs/Commands/Rcheckin.cs
@@ -130,7 +130,7 @@ namespace GitTfs.Commands
                     var fetchResult = tfsRemote.FetchWithMerge(newChangesetId, false, parents.Select(c => c.Sha).ToArray());
                     if (fetchResult.NewChangesetCount != 1)
                     {
-                        var lastCommit = _globals.Repository.FindCommitHashByChangesetId(newChangesetId);
+                        var lastCommit = _globals.Repository.FindCommitHashByChangesetId(string.Empty, newChangesetId).SingleOrDefault();
                         RebaseOnto(lastCommit, target);
                         if (AutoRebase)
                             tfsRemote.Repository.CommandNoisy("rebase", "--rebase-merges", tfsRemote.RemoteRef);
@@ -146,7 +146,7 @@ namespace GitTfs.Commands
                 {
                     if (newChangesetId != 0)
                     {
-                        var lastCommit = _globals.Repository.FindCommitHashByChangesetId(newChangesetId);
+                        var lastCommit = _globals.Repository.FindCommitHashByChangesetId(string.Empty, newChangesetId).SingleOrDefault();
                         RebaseOnto(lastCommit, currentParent);
                     }
                     throw;

--- a/src/GitTfs/Core/DerivedGitTfsRemote.cs
+++ b/src/GitTfs/Core/DerivedGitTfsRemote.cs
@@ -128,7 +128,7 @@ namespace GitTfs.Core
 
         public bool IsInDotGit(string path) => throw DerivedRemoteException;
 
-        public IGitTfsRemote InitBranch(RemoteOptions remoteOptions, string tfsRepositoryPath, int shaRootChangesetId, bool fetchParentBranch, string gitBranchNameExpected = null, IRenameResult renameResult = null) => throw new NotImplementedException();
+        public IGitTfsRemote InitBranch(RemoteOptions remoteOptions, string tfsRepositoryPath, int rootChangesetId = -1, bool fetchParentBranch = false, string tfsRootBranchPath = null, string gitBranchNameExpected = null, IRenameResult renameResult = null) => throw new NotImplementedException();
 
         public string GetPathInGitRepo(string tfsPath) => throw DerivedRemoteException;
 

--- a/src/GitTfs/Core/GitRepository.cs
+++ b/src/GitTfs/Core/GitRepository.cs
@@ -42,7 +42,8 @@ namespace GitTfs.Core
                 logEntry.Tree,
                 parents,
                 false);
-            changesetsCache[logEntry.ChangesetId] = commit.Sha;
+            Trace.WriteLine($"New commit for changeset {logEntry.ChangesetId} (remote branch {logEntry.Remote.RemoteRef}) = {commit.Sha}");
+            changesetsCache[(logEntry.ChangesetId, logEntry.Remote.RemoteRef)] = commit.Sha;
             return new GitCommit(commit);
         }
 
@@ -334,12 +335,11 @@ namespace GitTfs.Core
             Trace.WriteLine("Commits visited count:" + alreadyVisitedCommits.Count);
         }
 
-        public TfsChangesetInfo GetTfsChangesetById(string remoteRef, int changesetId)
+        public IReadOnlyList<TfsChangesetInfo> GetTfsChangesetById(string remoteRef, int changesetId)
         {
-            var commit = FindCommitByChangesetId(changesetId, remoteRef);
-            if (commit == null)
-                return null;
-            return TryParseChangesetInfo(commit.Message, commit.Sha);
+            IReadOnlyList<Commit> commitList = FindCommitByChangesetId(changesetId, remoteRef);
+
+            return commitList.Select(x => TryParseChangesetInfo(x.Message, x.Sha)).ToList();
         }
 
         public TfsChangesetInfo GetCurrentTfsCommit()
@@ -519,16 +519,14 @@ namespace GitTfs.Core
             return reference != null;
         }
 
-        private readonly Dictionary<int, string> changesetsCache = new Dictionary<int, string>();
+        private readonly Dictionary<(int changeset, string branch), string> changesetsCache = new Dictionary<(int changeset, string branch), string>();
         private bool cacheIsFull = false;
 
-        public string FindCommitHashByChangesetId(int changesetId)
+        public IReadOnlyList<string> FindCommitHashByChangesetId(string remoteRef, int changesetId)
         {
-            var commit = FindCommitByChangesetId(changesetId);
-            if (commit == null)
-                return null;
+            IReadOnlyList<Commit> commitList = FindCommitByChangesetId(changesetId, remoteRef);
 
-            return commit.Sha;
+            return commitList.Select(x => x.Sha).ToList();
         }
 
         private static readonly Regex tfsIdRegex = new Regex("^git-tfs-id: .*;C([0-9]+)\r?$", RegexOptions.Multiline | RegexOptions.Compiled | RegexOptions.RightToLeft);
@@ -546,76 +544,95 @@ namespace GitTfs.Core
             return false;
         }
 
-        private Commit FindCommitByChangesetId(int changesetId, string remoteRef = null)
+        private IReadOnlyList<Commit> FindCommitByChangesetId(int changesetId, string remoteRef)
         {
-            Trace.WriteLine("Looking for changeset " + changesetId + " in git repository...");
+            Trace.WriteLine($"Looking for changeset {changesetId} (remote branch {remoteRef}) in git repository...");
 
             if (remoteRef == null)
             {
-                string sha;
-                if (changesetsCache.TryGetValue(changesetId, out sha))
-                {
-                    Trace.WriteLine("Changeset " + changesetId + " found at " + sha);
-                    return _repository.Lookup<Commit>(sha);
-                }
-                if (cacheIsFull)
-                {
-                    Trace.WriteLine("Looking for changeset " + changesetId + " in git repository: CacheIsFull, stopped looking.");
-                    return null;
-                }
+                throw new ArgumentNullException(nameof(remoteRef));
+                //string sha;
+                //if (changesetsCache.TryGetValue(changesetId, out sha))
+                //{
+                //    Trace.WriteLine("Changeset " + changesetId + " found at " + sha);
+                //    return new List<Commit>() { _repository.Lookup<Commit>(sha) };
+                //}
+                //if (cacheIsFull)
+                //{
+                //    Trace.WriteLine("Looking for changeset " + changesetId + " in git repository: CacheIsFull, stopped looking.");
+                //    return null;
+                //}
+            }
+            if (changesetsCache.TryGetValue((changesetId, remoteRef), out string sha))
+            {
+                Trace.WriteLine($"Changeset {changesetId} (remote branch {remoteRef}) found at {sha} (Cache hit)");
+                return new List<Commit>() { _repository.Lookup<Commit>(sha) };
             }
 
-            var reachableFromRemoteBranches = new CommitFilter
+            IEnumerable<Branch> query = _repository.Branches.Where(p => p.IsRemote);
+            if (!string.IsNullOrEmpty(remoteRef))
             {
-                IncludeReachableFrom = _repository.Branches.Where(p => p.IsRemote),
-                SortBy = CommitSortStrategies.Time
-            };
-
-            if (remoteRef != null)
-            {
-                var query = _repository.Branches.Where(p => p.IsRemote && p.CanonicalName.EndsWith(remoteRef));
+                query = _repository.Branches.Where(p => p.IsRemote && p.CanonicalName.EndsWith(remoteRef));
                 Trace.WriteLine("Looking for changeset " + changesetId + " in git repository: Adding remotes:");
                 foreach (var reachable in query)
                 {
-                    Trace.WriteLine(reachable.CanonicalName + "reachable from " + remoteRef);
+                    Trace.WriteLine(reachable.CanonicalName + " reachable from " + remoteRef);
                 }
-                reachableFromRemoteBranches.IncludeReachableFrom = query;
             }
-            var commitsFromRemoteBranches = _repository.Commits.QueryBy(reachableFromRemoteBranches);
-
-            Commit commit = null;
-            foreach (var c in commitsFromRemoteBranches)
+            List<Commit> commitList = new List<Commit>();
+            foreach (Branch branch in query)
             {
-                int id;
-                if (TryParseChangesetId(c.Message, out id))
+                var reachableFromRemoteBranches = new CommitFilter
                 {
-                    changesetsCache[id] = c.Sha;
-                    if (id == changesetId)
-                    {
-                        commit = c;
-                        break;
-                    }
-                }
-                else
+                    IncludeReachableFrom = _repository.Branches.Where(x => x.IsRemote && x.CanonicalName == branch.CanonicalName),
+                    SortBy = CommitSortStrategies.Time
+                };
+                var commitsFromRemoteBranches = _repository.Commits.QueryBy(reachableFromRemoteBranches);
+
+                foreach (var c in commitsFromRemoteBranches)
                 {
-                    foreach (var note in c.Notes)
+                    if (TryParseChangesetId(c.Message, out int id))
                     {
-                        if (TryParseChangesetId(note.Message, out id))
+                        changesetsCache[(id, remoteRef)] = c.Sha;
+                        changesetsCache[(id, branch.CanonicalName)] = c.Sha;
+                        if (id == changesetId)
                         {
-                            changesetsCache[id] = c.Sha;
-                            if (id == changesetId)
+                            commitList.Add(c);
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        foreach (var note in c.Notes)
+                        {
+                            if (TryParseChangesetId(note.Message, out id))
                             {
-                                commit = c;
-                                break;
+                                changesetsCache[(id, remoteRef)] = c.Sha;
+                                changesetsCache[(id, branch.CanonicalName)] = c.Sha;
+                                if (id == changesetId)
+                                {
+                                    commitList.Add(c);
+                                    break;
+                                }
                             }
                         }
                     }
                 }
             }
-            if (remoteRef == null && commit == null)
+            if (remoteRef == null && commitList.Count == 0)
                 cacheIsFull = true; // repository fully scanned
-            Trace.WriteLine((commit == null) ? " => Commit " + changesetId + " not found!" : " => Commit " + changesetId + " found! hash: " + commit.Sha);
-            return commit;
+            if (commitList.Count == 0)
+            {
+                Trace.WriteLine(" => Commit " + changesetId + " not found!");
+            }
+            else
+            {
+                foreach (Commit commit in commitList)
+                {
+                    Trace.WriteLine(" => Commit " + changesetId + " found! hash: " + commit.Sha);
+                }
+            }
+            return commitList;
         }
 
         public void CreateTag(string name, string sha, string comment, string Owner, string emailOwner, DateTime creationDate)

--- a/src/GitTfs/Core/GitTfsRemote.cs
+++ b/src/GitTfs/Core/GitTfsRemote.cs
@@ -163,7 +163,7 @@ namespace GitTfs.Core
             set => maxCommitHash = value;
         }
 
-        private TfsChangesetInfo GetTfsChangesetById(int id) => Repository.GetTfsChangesetById(RemoteRef, id);
+        private TfsChangesetInfo GetTfsChangesetById(int id) => Repository.GetTfsChangesetById(RemoteRef, id).SingleOrDefault();
 
         private void InitHistory()
         {
@@ -410,11 +410,12 @@ namespace GitTfs.Core
                                      " is a merge changeset. But git-tfs is unable to determine the parent changeset.");
                     return true;
                 }
-                var shaParent = Repository.FindCommitHashByChangesetId(parentChangesetId);
+                IReadOnlyList<string> shaParentList = Repository.FindCommitHashByChangesetId(changeset.Summary.Remote.RemoteRef, parentChangesetId);
+                string shaParent = shaParentList.SingleOrDefault();
                 if (shaParent == null)
                 {
                     string omittedParentBranch;
-                    shaParent = FindMergedRemoteAndFetch(parentChangesetId, stopOnFailMergeCommit, out omittedParentBranch);
+                    shaParent = FindMergedRemoteAndFetch(changeset.Summary.Remote.RemoteRef, parentChangesetId, stopOnFailMergeCommit, out omittedParentBranch);
                     changeset.OmittedParentBranch = omittedParentBranch;
                 }
                 if (shaParent != null)
@@ -544,15 +545,16 @@ namespace GitTfs.Core
             return workItemsTranslated;
         }
 
-        private string FindRootRemoteAndFetch(int parentChangesetId, IRenameResult renameResult = null)
+        private string FindRootRemoteAndFetch(string remoteRef, int parentChangesetId, IRenameResult renameResult = null)
         {
             string omittedParentBranch;
-            return FindRemoteAndFetch(parentChangesetId, false, false, renameResult, out omittedParentBranch);
+            return FindRemoteAndFetch(remoteRef, parentChangesetId, false, false, renameResult, out omittedParentBranch);
         }
 
-        private string FindMergedRemoteAndFetch(int parentChangesetId, bool stopOnFailMergeCommit, out string omittedParentBranch) => FindRemoteAndFetch(parentChangesetId, false, true, null, out omittedParentBranch);
+        private string FindMergedRemoteAndFetch(string remoteRef, int parentChangesetId, bool stopOnFailMergeCommit, out string omittedParentBranch)
+            => FindRemoteAndFetch(remoteRef, parentChangesetId, false, true, null, out omittedParentBranch);
 
-        private string FindRemoteAndFetch(int parentChangesetId, bool stopOnFailMergeCommit, bool mergeChangeset, IRenameResult renameResult, out string omittedParentBranch)
+        private string FindRemoteAndFetch(string remoteRef, int parentChangesetId, bool stopOnFailMergeCommit, bool mergeChangeset, IRenameResult renameResult, out string omittedParentBranch)
         {
             var tfsRemote = FindOrInitTfsRemoteOfChangeset(parentChangesetId, mergeChangeset, renameResult, out omittedParentBranch);
 
@@ -571,7 +573,7 @@ namespace GitTfs.Core
                     if (tfsRemote.Repository.IsBare)
                         tfsRemote.Repository.UpdateRef(GitRepository.ShortToLocalName(tfsRemote.Id), tfsRemote.MaxCommitHash);
                 }
-                return Repository.FindCommitHashByChangesetId(parentChangesetId);
+                return Repository.FindCommitHashByChangesetId(tfsRemote.RemoteRef, parentChangesetId).SingleOrDefault();
             }
             return null;
         }
@@ -651,7 +653,7 @@ namespace GitTfs.Core
             foreach (var branch in branchesDatas)
             {
                 var rootChangesetId = branch.SourceBranchChangesetId;
-                remote = InitBranch(_remoteOptions, branch.TfsBranchPath, rootChangesetId, fetchParentBranch: isFirstBranchChangeset, renameResult: renameResult);
+                remote = InitBranch(_remoteOptions, branch.TfsBranchPath, rootChangesetId, tfsRootBranchPath: branch.TfsSourceBranchPath, fetchParentBranch: isFirstBranchChangeset, renameResult: renameResult);
                 isFirstBranchChangeset = false;
                 if (remote == null)
                 {
@@ -953,7 +955,9 @@ namespace GitTfs.Core
             return gitBranchName;
         }
 
-        public IGitTfsRemote InitBranch(RemoteOptions remoteOptions, string tfsRepositoryPath, int rootChangesetId, bool fetchParentBranch, string gitBranchNameExpected = null, IRenameResult renameResult = null) => InitTfsBranch(remoteOptions, tfsRepositoryPath, rootChangesetId, fetchParentBranch, gitBranchNameExpected, renameResult);
+        public IGitTfsRemote InitBranch(RemoteOptions remoteOptions, string tfsRepositoryPath, int rootChangesetId, bool fetchParentBranch, string tfsRootBranchPath = null,
+            string gitBranchNameExpected = null, IRenameResult renameResult = null)
+            => InitTfsBranch(remoteOptions, tfsRepositoryPath, rootChangesetId, tfsRootBranchPath, fetchParentBranch, gitBranchNameExpected, renameResult);
 
         private bool IgnoreException(string message, bool ignoreRestricted, bool printHint = true)
         {
@@ -969,11 +973,14 @@ namespace GitTfs.Core
             return false;
         }
 
-        private IGitTfsRemote InitTfsBranch(RemoteOptions remoteOptions, string tfsRepositoryPath, int rootChangesetId = -1, bool fetchParentBranch = false, string gitBranchNameExpected = null, IRenameResult renameResult = null, bool ignoreRestricted = false)
+        private IGitTfsRemote InitTfsBranch(RemoteOptions remoteOptions, string tfsRepositoryPath, int rootChangesetId = -1,
+            string tfsRootBranchPath = null, bool fetchParentBranch = false, string gitBranchNameExpected = null, IRenameResult renameResult = null,
+            bool ignoreRestricted = false)
         {
-            Trace.WriteLine("Begin process of creating branch for remote :" + tfsRepositoryPath);
+            Trace.WriteLine("Begin process of creating branch for remote :" + tfsRepositoryPath + "; root branch:" + tfsRootBranchPath);
             // TFS string representations of repository paths do not end in trailing slashes
             tfsRepositoryPath = (tfsRepositoryPath ?? string.Empty).TrimEnd('/');
+            tfsRootBranchPath = (tfsRootBranchPath ?? string.Empty).TrimEnd('/');
 
             string gitBranchName = ExtractGitBranchNameFromTfsRepositoryPath(
                 string.IsNullOrWhiteSpace(gitBranchNameExpected) ? tfsRepositoryPath : gitBranchNameExpected);
@@ -984,14 +991,21 @@ namespace GitTfs.Core
             string sha1RootCommit = null;
             if (rootChangesetId != -1)
             {
+                string branchToLookAt = (!string.IsNullOrEmpty(tfsRootBranchPath)) ? tfsRootBranchPath : tfsRepositoryPath;
+                var allRemotes = _globals.Repository.ReadAllTfsRemotes();
+                var remote = allRemotes.FirstOrDefault(r => r.TfsRepositoryPath.ToLower() == branchToLookAt.ToLower());
+                if (remote != null)
+                {
+                    branchToLookAt = remote.RemoteRef;
+                }
                 sha1RootCommit = renameResult != null && renameResult.IsProcessingRenameChangeset
                     ? renameResult.LastParentCommitBeforeRename
-                    : Repository.FindCommitHashByChangesetId(rootChangesetId);
+                    : Repository.FindCommitHashByChangesetId(branchToLookAt, rootChangesetId).SingleOrDefault();
                 if (fetchParentBranch && string.IsNullOrWhiteSpace(sha1RootCommit))
                 {
                     try
                     {
-                        sha1RootCommit = FindRootRemoteAndFetch(rootChangesetId, renameResult);
+                        sha1RootCommit = FindRootRemoteAndFetch(branchToLookAt, rootChangesetId, renameResult);
                     }
                     catch (Exception ex)
                     {

--- a/src/GitTfs/Core/IGitRepository.cs
+++ b/src/GitTfs/Core/IGitRepository.cs
@@ -25,7 +25,7 @@ namespace GitTfs.Core
         void MoveTfsRefForwardIfNeeded(IGitTfsRemote remote);
         void MoveTfsRefForwardIfNeeded(IGitTfsRemote remote, string @ref);
         IEnumerable<TfsChangesetInfo> GetLastParentTfsCommits(string head);
-        TfsChangesetInfo GetTfsChangesetById(string remoteRef, int changesetId);
+        IReadOnlyList<TfsChangesetInfo> GetTfsChangesetById(string remoteRef, int changesetId);
         TfsChangesetInfo GetTfsCommit(GitCommit commit);
         TfsChangesetInfo GetTfsCommit(string sha);
         TfsChangesetInfo GetCurrentTfsCommit();
@@ -43,7 +43,7 @@ namespace GitTfs.Core
         string AssertValidBranchName(string gitBranchName);
         bool CreateBranch(string gitBranchName, string target);
         Branch RenameBranch(string oldName, string newName);
-        string FindCommitHashByChangesetId(int changesetId);
+        IReadOnlyList<string> FindCommitHashByChangesetId(string remoteRef, int changesetId);
         void CreateTag(string name, string sha, string comment, string Owner, string emailOwner, DateTime creationDate);
         void CreateNote(string sha, string content, string owner, string emailOwner, DateTime creationDate);
         void MoveRemote(string oldRemoteName, string newRemoteName);

--- a/src/GitTfs/Core/IGitTfsRemote.cs
+++ b/src/GitTfs/Core/IGitTfsRemote.cs
@@ -57,7 +57,8 @@ namespace GitTfs.Core
         bool ShouldSkip(string path);
         bool IsIgnored(string path);
         bool IsInDotGit(string path);
-        IGitTfsRemote InitBranch(RemoteOptions remoteOptions, string tfsRepositoryPath, int rootChangesetId = -1, bool fetchParentBranch = false, string gitBranchNameExpected = null, IRenameResult renameResult = null);
+        IGitTfsRemote InitBranch(RemoteOptions remoteOptions, string tfsRepositoryPath, int rootChangesetId = -1, bool fetchParentBranch = false, string tfsRootBranchPath = null,
+            string gitBranchNameExpected = null, IRenameResult renameResult = null);
         string GetPathInGitRepo(string tfsPath);
         IFetchResult Fetch(bool stopOnFailMergeCommit = false, int lastChangesetIdToFetch = -1, IRenameResult renameResult = null);
         IFetchResult FetchWithMerge(int mergeChangesetId, bool stopOnFailMergeCommit = false, IRenameResult renameResult = null, params string[] parentCommitsHashes);

--- a/src/GitTfs/Core/TfsInterop/RootBranch.cs
+++ b/src/GitTfs/Core/TfsInterop/RootBranch.cs
@@ -5,28 +5,31 @@ namespace GitTfs.Core.TfsInterop
     [DebuggerDisplay("{DebuggerDisplay}")]
     public class RootBranch
     {
-        public RootBranch(int sourceBranchChangesetId, string tfsBranchPath)
-            : this(sourceBranchChangesetId, -1, tfsBranchPath)
+        public RootBranch(int sourceBranchChangesetId, string tfsSourceBranchPath, string tfsBranchPath)
+            : this(sourceBranchChangesetId, tfsSourceBranchPath, -1, tfsBranchPath)
         {
         }
 
-        public RootBranch(int sourceBranchChangesetId, int targetBranchChangesetId, string tfsBranchPath)
+        public RootBranch(int sourceBranchChangesetId, string tfsSourceBranchPath, int targetBranchChangesetId, string tfsBranchPath)
         {
             SourceBranchChangesetId = sourceBranchChangesetId;
             TargetBranchChangesetId = targetBranchChangesetId;
+            TfsSourceBranchPath = tfsSourceBranchPath;
             TfsBranchPath = tfsBranchPath;
         }
 
         public int SourceBranchChangesetId { get; }
         public int TargetBranchChangesetId { get; }
+        public string TfsSourceBranchPath { get; }
         public string TfsBranchPath { get; }
         public bool IsRenamedBranch { get; set; }
 
-        private string DebuggerDisplay => string.Format("{0} C{1}{2}{3}",
+        private string DebuggerDisplay => string.Format("{0} C{1}{2}{3}{4}",
                     /* {0} */ TfsBranchPath,
                     /* {1} */ SourceBranchChangesetId,
                     /* {2} */ TargetBranchChangesetId > -1 ? $" (target C{TargetBranchChangesetId})" : string.Empty,
-                    /* {3} */ IsRenamedBranch ? " renamed" : ""
+                    /* {3} */ IsRenamedBranch ? " renamed" : "",
+                    /* {4} */ "Source " + TfsSourceBranchPath
                 );
     }
 }

--- a/src/GitTfsTest/Commands/InitBranchTest.cs
+++ b/src/GitTfsTest/Commands/InitBranchTest.cs
@@ -67,10 +67,10 @@ namespace GitTfs.Test.Commands
 
             InitMocks4Tests(GIT_BRANCH_TO_INIT, out var gitRepositoryMock, out var trunkGitTfsRemoteMock, out var newBranchRemoteMock, out var tfsHelperMock);
 
-            tfsHelperMock.Setup(t => t.GetRootChangesetForBranch("$/MyProject/MyBranch", -1, null)).Returns(new List<RootBranch>() { new RootBranch(2010, "$/MyProject/MyBranch") });
+            tfsHelperMock.Setup(t => t.GetRootChangesetForBranch("$/MyProject/MyBranch", -1, null)).Returns(new List<RootBranch>() { new RootBranch(2010, string.Empty, "$/MyProject/MyBranch") });
 
             trunkGitTfsRemoteMock.Name = nameof(trunkGitTfsRemoteMock);
-            trunkGitTfsRemoteMock.Setup(t => t.InitBranch(It.IsAny<RemoteOptions>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<IRenameResult>())).Returns(newBranchRemoteMock.Object).Verifiable();
+            trunkGitTfsRemoteMock.Setup(t => t.InitBranch(It.IsAny<RemoteOptions>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IRenameResult>())).Returns(newBranchRemoteMock.Object).Verifiable();
             trunkGitTfsRemoteMock.SetupGet(x => x.Tfs).Returns(tfsHelperMock.Object);
 
             gitRepositoryMock.Name = nameof(gitRepositoryMock);
@@ -100,9 +100,9 @@ namespace GitTfs.Test.Commands
 
             trunkGitTfsRemoteMock.Name = nameof(trunkGitTfsRemoteMock);
             trunkGitTfsRemoteMock.Setup(r => r.Fetch(It.IsAny<bool>(), It.IsAny<int>(), It.IsAny<IRenameResult>())).Returns(new GitTfsRemote.FetchResult() { IsSuccess = true });
-            trunkGitTfsRemoteMock.Setup(t => t.InitBranch(It.IsAny<RemoteOptions>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<IRenameResult>())).Returns(newBranchRemoteMock.Object);
+            trunkGitTfsRemoteMock.Setup(t => t.InitBranch(It.IsAny<RemoteOptions>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IRenameResult>())).Returns(newBranchRemoteMock.Object);
 
-            tfsHelperMock.Setup(t => t.GetRootChangesetForBranch("$/MyProject/MyBranch", -1, null)).Returns(new List<RootBranch>() { new RootBranch(2010, "$/MyProject/MyBranch") });
+            tfsHelperMock.Setup(t => t.GetRootChangesetForBranch("$/MyProject/MyBranch", -1, null)).Returns(new List<RootBranch>() { new RootBranch(2010, string.Empty, "$/MyProject/MyBranch") });
 
             TfsHelper tfsHelper = new TfsHelper(mocks.Container, null);
             Mock<IGitTfsRemote> gitTfsRemoteMock = new Mock<IGitTfsRemote>().SetupAllProperties();
@@ -153,7 +153,7 @@ namespace GitTfs.Test.Commands
 
             InitMocks4Tests(GIT_BRANCH_TO_INIT, out var gitRepository, out var remote, out var newBranchRemote, out var tfsHelperMock);
 
-            tfsHelperMock.Setup(t => t.GetRootChangesetForBranch("$/MyProject/MyBranch", -1, null)).Returns(new List<RootBranch>() { new RootBranch(2010, "$/MyProject/MyBranch") });
+            tfsHelperMock.Setup(t => t.GetRootChangesetForBranch("$/MyProject/MyBranch", -1, null)).Returns(new List<RootBranch>() { new RootBranch(2010, string.Empty, "$/MyProject/MyBranch") });
 
             gitRepository.Setup(x => x.ReadTfsRemote("default")).Returns(remote.Object).Verifiable();
             gitRepository.Setup(x => x.ReadAllTfsRemotes()).Returns(new List<IGitTfsRemote> { remote.Object }).Verifiable();
@@ -194,7 +194,7 @@ namespace GitTfs.Test.Commands
 
             #region Branch1
             var rootChangeSetB1 = 1000;
-            tfsHelperMock.Setup(t => t.GetRootChangesetForBranch(tfsPathBranch1, -1, null)).Returns(new List<RootBranch>() { new RootBranch(rootChangeSetB1, tfsPathBranch1) });
+            tfsHelperMock.Setup(t => t.GetRootChangesetForBranch(tfsPathBranch1, -1, null)).Returns(new List<RootBranch>() { new RootBranch(rootChangeSetB1, string.Empty, tfsPathBranch1) });
 
             newBranch1RemoteMock.Name = nameof(newBranch1RemoteMock);
             newBranch1RemoteMock.Setup(r => r.RemoteRef).Returns("refs/remote/tfs/" + GIT_BRANCH_TO_INIT1);//.Verifiable();
@@ -208,7 +208,7 @@ namespace GitTfs.Test.Commands
             newBranch2RemoteMock.SetupGet(r => r.Id).Returns(GIT_BRANCH_TO_INIT2);
 
             var rootChangeSetB2 = 2000;
-            tfsHelperMock.Setup(t => t.GetRootChangesetForBranch(tfsPathBranch2, -1, null)).Returns(new List<RootBranch>() { new RootBranch(rootChangeSetB2, tfsPathBranch2) });
+            tfsHelperMock.Setup(t => t.GetRootChangesetForBranch(tfsPathBranch2, -1, null)).Returns(new List<RootBranch>() { new RootBranch(rootChangeSetB2, string.Empty, tfsPathBranch2) });
 
             newBranch2RemoteMock.Name = nameof(newBranch2RemoteMock);
             newBranch2RemoteMock.Setup(r => r.RemoteRef).Returns("refs/remote/tfs/" + GIT_BRANCH_TO_INIT2);//.Verifiable();
@@ -217,8 +217,8 @@ namespace GitTfs.Test.Commands
             #endregion
 
             trunkGitTfsRemote.Setup(r => r.Fetch(It.IsAny<bool>(), It.IsAny<int>(), It.IsAny<IRenameResult>())).Returns(new GitTfsRemote.FetchResult() { IsSuccess = true }).Verifiable();
-            trunkGitTfsRemote.Setup(t => t.InitBranch(It.IsAny<RemoteOptions>(), tfsPathBranch1, It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<IRenameResult>())).Returns(newBranch1RemoteMock.Object);
-            trunkGitTfsRemote.Setup(t => t.InitBranch(It.IsAny<RemoteOptions>(), tfsPathBranch2, It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<IRenameResult>())).Returns(newBranch2RemoteMock.Object);
+            trunkGitTfsRemote.Setup(t => t.InitBranch(It.IsAny<RemoteOptions>(), tfsPathBranch1, It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IRenameResult>())).Returns(newBranch1RemoteMock.Object);
+            trunkGitTfsRemote.Setup(t => t.InitBranch(It.IsAny<RemoteOptions>(), tfsPathBranch2, It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IRenameResult>())).Returns(newBranch2RemoteMock.Object);
             trunkGitTfsRemote.Object.MaxChangesetId = 2000; //Simulate fetch already done
             Assert.Equal(GitTfsExitCodes.OK, mocks.ClassUnderTest.Run());
 
@@ -254,7 +254,7 @@ namespace GitTfs.Test.Commands
 
             #region Branch1
             var rootChangeSetB1 = 1000;
-            tfsHelperMock.Setup(t => t.GetRootChangesetForBranch(tfsPathBranch1, -1, null)).Returns(new List<RootBranch>() { new RootBranch(rootChangeSetB1, tfsPathBranch1) });
+            tfsHelperMock.Setup(t => t.GetRootChangesetForBranch(tfsPathBranch1, -1, null)).Returns(new List<RootBranch>() { new RootBranch(rootChangeSetB1, string.Empty, tfsPathBranch1) });
 
             newBranch1RemoteMock.Name = nameof(newBranch1RemoteMock);
             newBranch1RemoteMock.Setup(r => r.RemoteRef).Returns("refs/remote/tfs/" + GIT_BRANCH_TO_INIT1);//.Verifiable();
@@ -267,7 +267,7 @@ namespace GitTfs.Test.Commands
             newBranch2RemoteMock.SetupGet(r => r.Id).Returns(GIT_BRANCH_TO_INIT2);
 
             var rootChangeSetB2 = 2000;
-            tfsHelperMock.Setup(t => t.GetRootChangesetForBranch(tfsPathBranch2, -1, null)).Returns(new List<RootBranch>() { new RootBranch(rootChangeSetB2, tfsPathBranch2) });
+            tfsHelperMock.Setup(t => t.GetRootChangesetForBranch(tfsPathBranch2, -1, null)).Returns(new List<RootBranch>() { new RootBranch(rootChangeSetB2, string.Empty, tfsPathBranch2) });
 
             newBranch2RemoteMock.Name = nameof(newBranch2RemoteMock);
             newBranch2RemoteMock.Setup(r => r.RemoteRef).Returns("refs/remote/tfs/" + GIT_BRANCH_TO_INIT2);//.Verifiable();
@@ -277,8 +277,8 @@ namespace GitTfs.Test.Commands
 
 
             trunkGitTfsRemote.Setup(r => r.Fetch(It.IsAny<bool>(), It.IsAny<int>(), It.IsAny<IRenameResult>())).Returns(new GitTfsRemote.FetchResult() { IsSuccess = true }).Verifiable();
-            trunkGitTfsRemote.Setup(t => t.InitBranch(It.IsAny<RemoteOptions>(), tfsPathBranch1, It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<IRenameResult>())).Returns(newBranch1RemoteMock.Object);
-            trunkGitTfsRemote.Setup(t => t.InitBranch(It.IsAny<RemoteOptions>(), tfsPathBranch2, It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<IRenameResult>())).Returns(newBranch2RemoteMock.Object);
+            trunkGitTfsRemote.Setup(t => t.InitBranch(It.IsAny<RemoteOptions>(), tfsPathBranch1, It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IRenameResult>())).Returns(newBranch1RemoteMock.Object);
+            trunkGitTfsRemote.Setup(t => t.InitBranch(It.IsAny<RemoteOptions>(), tfsPathBranch2, It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IRenameResult>())).Returns(newBranch2RemoteMock.Object);
             trunkGitTfsRemote.Object.MaxChangesetId = 2000; //Simulate fetch already done
             Assert.Equal(GitTfsExitCodes.OK, mocks.ClassUnderTest.Run());
 
@@ -321,7 +321,7 @@ namespace GitTfs.Test.Commands
 
             #region Branch1
             var rootChangeSetB1 = 1000;
-            tfsHelperMock.Setup(t => t.GetRootChangesetForBranch(tfsPathBranch1, -1, null)).Returns(new List<RootBranch>() { new RootBranch(rootChangeSetB1, tfsPathBranch1) });
+            tfsHelperMock.Setup(t => t.GetRootChangesetForBranch(tfsPathBranch1, -1, null)).Returns(new List<RootBranch>() { new RootBranch(rootChangeSetB1, string.Empty, tfsPathBranch1) });
 
             #endregion
 
@@ -330,7 +330,7 @@ namespace GitTfs.Test.Commands
             newBranch2RemoteMock.SetupGet(r => r.Id).Returns(GIT_BRANCH_TO_INIT2);
 
             var rootChangeSetB2 = 2000;
-            tfsHelperMock.Setup(t => t.GetRootChangesetForBranch(tfsPathBranch2, -1, null)).Returns(new List<RootBranch>() { new RootBranch(rootChangeSetB2, tfsPathBranch2) });
+            tfsHelperMock.Setup(t => t.GetRootChangesetForBranch(tfsPathBranch2, -1, null)).Returns(new List<RootBranch>() { new RootBranch(rootChangeSetB2, string.Empty, tfsPathBranch2) });
 
             #endregion
 


### PR DESCRIPTION
Unfortunately, a changeset can contain changes for different branches. So a changeset id does not identify a commit id 1:1. Instead only the combination of both the changeset id and the branch can identify the commit id.

At my company when there is a hotfix checked in for the main branch. It may sometimes be merged to different release versions (let's say V1, V2 and V3). All these merges are then checked with one changeset.
When after that a hotfix branch is created for let's say V2 git-tfs fails to find the correct commit id for the merge base because it just searches by changeset id and may find the commit in V1.